### PR TITLE
refactor: decompose Renderer2D and optimize RenderBuffer2D sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 - **Breaking:** `IRenderPipeline3D.Execute` signature changed from curried (`gameCtx -> buffer -> rtPool -> unit`) to tupled (`gameCtx * buffer * rtPool -> unit`). All implementations and call sites must update.
 - `SpriteState` moved from `Command2D` module to top-level `Mibo.Elmish.Graphics2D` namespace.
 - `Renderer2D` refactored: extracted command dispatch into `module private CommandHandlers` with `RendererState` struct threaded `byref`. Post-processing extracted into `PostProcess2D` module. Class reduced from ~530 LOC to ~60 LOC of orchestration.
-- `RenderBuffer2D.Sort` optimized: layer keys are now precomputed during `Add` (O(n) pattern matches) and sort uses `Array.Sort(keys, items, ...)` with primitive int comparisons, eliminating O(n log n) repeated pattern matching over the 37-case `Command2D` union.
+- `RenderBuffer2D.Sort` optimized: layer keys are now precomputed during `Add` (O(n) pattern matches) and sort uses `Array.Sort(keys, items, ...)` with primitive int comparisons, eliminating O(n log n) repeated pattern matching over the 37-case `Command2D` union. Sort is now stable — same-layer commands preserve insertion order via packed `int64` keys (layer in high 32 bits, insertion index in low 32 bits).
 - Shadow rendering: `collectMeshDraws` now partitions draws (non-skinned first, skinned second) to minimize shader switches in the shadow pass.
 - Shadow rendering: `renderShadowRegion` skips `computeNormalMatrix` and `SetShaderValueMatrix` when consecutive meshes share the same transform.
 - Removed `lightsDirty` class field from `ForwardPbrPipeline`; handlers now check only `ShaderVariant.LightsDirty`. `handleLightCommand` sets all three variants' dirty flags directly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 - **Breaking:** `LitSprite` command signature changed — now carries `LightContext2D * SpriteState` instead of 8 individual fields. Consumers must update pattern matches and `LightDraw.litSprite` call sites to use the new `SpriteState` type.
 - `SpriteState` moved from `Command2D` module to top-level `Mibo.Elmish.Graphics2D` namespace.
+- `Renderer2D` refactored: extracted command dispatch into `module private CommandHandlers` with `RendererState` struct threaded `byref`. Post-processing extracted into `PostProcess2D` module. Class reduced from ~530 LOC to ~60 LOC of orchestration.
+- `RenderBuffer2D.Sort` optimized: layer keys are now precomputed during `Add` (O(n) pattern matches) and sort uses `Array.Sort(keys, items, ...)` with primitive int comparisons, eliminating O(n log n) repeated pattern matching over the 37-case `Command2D` union.
 
 ## [1.0.0] - 2026.05.30
 

--- a/src/Mibo.Raylib.Tests/Graphics2DTests.fs
+++ b/src/Mibo.Raylib.Tests/Graphics2DTests.fs
@@ -840,34 +840,26 @@ let renderBuffer2DTests =
     test "Sort preserves insertion order for same layer" {
       let buf = RenderBuffer2D()
 
-      let cmdA =
-        Command2D.fillCircle
-          (5<RenderLayer>, Color.Red)
-          (Vector2(1.0f, 0.0f), 10.0f)
+      // Use enough items on the same layer that an unstable sort would
+      // reorder them — 3 items is too few to trigger swaps in most algorithms.
+      let colors = [|
+        for i in 0..19 -> Color(byte i, byte(i * 10), 0uy, 255uy)
+      |]
 
-      let cmdB =
-        Command2D.fillCircle
-          (5<RenderLayer>, Color.Blue)
-          (Vector2(2.0f, 0.0f), 10.0f)
+      for c in colors do
+        buf.Add(
+          Command2D.fillCircle
+            (5<RenderLayer>, c)
+            (Vector2(float32 c.R, 0.0f), 10.0f)
+        )
 
-      let cmdC =
-        Command2D.fillCircle
-          (5<RenderLayer>, Color.Green)
-          (Vector2(3.0f, 0.0f), 10.0f)
-
-      buf.Add(cmdA)
-      buf.Add(cmdB)
-      buf.Add(cmdC)
       buf.Sort()
 
-      match buf.Item 0, buf.Item 1, buf.Item 2 with
-      | Command2D.FillCircle(_, _, c1, _),
-        Command2D.FillCircle(_, _, c2, _),
-        Command2D.FillCircle(_, _, c3, _) ->
-        Expect.equal c1 Color.Red "First should be Red"
-        Expect.equal c2 Color.Blue "Second should be Blue"
-        Expect.equal c3 Color.Green "Third should be Green"
-      | _ -> Tests.failtest "Expected FillCircle commands"
+      for i = 0 to colors.Length - 1 do
+        match buf.Item i with
+        | Command2D.FillCircle(_, _, c, _) ->
+          Expect.equal c colors[i] $"Item {i} should match insertion order"
+        | _ -> Tests.failtest "Expected FillCircle"
     }
 
     test "Buffer expands capacity when full" {

--- a/src/Mibo.Raylib/Graphics2D/RenderBuffer.fs
+++ b/src/Mibo.Raylib/Graphics2D/RenderBuffer.fs
@@ -23,7 +23,7 @@ type RenderBuffer2D
 
   let initialCapacity = defaultArg capacity 1024
   let mutable items = ArrayPool<Command2D>.Shared.Rent(initialCapacity)
-  let mutable keys = ArrayPool<int>.Shared.Rent(initialCapacity)
+  let mutable keys = ArrayPool<int64>.Shared.Rent(initialCapacity)
   let mutable count = 0
 
   let getLayer(cmd: Command2D) =
@@ -81,12 +81,12 @@ type RenderBuffer2D
       let newSize = max (items.Length * 2) (count + needed)
 
       let newItems = ArrayPool<Command2D>.Shared.Rent(newSize)
-      let newKeys = ArrayPool<int>.Shared.Rent(newSize)
+      let newKeys = ArrayPool<int64>.Shared.Rent(newSize)
 
       Array.Copy(items, newItems, count)
       Array.Copy(keys, newKeys, count)
-      ArrayPool<Command2D>.Shared.Return(items)
-      ArrayPool<int>.Shared.Return(keys)
+      ArrayPool<Command2D>.Shared.Return(items, true)
+      ArrayPool<int64>.Shared.Return(keys)
       items <- newItems
       keys <- newKeys
 
@@ -100,7 +100,7 @@ type RenderBuffer2D
   member _.Add(cmd: Command2D) =
     ensureCapacity 1
     items[count] <- cmd
-    keys[count] <- int(getLayer cmd)
+    keys[count] <- (int64(int(getLayer cmd)) <<< 32) ||| int64 count
     count <- count + 1
 
   /// <summary>
@@ -110,8 +110,9 @@ type RenderBuffer2D
   member _.Clear() = count <- 0
 
   /// <summary>
-  /// Sorts commands by layer in ascending order.
-  /// Uses precomputed layer keys to avoid repeated pattern matching during comparisons.
+  /// Sorts commands by layer in ascending order, preserving insertion order for same-layer commands.
+  /// Uses precomputed int64 keys (layer in high 32 bits, insertion index in low 32 bits) to avoid
+  /// repeated pattern matching during comparisons and guarantee stable sort.
   /// Must be called after <see cref="M:Mibo.Elmish.Graphics2D.RenderBuffer2D.Clear"/>
   /// and population, before iteration.
   /// </summary>

--- a/src/Mibo.Raylib/Graphics2D/RenderBuffer.fs
+++ b/src/Mibo.Raylib/Graphics2D/RenderBuffer.fs
@@ -2,7 +2,6 @@ namespace Mibo.Elmish.Graphics2D
 
 open System
 open System.Buffers
-open System.Collections.Generic
 
 /// <summary>
 /// An allocation-free buffer for 2D render commands, sorted by layer.
@@ -22,8 +21,9 @@ type RenderBuffer2D
   /// <summary>Initial capacity. Defaults to 1024 if not specified.</summary>
   ?capacity: int) =
 
-  let mutable items = ArrayPool<Command2D>.Shared.Rent(defaultArg capacity 1024)
-
+  let initialCapacity = defaultArg capacity 1024
+  let mutable items = ArrayPool<Command2D>.Shared.Rent(initialCapacity)
+  let mutable keys = ArrayPool<int>.Shared.Rent(initialCapacity)
   let mutable count = 0
 
   let getLayer(cmd: Command2D) =
@@ -76,20 +76,19 @@ type RenderBuffer2D
     | Command2D.DisableShadows(_, layer) -> layer
     | Command2D.Particle(_, _, _, layer) -> layer
 
-  let layerComparer =
-    { new IComparer<Command2D> with
-        member _.Compare(a, b) = int(getLayer a) - int(getLayer b)
-    }
-
   let ensureCapacity(needed: int) =
     if count + needed > items.Length then
       let newSize = max (items.Length * 2) (count + needed)
 
-      let newArr = ArrayPool<Command2D>.Shared.Rent(newSize)
+      let newItems = ArrayPool<Command2D>.Shared.Rent(newSize)
+      let newKeys = ArrayPool<int>.Shared.Rent(newSize)
 
-      Array.Copy(items, newArr, count)
+      Array.Copy(items, newItems, count)
+      Array.Copy(keys, newKeys, count)
       ArrayPool<Command2D>.Shared.Return(items)
-      items <- newArr
+      ArrayPool<int>.Shared.Return(keys)
+      items <- newItems
+      keys <- newKeys
 
   /// <summary>The number of commands currently in the buffer.</summary>
   member _.Count = count
@@ -101,6 +100,7 @@ type RenderBuffer2D
   member _.Add(cmd: Command2D) =
     ensureCapacity 1
     items[count] <- cmd
+    keys[count] <- int(getLayer cmd)
     count <- count + 1
 
   /// <summary>
@@ -111,8 +111,8 @@ type RenderBuffer2D
 
   /// <summary>
   /// Sorts commands by layer in ascending order.
+  /// Uses precomputed layer keys to avoid repeated pattern matching during comparisons.
   /// Must be called after <see cref="M:Mibo.Elmish.Graphics2D.RenderBuffer2D.Clear"/>
   /// and population, before iteration.
   /// </summary>
-  member _.Sort() =
-    Array.Sort(items, 0, count, layerComparer)
+  member _.Sort() = Array.Sort(keys, items, 0, count)

--- a/src/Mibo.Raylib/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.Raylib/Graphics2D/Renderer2D.fs
@@ -23,6 +23,68 @@ type PostProcessPass = {
   OnSetup: (Shader -> GameContext -> unit) voption
 }
 
+/// <summary>Post-processing chain for 2D rendering.</summary>
+module PostProcess2D =
+
+  /// <summary>
+  /// Applies a chain of post-processing passes via ping-pong render textures.
+  /// The scene is already rendered to <paramref name="sceneTarget"/>. Each pass
+  /// renders to a pooled RT (except the last, which renders to the backbuffer).
+  /// </summary>
+  let apply
+    (
+      ctx: GameContext,
+      sceneTarget: RenderTexture2D,
+      passes: PostProcessPass[],
+      rtPool: IRenderTargetPool
+    ) =
+    let mutable src = sceneTarget
+    let w = ctx.WindowWidth
+    let h = ctx.WindowHeight
+
+    for i = 0 to passes.Length - 1 do
+      let pass = passes[i]
+      let isLast = i = passes.Length - 1
+
+      let dst: RenderTexture2D voption =
+        if isLast then
+          ValueNone
+        else
+          ValueSome(rtPool.Acquire(w, h))
+
+      match dst with
+      | ValueSome target ->
+        Raylib.BeginTextureMode(target)
+        Raylib.ClearBackground(Color.Black)
+      | ValueNone -> ()
+
+      Raylib.BeginShaderMode(pass.Shader)
+
+      match pass.OnSetup with
+      | ValueSome f -> f pass.Shader ctx
+      | ValueNone -> ()
+
+      let sourceRect = Rectangle(0f, 0f, float32 w, float32 -h)
+
+      let destRect = Rectangle(0f, 0f, float32 w, float32 h)
+
+      Raylib.DrawTexturePro(
+        src.Texture,
+        sourceRect,
+        destRect,
+        Vector2.Zero,
+        0f,
+        Color.White
+      )
+
+      Raylib.EndShaderMode()
+
+      match dst with
+      | ValueSome target ->
+        Raylib.EndTextureMode()
+        src <- target
+      | ValueNone -> ()
+
 /// <summary>Configuration for the <see cref="T:Mibo.Elmish.Graphics2D.Renderer2D`1"/>.</summary>
 [<Struct>]
 type Renderer2DConfig = {
@@ -64,95 +126,80 @@ module Renderer2DConfig =
     ClearColor = ValueNone
   }
 
-/// <summary>
-/// A deferred 2D renderer that sorts commands by layer and executes them
-/// via pattern matching on <see cref="T:Mibo.Elmish.Graphics2D.Command2D"/>.
-/// </summary>
-/// <remarks>
-/// <para>
-/// Commands are accumulated each frame via the <c>view</c> function into a
-/// <see cref="T:Mibo.Elmish.Graphics2D.RenderBuffer2D"/>, sorted by layer, then executed
-/// in order. raylib handles internal draw-call batching automatically.
-/// </para>
-/// <para>
-/// When <see cref="P:Mibo.Elmish.Graphics2D.Renderer2DConfig.PostProcess"/> is
-/// configured, the scene renders to a <see cref="T:Raylib_cs.RenderTexture2D"/>
-/// and each pass is applied sequentially via ping-pong render textures from the
-/// <see cref="T:Mibo.Elmish.Graphics2D.IRenderTargetPool"/>.
-/// </para>
-/// <para>
-/// Register via <c>Program.withRenderer</c>:
-/// <code lang="fsharp">
-/// Program.mkProgram init update view
-/// |> Program.withRenderer(fun () -> Renderer2D.create view)
-/// </code>
-/// </para>
-/// </remarks>
-/// <typeparam name="Model">The application model type, passed to the view function.</typeparam>
-type Renderer2D<'Model>
-  (
-    view: GameContext -> 'Model -> RenderBuffer2D -> unit,
-    config: Renderer2DConfig
-  ) =
+// ═══════════════════════════════════════════════════════════════════
+// Private command handlers — extracted from Renderer2D for readability
+// ═══════════════════════════════════════════════════════════════════
 
-  let buffer = RenderBuffer2D(capacity = 4096)
-  let rtPool: IRenderTargetPool = new RenderTargetPool()
+module private CommandHandlers =
 
-  let mutable _camera: Camera2D voption = ValueNone
-  let mutable _shader: Shader voption = ValueNone
-  let mutable _hasViewport = false
-  let mutable _windowWidth = 0
-  let mutable _windowHeight = 0
+  /// <summary>Mutable renderer state threaded through command dispatch byref.</summary>
+  [<Struct>]
+  type RendererState = {
+    mutable Camera: Camera2D voption
+    mutable Shader: Shader voption
+    mutable HasViewport: bool
+    WindowWidth: int
+    WindowHeight: int
+  }
 
-  let beginCamera(c: Camera2D) =
+  // ── Camera state management ──────────────────────────────────
+
+  let private beginCamera (c: Camera2D) (state: byref<RendererState>) =
     Rlgl.DrawRenderBatchActive()
 
-    if _camera.IsSome then
+    if state.Camera.IsSome then
       Raylib.EndMode2D()
 
     Raylib.BeginMode2D(c)
-    _camera <- ValueSome c
+    state.Camera <- ValueSome c
 
-  let endCamera() =
-    if _camera.IsSome then
+  let private endCamera(state: byref<RendererState>) =
+    if state.Camera.IsSome then
       Rlgl.DrawRenderBatchActive()
       Raylib.EndMode2D()
-      _camera <- ValueNone
+      state.Camera <- ValueNone
 
-    if _hasViewport then
-      Rlgl.Viewport(0, 0, _windowWidth, _windowHeight)
-      _hasViewport <- false
+    if state.HasViewport then
+      Rlgl.Viewport(0, 0, state.WindowWidth, state.WindowHeight)
+      state.HasViewport <- false
 
-  let beginShader(s: Shader) =
-    match _shader with
+  // ── Shader state management ──────────────────────────────────
+
+  let private beginShader (s: Shader) (state: byref<RendererState>) =
+    match state.Shader with
     | ValueSome cur when cur.Id = s.Id -> ()
     | _ ->
       Rlgl.DrawRenderBatchActive()
 
-      if _shader.IsSome then
+      if state.Shader.IsSome then
         Raylib.EndShaderMode()
 
       Raylib.BeginShaderMode(s)
-      _shader <- ValueSome s
+      state.Shader <- ValueSome s
 
-  let endShader() =
-    if _shader.IsSome then
+  let private endShader(state: byref<RendererState>) =
+    if state.Shader.IsSome then
       Rlgl.DrawRenderBatchActive()
       Raylib.EndShaderMode()
-      _shader <- ValueNone
+      state.Shader <- ValueNone
 
-  let drawImmediate(action: unit -> unit) =
+  // ── Escape hatch ─────────────────────────────────────────────
+
+  let private drawImmediate
+    (action: unit -> unit)
+    (state: byref<RendererState>)
+    =
     Rlgl.DrawRenderBatchActive()
-    let savedCam = _camera
-    let savedShader = _shader
+    let savedCam = state.Camera
+    let savedShader = state.Shader
 
-    if _shader.IsSome then
+    if state.Shader.IsSome then
       Raylib.EndShaderMode()
-      _shader <- ValueNone
+      state.Shader <- ValueNone
 
-    if _camera.IsSome then
+    if state.Camera.IsSome then
       Raylib.EndMode2D()
-      _camera <- ValueNone
+      state.Camera <- ValueNone
 
     try
       action()
@@ -160,22 +207,67 @@ type Renderer2D<'Model>
       match savedCam with
       | ValueSome c ->
         Raylib.BeginMode2D(c)
-        _camera <- savedCam
+        state.Camera <- savedCam
       | ValueNone -> ()
 
       match savedShader with
       | ValueSome s ->
         Raylib.BeginShaderMode(s)
-        _shader <- savedShader
+        state.Shader <- savedShader
       | ValueNone -> ()
 
-  let executeCommands() =
+  // ── Lighting handlers ────────────────────────────────────────
+
+  let private handleLitSprite
+    (lightCtx: LightContext2D, sprite: SpriteState, state: byref<RendererState>)
+    =
+    let targetShader =
+      match sprite.NormalMap with
+      | ValueSome _ -> lightCtx.NormalMapShader
+      | ValueNone -> lightCtx.Shader
+
+    beginShader targetShader &state
+    lightCtx.ShaderActive <- true
+
+    if lightCtx.UniformsDirty then
+      lightCtx.UploadUniforms()
+      lightCtx.UniformsDirty <- false
+
+    lightCtx.EnsureLocationsCached()
+
+    match sprite.NormalMap with
+    | ValueSome nm ->
+      Raylib.SetShaderValueTexture(targetShader, lightCtx.LocNormalMap, nm)
+    | ValueNone -> ()
+
+    Raylib.DrawTexturePro(
+      sprite.Texture,
+      sprite.Source,
+      sprite.Dest,
+      sprite.Origin,
+      sprite.Rotation,
+      sprite.Color
+    )
+
+  let private handleEndLighting
+    (lightCtx: LightContext2D, state: byref<RendererState>)
+    =
+    if lightCtx.ShaderActive then
+      endShader &state
+      lightCtx.ShaderActive <- false
+      lightCtx.UniformsDirty <- true
+
+  // ── Main dispatch ────────────────────────────────────────────
+
+  let execute(state: byref<RendererState>, buffer: RenderBuffer2D) =
     for i = 0 to buffer.Count - 1 do
       match buffer[i] with
+      // Sprite & Text
       | Command2D.Sprite(texture, dest, source, origin, rotation, color, _) ->
         Raylib.DrawTexturePro(texture, source, dest, origin, rotation, color)
       | Command2D.Text(font, text, position, fontSize, spacing, color, _) ->
         Raylib.DrawTextEx(font, text, position, fontSize, spacing, color)
+      // Rectangles
       | Command2D.FillRect(rect, color, _) ->
         Raylib.DrawRectangleRec(rect, color)
       | Command2D.RectOutline(rect, thickness, color, _) ->
@@ -201,6 +293,7 @@ type Renderer2D<'Model>
         Raylib.DrawRectangleGradientH(x, y, w, h, left, right)
       | Command2D.RectGradient(rect, tl, bl, tr, br, _) ->
         Raylib.DrawRectangleGradientEx(rect, tl, bl, tr, br)
+      // Circles & Ellipses
       | Command2D.FillCircle(center, radius, color, _) ->
         Raylib.DrawCircleV(center, radius, color)
       | Command2D.CircleOutline(center, radius, color, _) ->
@@ -280,6 +373,7 @@ type Renderer2D<'Model>
         Raylib.DrawEllipse(centerX, centerY, radiusH, radiusV, color)
       | Command2D.EllipseOutline(centerX, centerY, radiusH, radiusV, color, _) ->
         Raylib.DrawEllipseLines(centerX, centerY, radiusH, radiusV, color)
+      // Lines & Curves
       | Command2D.Line(start, finish, color, _) ->
         Raylib.DrawLineV(start, finish, color)
       | Command2D.LineThick(start, finish, thickness, color, _) ->
@@ -294,6 +388,7 @@ type Renderer2D<'Model>
           thickness,
           color
         )
+      // Triangles & Polygons
       | Command2D.Triangle(v1, v2, v3, color, _) ->
         Raylib.DrawTriangle(v1, v2, v3, color)
       | Command2D.TriangleFan(points, color, _) ->
@@ -317,31 +412,33 @@ type Renderer2D<'Model>
           thickness,
           color
         )
-      | Command2D.BeginCamera(camera, _) -> beginCamera camera
+      // Camera
+      | Command2D.BeginCamera(camera, _) -> beginCamera camera &state
       | Command2D.BeginCameraConfig(config: Camera2DConfig, _) ->
-        // Apply viewport if specified
         match config.Viewport with
         | ValueSome vp ->
-          let vpX = int(vp.X * float32 _windowWidth)
-          let vpY = int(vp.Y * float32 _windowHeight)
-          let vpW = int(vp.Width * float32 _windowWidth)
-          let vpH = int(vp.Height * float32 _windowHeight)
+          let vpX = int(vp.X * float32 state.WindowWidth)
+          let vpY = int(vp.Y * float32 state.WindowHeight)
+          let vpW = int(vp.Width * float32 state.WindowWidth)
+          let vpH = int(vp.Height * float32 state.WindowHeight)
           Rlgl.DrawRenderBatchActive()
           Rlgl.Viewport(vpX, vpY, vpW, vpH)
-          _hasViewport <- true
+          state.HasViewport <- true
         | ValueNone -> ()
 
-        // Clear if specified
         match config.ClearColor with
         | ValueSome c -> Raylib.ClearBackground(c)
         | ValueNone -> ()
 
-        beginCamera config.Camera
-      | Command2D.EndCamera _ -> endCamera()
-      | Command2D.BeginShader(shader, _) -> beginShader shader
-      | Command2D.EndShader _ -> endShader()
+        beginCamera config.Camera &state
+      | Command2D.EndCamera _ -> endCamera &state
+      // Shader
+      | Command2D.BeginShader(shader, _) -> beginShader shader &state
+      | Command2D.EndShader _ -> endShader &state
+      // Render Targets
       | Command2D.BeginTarget(target, _) -> Raylib.BeginTextureMode(target)
       | Command2D.EndTarget _ -> Raylib.EndTextureMode()
+      // Render State
       | Command2D.SetBlend(mode, _) -> Rlgl.SetBlendMode(mode)
       | Command2D.SetScissor(x, y, w, h, _) ->
         Rlgl.EnableScissorTest()
@@ -349,49 +446,18 @@ type Renderer2D<'Model>
       | Command2D.ClearScissor _ -> Rlgl.DisableScissorTest()
       | Command2D.SetLineWidth(width, _) -> Rlgl.SetLineWidth(width)
       | Command2D.SetViewport(x, y, w, h, _) -> Rlgl.Viewport(x, y, w, h)
-      | Command2D.DrawImmediate(action, _) -> drawImmediate action
+      // Escape Hatches
+      | Command2D.DrawImmediate(action, _) -> drawImmediate action &state
       | Command2D.Clear(color, _) -> Raylib.ClearBackground(color)
+      // Lighting
       | Command2D.NoopLight _ -> ()
       | Command2D.LitSprite(lightCtx, sprite) ->
-        // Select the correct shader variant for this sprite.
-        // beginShader handles the batch flush and BeginShaderMode switch
-        // when the shader ID changes — the standard raylib pattern.
-        let targetShader =
-          match sprite.NormalMap with
-          | ValueSome _ -> lightCtx.NormalMapShader
-          | ValueNone -> lightCtx.Shader
-
-        beginShader targetShader
-        lightCtx.ShaderActive <- true
-
-        // Upload light uniforms once per frame (to both shader variants).
-        if lightCtx.UniformsDirty then
-          lightCtx.UploadUniforms()
-          lightCtx.UniformsDirty <- false
-
-        lightCtx.EnsureLocationsCached()
-
-        // Bind the normal map texture when using the normal-map shader.
-        match sprite.NormalMap with
-        | ValueSome nm ->
-          Raylib.SetShaderValueTexture(targetShader, lightCtx.LocNormalMap, nm)
-        | ValueNone -> ()
-
-        Raylib.DrawTexturePro(
-          sprite.Texture,
-          sprite.Source,
-          sprite.Dest,
-          sprite.Origin,
-          sprite.Rotation,
-          sprite.Color
-        )
+        handleLitSprite(lightCtx, sprite, &state)
       | Command2D.EndLighting(lightCtx, _) ->
-        if lightCtx.ShaderActive then
-          endShader()
-          lightCtx.ShaderActive <- false
-          lightCtx.UniformsDirty <- true
+        handleEndLighting(lightCtx, &state)
       | Command2D.EnableShadows(lightCtx, _) -> lightCtx.UniformsDirty <- true
       | Command2D.DisableShadows(lightCtx, _) -> lightCtx.UniformsDirty <- true
+      // Particles
       | Command2D.Particle(texture, particles, count, _) ->
         for j = 0 to count - 1 do
           let p = particles[j]
@@ -411,58 +477,48 @@ type Renderer2D<'Model>
 
           Raylib.DrawTexturePro(texture, src, dst, Vector2.Zero, 0.f, p.Color)
 
-    endShader()
-    endCamera()
+    endShader &state
+    endCamera &state
 
-  let applyPostProcess
-    (ctx: GameContext, sceneTarget: RenderTexture2D, passes: PostProcessPass[])
-    =
-    let mutable src = sceneTarget
-    let w = ctx.WindowWidth
-    let h = ctx.WindowHeight
+/// <summary>
+/// A deferred 2D renderer that sorts commands by layer and executes them
+/// via pattern matching on <see cref="T:Mibo.Elmish.Graphics2D.Command2D"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Commands are accumulated each frame via the <c>view</c> function into a
+/// <see cref="T:Mibo.Elmish.Graphics2D.RenderBuffer2D"/>, sorted by layer, then executed
+/// in order. raylib handles internal draw-call batching automatically.
+/// </para>
+/// <para>
+/// When <see cref="P:Mibo.Elmish.Graphics2D.Renderer2DConfig.PostProcess"/> is
+/// configured, the scene renders to a <see cref="T:Raylib_cs.RenderTexture2D"/>
+/// and each pass is applied sequentially via ping-pong render textures from the
+/// <see cref="T:Mibo.Elmish.Graphics2D.IRenderTargetPool"/>.
+/// </para>
+/// <para>
+/// Register via <c>Program.withRenderer</c>:
+/// <code lang="fsharp">
+/// Program.mkProgram init update view
+/// |> Program.withRenderer(fun () -> Renderer2D.create view)
+/// </code>
+/// </para>
+/// </remarks>
+/// <typeparam name="Model">The application model type, passed to the view function.</typeparam>
+type Renderer2D<'Model>
+  (
+    view: GameContext -> 'Model -> RenderBuffer2D -> unit,
+    config: Renderer2DConfig
+  ) =
 
-    for i = 0 to passes.Length - 1 do
-      let pass = passes[i]
-      let isLast = i = passes.Length - 1
+  let buffer = RenderBuffer2D(capacity = 4096)
+  let rtPool: IRenderTargetPool = new RenderTargetPool()
 
-      let dst: RenderTexture2D voption =
-        if isLast then
-          ValueNone
-        else
-          ValueSome(rtPool.Acquire(w, h))
-
-      match dst with
-      | ValueSome target ->
-        Raylib.BeginTextureMode(target)
-        Raylib.ClearBackground(Color.Black)
-      | ValueNone -> ()
-
-      Raylib.BeginShaderMode(pass.Shader)
-
-      match pass.OnSetup with
-      | ValueSome f -> f pass.Shader ctx
-      | ValueNone -> ()
-
-      let sourceRect = Raylib_cs.Rectangle(0f, 0f, float32 w, float32 -h)
-
-      let destRect = Raylib_cs.Rectangle(0f, 0f, float32 w, float32 h)
-
-      Raylib.DrawTexturePro(
-        src.Texture,
-        sourceRect,
-        destRect,
-        Vector2.Zero,
-        0f,
-        Color.White
-      )
-
-      Raylib.EndShaderMode()
-
-      match dst with
-      | ValueSome target ->
-        Raylib.EndTextureMode()
-        src <- target
-      | ValueNone -> ()
+  let mutable _camera: Camera2D voption = ValueNone
+  let mutable _shader: Shader voption = ValueNone
+  let mutable _hasViewport = false
+  let mutable _windowWidth = 0
+  let mutable _windowHeight = 0
 
   interface IRenderer<'Model> with
     member _.Draw(ctx, model, _gameTime) =
@@ -473,13 +529,21 @@ type Renderer2D<'Model>
       view ctx model buffer
       buffer.Sort()
 
+      let mutable state: CommandHandlers.RendererState = {
+        Camera = _camera
+        Shader = _shader
+        HasViewport = _hasViewport
+        WindowWidth = _windowWidth
+        WindowHeight = _windowHeight
+      }
+
       match config.PostProcess with
       | ValueNone ->
         match config.ClearColor with
         | ValueSome c -> Raylib.ClearBackground(c)
         | ValueNone -> ()
 
-        executeCommands()
+        CommandHandlers.execute(&state, buffer)
       | ValueSome passes ->
         let sceneRT = rtPool.Acquire(ctx.WindowWidth, ctx.WindowHeight)
 
@@ -489,11 +553,15 @@ type Renderer2D<'Model>
         | ValueSome c -> Raylib.ClearBackground(c)
         | ValueNone -> ()
 
-        executeCommands()
+        CommandHandlers.execute(&state, buffer)
         Raylib.EndTextureMode()
 
-        applyPostProcess(ctx, sceneRT, passes)
+        PostProcess2D.apply(ctx, sceneRT, passes, rtPool)
         rtPool.ReleaseAll()
+
+      _camera <- state.Camera
+      _shader <- state.Shader
+      _hasViewport <- state.HasViewport
 
   interface IDisposable with
     member _.Dispose() =


### PR DESCRIPTION
## Summary

Decomposes the monolithic \Renderer2D\ class (529 LOC) into focused modules and optimizes the \RenderBuffer2D.Sort\ hot path.

## Changes

### Renderer2D decomposition

The \Renderer2D\ class was doing everything: buffer lifecycle, camera/shader state management, command dispatch (250+ line match block), post-processing, and render target pooling. Refactored into:

- **\Renderer2D\ class** (~60 LOC) — owns buffer + rtPool lifecycle, packs state into \RendererState\, delegates to \CommandHandlers.execute\, unpacks state back
- **\module private CommandHandlers\** — \RendererState\ struct (5 mutable fields threaded \yref\), extracted handlers for camera/shader state management, lighting, drawImmediate, and the main dispatch loop
- **\PostProcess2D\ module** — extracted ping-pong post-process chain as a standalone function

28 simple drawing commands (Sprite, FillRect, Line, etc.) stay inline in the match as one-line raylib forwards — no extraction overhead.

### RenderBuffer2D sort optimization

The \getLayer\ pattern match (37-case DU) was called O(n log n) times during \Array.Sort\ via the \IComparer\. Now:

- Layer keys are precomputed once during \Add\ (O(n) pattern matches)
- Sort uses \Array.Sort(keys, items, 0, count)\ with primitive int comparisons
- No pattern matching during sort

### Files changed

| File | Before | After |
|------|--------|-------|
| \Renderer2D.fs\ | 529 LOC | 597 LOC (more code, but decomposed into focused sections) |
| \RenderBuffer.fs\ | 118 LOC | 118 LOC (same size, different internals) |
| \CHANGELOG.md\ | — | Updated |

## Testing

- 425 tests passing
- PlatformerSample and ThreeDSample build clean
- \dotnet fantomas .\ applied