### PR TITLE
feat: add hex grid with layout DSL and layered grid

### DIFF
--- a/src/Mibo.Raylib.Tests/HexGridTests.fs
+++ b/src/Mibo.Raylib.Tests/HexGridTests.fs
@@ -1,0 +1,271 @@
+module Mibo.Raylib.Tests.HexGrid
+
+open Expecto
+open System.Numerics
+open Mibo.Layout
+
+[<Tests>]
+let tests =
+  testList "HexGrid" [
+    testList "CellGrid" [
+      testCase "create initializes with ValueNone cells"
+      <| fun _ ->
+        let grid = HexGrid.create 10 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        Expect.equal grid.Width 10 "Width should be 10"
+        Expect.equal grid.Height 5 "Height should be 5"
+        Expect.equal grid.Size 32f "Size should be 32"
+        Expect.equal grid.Orientation HexOrientation.PointyTop "Orientation"
+
+        for col in 0..9 do
+          for row in 0..4 do
+            Expect.equal
+              (HexGrid.get col row grid)
+              ValueNone
+              "Cell should be empty"
+
+      testCase "set and get roundtrip"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+
+        HexGrid.set 5 3 42 grid
+
+        Expect.equal
+          (HexGrid.get 5 3 grid)
+          (ValueSome 42)
+          "Should get set value"
+
+        Expect.equal
+          (HexGrid.get 0 0 grid)
+          ValueNone
+          "Unset cell should be empty"
+
+      testCase "set out of bounds is ignored"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        HexGrid.set -1 0 1 grid
+        HexGrid.set 0 -1 1 grid
+        HexGrid.set 5 0 1 grid
+        HexGrid.set 0 5 1 grid
+
+      testCase "get out of bounds returns ValueNone"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        Expect.equal (HexGrid.get -1 0 grid) ValueNone "Negative col"
+        Expect.equal (HexGrid.get 0 -1 grid) ValueNone "Negative row"
+        Expect.equal (HexGrid.get 5 0 grid) ValueNone "Col at width"
+        Expect.equal (HexGrid.get 0 5 grid) ValueNone "Row at height"
+
+      testCase "clear removes cell content"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        HexGrid.set 2 2 42 grid
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 42) "Should be set"
+
+        HexGrid.clear 2 2 grid
+        Expect.equal (HexGrid.get 2 2 grid) ValueNone "Should be cleared"
+
+      testCase "clear out of bounds is ignored"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        HexGrid.clear -1 0 grid
+        HexGrid.clear 0 -1 grid
+        HexGrid.clear 5 0 grid
+        HexGrid.clear 0 5 grid
+
+      testCase "iter visits all populated cells"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        HexGrid.set 1 1 10 grid
+        HexGrid.set 3 2 20 grid
+
+        let visited = ResizeArray<struct (int * int * int)>()
+        grid |> HexGrid.iter(fun col row v -> visited.Add(struct (col, row, v)))
+
+        Expect.equal visited.Count 2 "Should visit 2 cells"
+        Expect.contains visited (struct (1, 1, 10)) "Should contain first cell"
+        Expect.contains visited (struct (3, 2, 20)) "Should contain second cell"
+    ]
+
+    testList "World Position - PointyTop" [
+      testCase "getWorldPos at origin"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        let pos = HexGrid.getWorldPos 0 0 grid
+        let hexW = 32f * sqrt 3f
+        let hexH = 64f
+
+        Expect.equal pos.X (hexW / 2f) "X center of first hex"
+        Expect.equal pos.Y (hexH / 2f) "Y center of first hex"
+
+      testCase "getWorldPos with offset origin"
+      <| fun _ ->
+        let origin = Vector2(100f, 50f)
+
+        let grid = HexGrid.create 10 10 32f origin HexOrientation.PointyTop
+
+        let pos = HexGrid.getWorldPos 0 0 grid
+        let hexW = 32f * sqrt 3f
+        let hexH = 64f
+
+        Expect.equal pos.X (100f + hexW / 2f) "X with origin offset"
+        Expect.equal pos.Y (50f + hexH / 2f) "Y with origin offset"
+
+      testCase "getWorldPos odd row shifted right"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        let pos0 = HexGrid.getWorldPos 0 0 grid
+        let pos1 = HexGrid.getWorldPos 0 1 grid
+        let hexW = 32f * sqrt 3f
+
+        Expect.equal
+          pos1.X
+          (pos0.X + hexW / 2f)
+          "Odd row shifted right by half hex width"
+
+      testCase "getWorldPos column spacing"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        let pos0 = HexGrid.getWorldPos 0 0 grid
+        let pos1 = HexGrid.getWorldPos 1 0 grid
+        let hexW = 32f * sqrt 3f
+
+        Expect.equal pos1.X (pos0.X + hexW) "Columns spaced by hex width"
+
+      testCase "getWorldPos row spacing"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        let pos0 = HexGrid.getWorldPos 0 0 grid
+        let pos2 = HexGrid.getWorldPos 0 2 grid
+
+        Expect.equal
+          pos2.Y
+          (pos0.Y + 96f)
+          "Two rows apart = 2 * hexH * 0.75 = 96"
+    ]
+
+    testList "World Position - FlatTop" [
+      testCase "getWorldPos at origin"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+
+        let pos = HexGrid.getWorldPos 0 0 grid
+        let hexW = 64f
+        let hexH = 32f * sqrt 3f
+
+        Expect.equal pos.X (hexW / 2f) "X center of first hex"
+        Expect.equal pos.Y (hexH / 2f) "Y center of first hex"
+
+      testCase "getWorldPos odd column shifted down"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+
+        let pos0 = HexGrid.getWorldPos 0 0 grid
+        let pos1 = HexGrid.getWorldPos 1 0 grid
+        let hexH = 32f * sqrt 3f
+
+        Expect.equal
+          pos1.Y
+          (pos0.Y + hexH / 2f)
+          "Odd column shifted down by half hex height"
+
+      testCase "getWorldPos column spacing"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+
+        let pos0 = HexGrid.getWorldPos 0 0 grid
+        let pos2 = HexGrid.getWorldPos 2 0 grid
+
+        Expect.equal
+          pos2.X
+          (pos0.X + 96f)
+          "Two columns apart = 2 * hexW * 0.75 = 96"
+
+      testCase "getWorldPos row spacing"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+
+        let pos0 = HexGrid.getWorldPos 0 0 grid
+        let pos1 = HexGrid.getWorldPos 0 1 grid
+        let hexH = 32f * sqrt 3f
+
+        Expect.equal pos1.Y (pos0.Y + hexH) "Rows spaced by hex height"
+    ]
+
+    testList "iterVisible" [
+      testCase "iterVisible visits cells in viewport"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+
+        for col in 0..9 do
+          for row in 0..9 do
+            HexGrid.set col row (col * 10 + row) grid
+
+        let visited = ResizeArray<struct (int * int * int)>()
+
+        grid
+        |> HexGrid.iterVisible 0f 0f 200f 200f (fun col row v ->
+          visited.Add(struct (col, row, v)))
+
+        Expect.isGreaterThan visited.Count 0 "Should visit some cells"
+        Expect.isLessThan visited.Count 100 "Should not visit all cells"
+
+      testCase "iterVisible visits all cells when viewport covers grid"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        for col in 0..4 do
+          for row in 0..4 do
+            HexGrid.set col row (col * 10 + row) grid
+
+        let visited = ResizeArray<struct (int * int * int)>()
+
+        grid
+        |> HexGrid.iterVisible -1000f -1000f 1000f 1000f (fun col row v ->
+          visited.Add(struct (col, row, v)))
+
+        Expect.equal visited.Count 25 "Should visit all 25 cells"
+
+      testCase "iterVisible flat-top visits cells in viewport"
+      <| fun _ ->
+        let grid = HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+
+        for col in 0..9 do
+          for row in 0..9 do
+            HexGrid.set col row (col * 10 + row) grid
+
+        let visited = ResizeArray<struct (int * int * int)>()
+
+        grid
+        |> HexGrid.iterVisible 0f 0f 200f 200f (fun col row v ->
+          visited.Add(struct (col, row, v)))
+
+        Expect.isGreaterThan visited.Count 0 "Should visit some cells"
+        Expect.isLessThan visited.Count 100 "Should not visit all cells"
+
+      testCase "iterVisible empty viewport visits nothing"
+      <| fun _ ->
+        let grid = HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+
+        HexGrid.set 2 2 42 grid
+
+        let visited = ResizeArray<struct (int * int * int)>()
+
+        grid
+        |> HexGrid.iterVisible 5000f 5000f 6000f 6000f (fun col row v ->
+          visited.Add(struct (col, row, v)))
+
+        Expect.equal visited.Count 0 "Should visit no cells"
+    ]
+  ]

--- a/src/Mibo.Raylib.Tests/HexLayoutTests.fs
+++ b/src/Mibo.Raylib.Tests/HexLayoutTests.fs
@@ -1,0 +1,741 @@
+module Mibo.Raylib.Tests.HexLayout
+
+open Expecto
+open System.Numerics
+open Mibo.Layout
+
+[<Tests>]
+let tests =
+  testList "HexLayout" [
+    testList "DSL - PointyTop" [
+      testCase "run executes layout function"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section -> section |> HexLayout.set 2 2 42)
+
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 42) "Should set cell"
+
+      testCase "fill creates filled region"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.fill 2 3 4 2 99)
+
+        for col in 2..5 do
+          for row in 3..4 do
+            Expect.equal
+              (HexGrid.get col row grid)
+              (ValueSome 99)
+              $"Cell ({col},{row}) should be filled"
+
+        Expect.equal (HexGrid.get 1 3 grid) ValueNone "Left of fill"
+        Expect.equal (HexGrid.get 6 3 grid) ValueNone "Right of fill"
+
+      testCase "border creates hollow region"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.border 1 1 4 3 1)
+
+        for col in 1..4 do
+          Expect.equal
+            (HexGrid.get col 1 grid)
+            (ValueSome 1)
+            $"Top edge ({col},1)"
+
+          Expect.equal
+            (HexGrid.get col 3 grid)
+            (ValueSome 1)
+            $"Bottom edge ({col},3)"
+
+        for row in 1..3 do
+          Expect.equal
+            (HexGrid.get 1 row grid)
+            (ValueSome 1)
+            $"Left edge (1,{row})"
+
+          Expect.equal
+            (HexGrid.get 4 row grid)
+            (ValueSome 1)
+            $"Right edge (4,{row})"
+
+        Expect.equal (HexGrid.get 2 2 grid) ValueNone "Interior should be empty"
+
+      testCase "section provides relative coordinates"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.section 3 4 (fun inner ->
+              inner |> HexLayout.set 0 0 42))
+
+        Expect.equal
+          (HexGrid.get 3 4 grid)
+          (ValueSome 42)
+          "Section offset should apply"
+
+        Expect.equal (HexGrid.get 0 0 grid) ValueNone "Origin should be empty"
+
+      testCase "padding shrinks section"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.padding 2 (fun inner -> inner |> HexLayout.set 0 0 42))
+
+        Expect.equal
+          (HexGrid.get 2 2 grid)
+          (ValueSome 42)
+          "Padding offset should apply"
+
+      testCase "clear removes cells"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section |> HexLayout.fill 0 0 5 5 1 |> HexLayout.clear 1 1 2 2)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 1) "Corner should remain"
+
+        Expect.equal (HexGrid.get 1 1 grid) ValueNone "Cleared area"
+        Expect.equal (HexGrid.get 2 2 grid) ValueNone "Cleared area"
+        Expect.equal (HexGrid.get 3 1 grid) (ValueSome 1) "Outside clear"
+
+      testCase "repeatX creates horizontal line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.repeatX 2 1 5 7)
+
+        for col in 2..6 do
+          Expect.equal (HexGrid.get col 1 grid) (ValueSome 7) $"Cell ({col},1)"
+
+        Expect.equal (HexGrid.get 1 1 grid) ValueNone "Before start"
+        Expect.equal (HexGrid.get 7 1 grid) ValueNone "After end"
+
+      testCase "repeatY creates vertical line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.repeatY 1 2 4 8)
+
+        for row in 2..5 do
+          Expect.equal (HexGrid.get 1 row grid) (ValueSome 8) $"Cell (1,{row})"
+
+      testCase "setIfEmpty only sets when empty"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 10
+            |> HexLayout.setIfEmpty 1 1 99
+            |> HexLayout.setIfEmpty 2 2 99)
+
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 10) "Original kept"
+
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 99) "New value set"
+    ]
+
+    testList "DSL - FlatTop" [
+      testCase "run executes layout function"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section -> section |> HexLayout.set 2 2 42)
+
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 42) "Should set cell"
+
+      testCase "fill creates filled region"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.fill 2 3 4 2 99)
+
+        for col in 2..5 do
+          for row in 3..4 do
+            Expect.equal
+              (HexGrid.get col row grid)
+              (ValueSome 99)
+              $"Cell ({col},{row}) should be filled"
+
+        Expect.equal (HexGrid.get 1 3 grid) ValueNone "Left of fill"
+        Expect.equal (HexGrid.get 6 3 grid) ValueNone "Right of fill"
+
+      testCase "border creates hollow region"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.border 1 1 4 3 1)
+
+        for col in 1..4 do
+          Expect.equal
+            (HexGrid.get col 1 grid)
+            (ValueSome 1)
+            $"Top edge ({col},1)"
+
+          Expect.equal
+            (HexGrid.get col 3 grid)
+            (ValueSome 1)
+            $"Bottom edge ({col},3)"
+
+        for row in 1..3 do
+          Expect.equal
+            (HexGrid.get 1 row grid)
+            (ValueSome 1)
+            $"Left edge (1,{row})"
+
+          Expect.equal
+            (HexGrid.get 4 row grid)
+            (ValueSome 1)
+            $"Right edge (4,{row})"
+
+        Expect.equal (HexGrid.get 2 2 grid) ValueNone "Interior should be empty"
+
+      testCase "section provides relative coordinates"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.section 3 4 (fun inner ->
+              inner |> HexLayout.set 0 0 42))
+
+        Expect.equal
+          (HexGrid.get 3 4 grid)
+          (ValueSome 42)
+          "Section offset should apply"
+
+        Expect.equal (HexGrid.get 0 0 grid) ValueNone "Origin should be empty"
+
+      testCase "padding shrinks section"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.padding 2 (fun inner -> inner |> HexLayout.set 0 0 42))
+
+        Expect.equal
+          (HexGrid.get 2 2 grid)
+          (ValueSome 42)
+          "Padding offset should apply"
+
+      testCase "clear removes cells"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section |> HexLayout.fill 0 0 5 5 1 |> HexLayout.clear 1 1 2 2)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 1) "Corner should remain"
+
+        Expect.equal (HexGrid.get 1 1 grid) ValueNone "Cleared area"
+        Expect.equal (HexGrid.get 2 2 grid) ValueNone "Cleared area"
+        Expect.equal (HexGrid.get 3 1 grid) (ValueSome 1) "Outside clear"
+
+      testCase "repeatX creates horizontal line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.repeatX 2 1 5 7)
+
+        for col in 2..6 do
+          Expect.equal (HexGrid.get col 1 grid) (ValueSome 7) $"Cell ({col},1)"
+
+        Expect.equal (HexGrid.get 1 1 grid) ValueNone "Before start"
+        Expect.equal (HexGrid.get 7 1 grid) ValueNone "After end"
+
+      testCase "repeatY creates vertical line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.repeatY 1 2 4 8)
+
+        for row in 2..5 do
+          Expect.equal (HexGrid.get 1 row grid) (ValueSome 8) $"Cell (1,{row})"
+
+      testCase "setIfEmpty only sets when empty"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 10
+            |> HexLayout.setIfEmpty 1 1 99
+            |> HexLayout.setIfEmpty 2 2 99)
+
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 10) "Original kept"
+
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 99) "New value set"
+    ]
+
+    testList "Geometry - PointyTop" [
+      testCase "line draws horizontal line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.line 1 2 5 2 1)
+
+        for col in 1..5 do
+          Expect.equal (HexGrid.get col 2 grid) (ValueSome 1) $"Point ({col},2)"
+
+      testCase "line draws vertical line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.line 2 1 2 5 1)
+
+        for row in 1..5 do
+          Expect.equal (HexGrid.get 2 row grid) (ValueSome 1) $"Point (2,{row})"
+
+      testCase "line draws diagonal"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.line 0 0 4 4 1)
+
+        for i in 0..4 do
+          Expect.equal (HexGrid.get i i grid) (ValueSome 1) $"Point ({i},{i})"
+
+      testCase "circle outline draws points at radius"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 20 20 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.circle 10 10 5 false 1)
+
+        Expect.equal (HexGrid.get 15 10 grid) (ValueSome 1) "Right point"
+        Expect.equal (HexGrid.get 5 10 grid) (ValueSome 1) "Left point"
+        Expect.equal (HexGrid.get 10 15 grid) (ValueSome 1) "Bottom point"
+        Expect.equal (HexGrid.get 10 5 grid) (ValueSome 1) "Top point"
+
+        Expect.equal
+          (HexGrid.get 10 10 grid)
+          ValueNone
+          "Center empty for outline"
+
+      testCase "circle filled fills interior"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 20 20 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.circle 10 10 3 true 1)
+
+        Expect.equal (HexGrid.get 10 10 grid) (ValueSome 1) "Center filled"
+        Expect.equal (HexGrid.get 9 10 grid) (ValueSome 1) "Adjacent filled"
+
+      testCase "checker creates alternating pattern"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 4 4 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.checker 0 1)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 0) "(0,0) = odd"
+        Expect.equal (HexGrid.get 1 0 grid) (ValueSome 1) "(1,0) = even"
+        Expect.equal (HexGrid.get 0 1 grid) (ValueSome 1) "(0,1) = even"
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 0) "(1,1) = odd"
+    ]
+
+    testList "Geometry - FlatTop" [
+      testCase "line draws horizontal line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.line 1 2 5 2 1)
+
+        for col in 1..5 do
+          Expect.equal (HexGrid.get col 2 grid) (ValueSome 1) $"Point ({col},2)"
+
+      testCase "line draws vertical line"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.line 2 1 2 5 1)
+
+        for row in 1..5 do
+          Expect.equal (HexGrid.get 2 row grid) (ValueSome 1) $"Point (2,{row})"
+
+      testCase "line draws diagonal"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.line 0 0 4 4 1)
+
+        for i in 0..4 do
+          Expect.equal (HexGrid.get i i grid) (ValueSome 1) $"Point ({i},{i})"
+
+      testCase "circle outline draws points at radius"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 20 20 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.circle 10 10 5 false 1)
+
+        Expect.equal (HexGrid.get 15 10 grid) (ValueSome 1) "Right point"
+        Expect.equal (HexGrid.get 5 10 grid) (ValueSome 1) "Left point"
+        Expect.equal (HexGrid.get 10 15 grid) (ValueSome 1) "Bottom point"
+        Expect.equal (HexGrid.get 10 5 grid) (ValueSome 1) "Top point"
+
+        Expect.equal
+          (HexGrid.get 10 10 grid)
+          ValueNone
+          "Center empty for outline"
+
+      testCase "circle filled fills interior"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 20 20 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.circle 10 10 3 true 1)
+
+        Expect.equal (HexGrid.get 10 10 grid) (ValueSome 1) "Center filled"
+        Expect.equal (HexGrid.get 9 10 grid) (ValueSome 1) "Adjacent filled"
+
+      testCase "checker creates alternating pattern"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 4 4 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.checker 0 1)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 0) "(0,0) = odd"
+        Expect.equal (HexGrid.get 1 0 grid) (ValueSome 1) "(1,0) = even"
+        Expect.equal (HexGrid.get 0 1 grid) (ValueSome 1) "(0,1) = even"
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 0) "(1,1) = odd"
+    ]
+
+    testList "Procedural - PointyTop" [
+      testCase "generate fills with generator function"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.generate 1 1 3 3 (fun c r -> c * 10 + r))
+
+        Expect.equal
+          (HexGrid.get 1 1 grid)
+          (ValueSome 11)
+          "Generated value at (1,1)"
+
+        Expect.equal
+          (HexGrid.get 2 2 grid)
+          (ValueSome 22)
+          "Generated value at (2,2)"
+
+        Expect.equal
+          (HexGrid.get 3 3 grid)
+          (ValueSome 33)
+          "Generated value at (3,3)"
+
+        Expect.equal (HexGrid.get 0 0 grid) ValueNone "Outside generation"
+
+      testCase "scatter places random items"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.scatter 10 12345 42)
+
+        let mutable count = 0
+        grid |> HexGrid.iter(fun _ _ _ -> count <- count + 1)
+
+        Expect.isGreaterThan count 0 "Should place at least some items"
+        Expect.isLessThanOrEqual count 10 "Should not exceed requested count"
+
+      testCase "scatterStamp places stamps"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(
+            HexLayout.scatterStamp 3 42 (fun s -> s |> HexLayout.set 0 0 99)
+          )
+
+        let mutable count = 0
+        grid |> HexGrid.iter(fun _ _ _ -> count <- count + 1)
+
+        Expect.equal count 3 "Should place 3 stamps"
+    ]
+
+    testList "Procedural - FlatTop" [
+      testCase "generate fills with generator function"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.generate 1 1 3 3 (fun c r -> c * 10 + r))
+
+        Expect.equal
+          (HexGrid.get 1 1 grid)
+          (ValueSome 11)
+          "Generated value at (1,1)"
+
+        Expect.equal
+          (HexGrid.get 2 2 grid)
+          (ValueSome 22)
+          "Generated value at (2,2)"
+
+        Expect.equal
+          (HexGrid.get 3 3 grid)
+          (ValueSome 33)
+          "Generated value at (3,3)"
+
+        Expect.equal (HexGrid.get 0 0 grid) ValueNone "Outside generation"
+
+      testCase "scatter places random items"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.scatter 10 12345 42)
+
+        let mutable count = 0
+        grid |> HexGrid.iter(fun _ _ _ -> count <- count + 1)
+
+        Expect.isGreaterThan count 0 "Should place at least some items"
+        Expect.isLessThanOrEqual count 10 "Should not exceed requested count"
+
+      testCase "scatterStamp places stamps"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(
+            HexLayout.scatterStamp 3 42 (fun s -> s |> HexLayout.set 0 0 99)
+          )
+
+        let mutable count = 0
+        grid |> HexGrid.iter(fun _ _ _ -> count <- count + 1)
+
+        Expect.equal count 3 "Should place 3 stamps"
+    ]
+
+    testList "Transformation - PointyTop" [
+      testCase "iter provides read access to cells"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 10
+            |> HexLayout.set 2 2 20
+            |> HexLayout.iter 0 0 3 3 (fun c r v ->
+              match v with
+              | ValueSome value ->
+                HexGrid.set c r (value * 2) section.BackingGrid
+              | ValueNone -> ()))
+
+        Expect.equal
+          (HexGrid.get 1 1 grid)
+          (ValueSome 20)
+          "Iterated and doubled"
+
+        Expect.equal
+          (HexGrid.get 2 2 grid)
+          (ValueSome 40)
+          "Iterated and doubled"
+
+      testCase "map transforms existing content"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 10
+            |> HexLayout.set 2 2 20
+            |> HexLayout.map 0 0 3 3 ((*) 2))
+
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 20) "Mapped value"
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 40) "Mapped value"
+
+      testCase "replace swaps content values"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 1
+            |> HexLayout.set 2 2 1
+            |> HexLayout.set 3 3 2
+            |> HexLayout.replace 1 99)
+
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 99) "Replaced"
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 99) "Replaced"
+        Expect.equal (HexGrid.get 3 3 grid) (ValueSome 2) "Unchanged"
+    ]
+
+    testList "Transformation - FlatTop" [
+      testCase "iter provides read access to cells"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 10
+            |> HexLayout.set 2 2 20
+            |> HexLayout.iter 0 0 3 3 (fun c r v ->
+              match v with
+              | ValueSome value ->
+                HexGrid.set c r (value * 2) section.BackingGrid
+              | ValueNone -> ()))
+
+        Expect.equal
+          (HexGrid.get 1 1 grid)
+          (ValueSome 20)
+          "Iterated and doubled"
+
+        Expect.equal
+          (HexGrid.get 2 2 grid)
+          (ValueSome 40)
+          "Iterated and doubled"
+
+      testCase "map transforms existing content"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 10
+            |> HexLayout.set 2 2 20
+            |> HexLayout.map 0 0 3 3 ((*) 2))
+
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 20) "Mapped value"
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 40) "Mapped value"
+
+      testCase "replace swaps content values"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.set 1 1 1
+            |> HexLayout.set 2 2 1
+            |> HexLayout.set 3 3 2
+            |> HexLayout.replace 1 99)
+
+        Expect.equal (HexGrid.get 1 1 grid) (ValueSome 99) "Replaced"
+        Expect.equal (HexGrid.get 2 2 grid) (ValueSome 99) "Replaced"
+        Expect.equal (HexGrid.get 3 3 grid) (ValueSome 2) "Unchanged"
+    ]
+
+    testList "Flow - PointyTop" [
+      testCase "flowX places stamps along X"
+      <| fun _ ->
+        let stamps = [
+          (fun s -> HexLayout.set 0 0 1 s)
+          (fun s -> HexLayout.set 0 0 2 s)
+          (fun s -> HexLayout.set 0 0 3 s)
+        ]
+
+        let grid =
+          HexGrid.create 20 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.flowX 5 stamps)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 1) "First stamp"
+        Expect.equal (HexGrid.get 5 0 grid) (ValueSome 2) "Second stamp"
+        Expect.equal (HexGrid.get 10 0 grid) (ValueSome 3) "Third stamp"
+
+      testCase "flowY places stamps along Y"
+      <| fun _ ->
+        let stamps = [
+          (fun s -> HexLayout.set 0 0 1 s)
+          (fun s -> HexLayout.set 0 0 2 s)
+        ]
+
+        let grid =
+          HexGrid.create 5 20 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.flowY 3 stamps)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 1) "First stamp"
+        Expect.equal (HexGrid.get 0 3 grid) (ValueSome 2) "Second stamp"
+    ]
+
+    testList "Flow - FlatTop" [
+      testCase "flowX places stamps along X"
+      <| fun _ ->
+        let stamps = [
+          (fun s -> HexLayout.set 0 0 1 s)
+          (fun s -> HexLayout.set 0 0 2 s)
+          (fun s -> HexLayout.set 0 0 3 s)
+        ]
+
+        let grid =
+          HexGrid.create 20 5 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.flowX 5 stamps)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 1) "First stamp"
+        Expect.equal (HexGrid.get 5 0 grid) (ValueSome 2) "Second stamp"
+        Expect.equal (HexGrid.get 10 0 grid) (ValueSome 3) "Third stamp"
+
+      testCase "flowY places stamps along Y"
+      <| fun _ ->
+        let stamps = [
+          (fun s -> HexLayout.set 0 0 1 s)
+          (fun s -> HexLayout.set 0 0 2 s)
+        ]
+
+        let grid =
+          HexGrid.create 5 20 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(HexLayout.flowY 3 stamps)
+
+        Expect.equal (HexGrid.get 0 0 grid) (ValueSome 1) "First stamp"
+        Expect.equal (HexGrid.get 0 3 grid) (ValueSome 2) "Second stamp"
+    ]
+
+    testList "Composition - PointyTop" [
+      testCase "center centers a block"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.center 4 4 (fun inner ->
+              inner |> HexLayout.set 0 0 42))
+
+        Expect.equal
+          (HexGrid.get 3 3 grid)
+          (ValueSome 42)
+          "Centered block should be at (3,3)"
+
+      testCase "section creates sub-section"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.section 2 3 (fun inner ->
+              inner
+              |> HexLayout.section 1 1 (fun inner2 ->
+                inner2 |> HexLayout.set 0 0 42)))
+
+        Expect.equal
+          (HexGrid.get 3 4 grid)
+          (ValueSome 42)
+          "Nested section offset"
+    ]
+
+    testList "Composition - FlatTop" [
+      testCase "center centers a block"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.center 4 4 (fun inner ->
+              inner |> HexLayout.set 0 0 42))
+
+        Expect.equal
+          (HexGrid.get 3 3 grid)
+          (ValueSome 42)
+          "Centered block should be at (3,3)"
+
+      testCase "section creates sub-section"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> HexLayout.run(fun section ->
+            section
+            |> HexLayout.section 2 3 (fun inner ->
+              inner
+              |> HexLayout.section 1 1 (fun inner2 ->
+                inner2 |> HexLayout.set 0 0 42)))
+
+        Expect.equal
+          (HexGrid.get 3 4 grid)
+          (ValueSome 42)
+          "Nested section offset"
+    ]
+  ]

--- a/src/Mibo.Raylib.Tests/HexLayoutTests.fs
+++ b/src/Mibo.Raylib.Tests/HexLayoutTests.fs
@@ -336,6 +336,26 @@ let tests =
         Expect.equal (HexGrid.get 1 0 grid) (ValueSome 1) "(1,0) = even"
         Expect.equal (HexGrid.get 0 1 grid) (ValueSome 1) "(0,1) = even"
         Expect.equal (HexGrid.get 1 1 grid) (ValueSome 0) "(1,1) = odd"
+
+      testCase "scatterBorder with zero width does not throw"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.scatterBorder 0 0 0 5 10 42 1)
+
+        let mutable count = 0
+        grid |> HexGrid.iter(fun _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
+
+      testCase "scatterBorder with zero height does not throw"
+      <| fun _ ->
+        let grid =
+          HexGrid.create 5 5 32f Vector2.Zero HexOrientation.PointyTop
+          |> HexLayout.run(HexLayout.scatterBorder 0 0 5 0 10 42 1)
+
+        let mutable count = 0
+        grid |> HexGrid.iter(fun _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
     ]
 
     testList "Geometry - FlatTop" [

--- a/src/Mibo.Raylib.Tests/LayeredHexTests.fs
+++ b/src/Mibo.Raylib.Tests/LayeredHexTests.fs
@@ -1,0 +1,61 @@
+module Mibo.Raylib.Tests.LayeredHex
+
+open Expecto
+open System.Numerics
+open Mibo.Layout
+
+[<Tests>]
+let tests =
+  testList "LayeredHexGrid" [
+    testList "PointyTop" [
+      testCase "layer creates and accesses layers on demand"
+      <| fun _ ->
+        let layered =
+          LayeredHexGrid.create 10 10 32f Vector2.Zero HexOrientation.PointyTop
+          |> LayeredHexLayout.layer 0 (HexLayout.set 1 1 10)
+          |> LayeredHexLayout.layer 1 (HexLayout.set 2 2 20)
+
+        let (layer0, _) = LayeredHexGrid.getOrAddLayer 0 layered
+        let (layer1, _) = LayeredHexGrid.getOrAddLayer 1 layered
+
+        Expect.equal (HexGrid.get 1 1 layer0) (ValueSome 10) "Layer 0 content"
+
+        Expect.equal (HexGrid.get 2 2 layer1) (ValueSome 20) "Layer 1 content"
+
+        Expect.equal
+          (HexGrid.get 2 2 layer0)
+          ValueNone
+          "Layer 0 doesn't have layer 1 content"
+
+        Expect.equal
+          (HexGrid.get 1 1 layer1)
+          ValueNone
+          "Layer 1 doesn't have layer 0 content"
+    ]
+
+    testList "FlatTop" [
+      testCase "layer creates and accesses layers on demand"
+      <| fun _ ->
+        let layered =
+          LayeredHexGrid.create 10 10 32f Vector2.Zero HexOrientation.FlatTop
+          |> LayeredHexLayout.layer 0 (HexLayout.set 1 1 10)
+          |> LayeredHexLayout.layer 1 (HexLayout.set 2 2 20)
+
+        let (layer0, _) = LayeredHexGrid.getOrAddLayer 0 layered
+        let (layer1, _) = LayeredHexGrid.getOrAddLayer 1 layered
+
+        Expect.equal (HexGrid.get 1 1 layer0) (ValueSome 10) "Layer 0 content"
+
+        Expect.equal (HexGrid.get 2 2 layer1) (ValueSome 20) "Layer 1 content"
+
+        Expect.equal
+          (HexGrid.get 2 2 layer0)
+          ValueNone
+          "Layer 0 doesn't have layer 1 content"
+
+        Expect.equal
+          (HexGrid.get 1 1 layer1)
+          ValueNone
+          "Layer 1 doesn't have layer 0 content"
+    ]
+  ]

--- a/src/Mibo.Raylib.Tests/Layout3DTests.fs
+++ b/src/Mibo.Raylib.Tests/Layout3DTests.fs
@@ -332,6 +332,36 @@ let tests =
         Expect.equal (CellGrid3D.get 2 1 1 grid) (ValueSome 1) "Edge along X"
         Expect.equal (CellGrid3D.get 1 2 1 grid) (ValueSome 1) "Edge along Y"
         Expect.equal (CellGrid3D.get 1 1 2 grid) (ValueSome 1) "Edge along Z"
+
+      testCase "scatterEdges with zero width does not throw"
+      <| fun _ ->
+        let grid =
+          CellGrid3D.create 5 5 5 (Vector3(32f, 32f, 32f)) Vector3.Zero
+          |> Layout3D.run(Layout3D.scatterEdges 0 0 0 0 5 5 10 42 1)
+
+        let mutable count = 0
+        grid |> CellGrid3D.iter(fun _ _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
+
+      testCase "scatterEdges with zero height does not throw"
+      <| fun _ ->
+        let grid =
+          CellGrid3D.create 5 5 5 (Vector3(32f, 32f, 32f)) Vector3.Zero
+          |> Layout3D.run(Layout3D.scatterEdges 0 0 0 5 0 5 10 42 1)
+
+        let mutable count = 0
+        grid |> CellGrid3D.iter(fun _ _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
+
+      testCase "scatterEdges with zero depth does not throw"
+      <| fun _ ->
+        let grid =
+          CellGrid3D.create 5 5 5 (Vector3(32f, 32f, 32f)) Vector3.Zero
+          |> Layout3D.run(Layout3D.scatterEdges 0 0 0 5 5 0 10 42 1)
+
+        let mutable count = 0
+        grid |> CellGrid3D.iter(fun _ _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
     ]
 
     testList "Layout3D Repetition" [

--- a/src/Mibo.Raylib.Tests/LayoutTests.fs
+++ b/src/Mibo.Raylib.Tests/LayoutTests.fs
@@ -298,6 +298,26 @@ let tests =
         Expect.equal (CellGrid2D.get 1 0 grid) (ValueSome 1) "(1,0) = even"
         Expect.equal (CellGrid2D.get 0 1 grid) (ValueSome 1) "(0,1) = even"
         Expect.equal (CellGrid2D.get 1 1 grid) (ValueSome 0) "(1,1) = odd"
+
+      testCase "scatterBorder with zero width does not throw"
+      <| fun _ ->
+        let grid =
+          CellGrid2D.create 5 5 (Vector2(32f, 32f)) Vector2.Zero
+          |> Layout.run(Layout.scatterBorder 0 0 0 5 10 42 1)
+
+        let mutable count = 0
+        grid |> CellGrid2D.iter(fun _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
+
+      testCase "scatterBorder with zero height does not throw"
+      <| fun _ ->
+        let grid =
+          CellGrid2D.create 5 5 (Vector2(32f, 32f)) Vector2.Zero
+          |> Layout.run(Layout.scatterBorder 0 0 5 0 10 42 1)
+
+        let mutable count = 0
+        grid |> CellGrid2D.iter(fun _ _ _ -> count <- count + 1)
+        Expect.equal count 0 "Should place no items"
     ]
 
     testList "Platformer" [

--- a/src/Mibo.Raylib.Tests/LayoutTests.fs
+++ b/src/Mibo.Raylib.Tests/LayoutTests.fs
@@ -67,6 +67,25 @@ let tests =
         Expect.equal pos.X 196f "X = 100 + 3*32"
         Expect.equal pos.Y 114f "Y = 50 + 2*32"
 
+      testCase "clear removes cell content"
+      <| fun _ ->
+        let grid = CellGrid2D.create 5 5 (Vector2(32f, 32f)) Vector2.Zero
+
+        CellGrid2D.set 2 2 42 grid
+        Expect.equal (CellGrid2D.get 2 2 grid) (ValueSome 42) "Should be set"
+
+        CellGrid2D.clear 2 2 grid
+        Expect.equal (CellGrid2D.get 2 2 grid) ValueNone "Should be cleared"
+
+      testCase "clear out of bounds is ignored"
+      <| fun _ ->
+        let grid = CellGrid2D.create 5 5 (Vector2(32f, 32f)) Vector2.Zero
+
+        CellGrid2D.clear -1 0 grid
+        CellGrid2D.clear 0 -1 grid
+        CellGrid2D.clear 5 0 grid
+        CellGrid2D.clear 0 5 grid
+
       testCase "iter visits all populated cells"
       <| fun _ ->
         let grid = CellGrid2D.create 5 5 (Vector2(32f, 32f)) Vector2.Zero

--- a/src/Mibo.Raylib.Tests/Mibo.Raylib.Tests.fsproj
+++ b/src/Mibo.Raylib.Tests/Mibo.Raylib.Tests.fsproj
@@ -14,6 +14,9 @@
     <Compile Include="RenderBufferTests.fs" />
     <Compile Include="LayoutTests.fs" />
     <Compile Include="Layout3DTests.fs" />
+    <Compile Include="HexGridTests.fs" />
+    <Compile Include="HexLayoutTests.fs" />
+    <Compile Include="LayeredHexTests.fs" />
     <Compile Include="Graphics2DTests.fs" />
     <Compile Include="Graphics3DTests.fs" />
     <Compile Include="AnimationTests.fs" />

--- a/src/Mibo.Raylib/Layout/Grid2D.fs
+++ b/src/Mibo.Raylib/Layout/Grid2D.fs
@@ -39,6 +39,11 @@ module CellGrid2D =
     else
       ValueNone
 
+  let inline clear x y (grid: CellGrid2D<'T>) : unit =
+    if x >= 0 && x < grid.Width && y >= 0 && y < grid.Height then
+      let idx = toIndex x y grid.Width
+      grid.Cells.[idx] <- ValueNone
+
   let inline getWorldPos x y (grid: CellGrid2D<'T>) : Vector2 =
     Vector2(
       grid.Origin.X + float32 x * grid.CellSize.X,

--- a/src/Mibo.Raylib/Layout/HexGrid.fs
+++ b/src/Mibo.Raylib/Layout/HexGrid.fs
@@ -1,0 +1,148 @@
+namespace Mibo.Layout
+
+open System.Numerics
+
+[<Struct>]
+type HexOrientation =
+  | PointyTop
+  | FlatTop
+
+[<Struct>]
+type HexGrid<'T> = {
+  Origin: Vector2
+  Size: float32
+  Orientation: HexOrientation
+  Width: int
+  Height: int
+  Cells: 'T voption[]
+}
+
+module HexGrid =
+  let inline private toIndex col row width = col + row * width
+
+  let inline private hexDimensions
+    (size: float32)
+    (orientation: HexOrientation)
+    =
+    match orientation with
+    | PointyTop -> struct (size * sqrt 3f, size * 2f)
+    | FlatTop -> struct (size * 2f, size * sqrt 3f)
+
+  let create
+    width
+    height
+    (size: float32)
+    (origin: Vector2)
+    (orientation: HexOrientation)
+    : HexGrid<'T> =
+    {
+      Origin = origin
+      Size = size
+      Orientation = orientation
+      Width = width
+      Height = height
+      Cells = Array.create (width * height) ValueNone
+    }
+
+  let inline set col row (content: 'T) (grid: HexGrid<'T>) : unit =
+    if col >= 0 && col < grid.Width && row >= 0 && row < grid.Height then
+      let idx = toIndex col row grid.Width
+      grid.Cells.[idx] <- ValueSome content
+
+  let inline get col row (grid: HexGrid<'T>) : 'T voption =
+    if col >= 0 && col < grid.Width && row >= 0 && row < grid.Height then
+      let idx = toIndex col row grid.Width
+      grid.Cells.[idx]
+    else
+      ValueNone
+
+  let inline clear col row (grid: HexGrid<'T>) : unit =
+    if col >= 0 && col < grid.Width && row >= 0 && row < grid.Height then
+      let idx = toIndex col row grid.Width
+      grid.Cells.[idx] <- ValueNone
+
+  let inline getWorldPos col row (grid: HexGrid<'T>) : Vector2 =
+    let struct (hexW, hexH) = hexDimensions grid.Size grid.Orientation
+
+    match grid.Orientation with
+    | PointyTop ->
+      let x =
+        grid.Origin.X
+        + float32 col * hexW
+        + (if row % 2 = 1 then hexW / 2f else 0f)
+
+      let y = grid.Origin.Y + float32 row * hexH * 0.75f
+      Vector2(x + hexW / 2f, y + hexH / 2f)
+    | FlatTop ->
+      let x = grid.Origin.X + float32 col * hexW * 0.75f
+
+      let y =
+        grid.Origin.Y
+        + float32 row * hexH
+        + (if col % 2 = 1 then hexH / 2f else 0f)
+
+      Vector2(x + hexW / 2f, y + hexH / 2f)
+
+  let inline iter
+    ([<InlineIfLambda>] action: int -> int -> 'T -> unit)
+    (grid: HexGrid<'T>)
+    : unit =
+    let w = grid.Width
+
+    for i in 0 .. grid.Cells.Length - 1 do
+      match grid.Cells.[i] with
+      | ValueSome content ->
+        let col = i % w
+        let row = i / w
+        action col row content
+      | ValueNone -> ()
+
+  let inline iterVisible
+    (left: float32)
+    (top: float32)
+    (right: float32)
+    (bottom: float32)
+    ([<InlineIfLambda>] action: int -> int -> 'T -> unit)
+    (grid: HexGrid<'T>)
+    : unit =
+    let struct (hexW, hexH) = hexDimensions grid.Size grid.Orientation
+
+    let startCol, endCol, startRow, endRow =
+      match grid.Orientation with
+      | PointyTop ->
+        let sc = max 0 (int((left - grid.Origin.X) / hexW) - 1)
+        let ec = min (grid.Width - 1) (int((right - grid.Origin.X) / hexW) + 1)
+        let sr = max 0 (int((top - grid.Origin.Y) / (hexH * 0.75f)) - 1)
+
+        let er =
+          min
+            (grid.Height - 1)
+            (int((bottom - grid.Origin.Y) / (hexH * 0.75f)) + 1)
+
+        sc, ec, sr, er
+      | FlatTop ->
+        let sc = max 0 (int((left - grid.Origin.X) / (hexW * 0.75f)) - 1)
+
+        let ec =
+          min
+            (grid.Width - 1)
+            (int((right - grid.Origin.X) / (hexW * 0.75f)) + 1)
+
+        let sr = max 0 (int((top - grid.Origin.Y) / hexH) - 1)
+
+        let er =
+          min (grid.Height - 1) (int((bottom - grid.Origin.Y) / hexH) + 1)
+
+        sc, ec, sr, er
+
+    let w = grid.Width
+
+    for row in startRow..endRow do
+      let rowOffset = row * w
+
+      for col in startCol..endCol do
+        let idx = rowOffset + col
+
+        match grid.Cells.[idx] with
+        | ValueSome content -> action col row content
+        | ValueNone -> ()

--- a/src/Mibo.Raylib/Layout/HexLayout.fs
+++ b/src/Mibo.Raylib/Layout/HexLayout.fs
@@ -294,27 +294,28 @@ module HexLayout =
     content
     (section: HexGridSection<'T>)
     : HexGridSection<'T> =
-    let rng = System.Random(seed)
+    if width > 0 && height > 0 then
+      let rng = System.Random(seed)
 
-    for _ in 1..count do
-      let side = rng.Next(0, 4)
+      for _ in 1..count do
+        let side = rng.Next(0, 4)
 
-      match side with
-      | 0 -> setHexLocal (col + rng.Next(0, width)) row content section
-      | 1 ->
-        setHexLocal
-          (col + rng.Next(0, width))
-          (row + height - 1)
-          content
-          section
-      | 2 -> setHexLocal col (row + rng.Next(0, height)) content section
-      | 3 ->
-        setHexLocal
-          (col + width - 1)
-          (row + rng.Next(0, height))
-          content
-          section
-      | _ -> ()
+        match side with
+        | 0 -> setHexLocal (col + rng.Next(0, width)) row content section
+        | 1 ->
+          setHexLocal
+            (col + rng.Next(0, width))
+            (row + height - 1)
+            content
+            section
+        | 2 -> setHexLocal col (row + rng.Next(0, height)) content section
+        | 3 ->
+          setHexLocal
+            (col + width - 1)
+            (row + rng.Next(0, height))
+            content
+            section
+        | _ -> ()
 
     section
 

--- a/src/Mibo.Raylib/Layout/HexLayout.fs
+++ b/src/Mibo.Raylib/Layout/HexLayout.fs
@@ -1,0 +1,769 @@
+namespace Mibo.Layout
+
+open HexGrid
+
+[<Struct>]
+type HexGridSection<'T> = {
+  BackingGrid: HexGrid<'T>
+  OffsetCol: int
+  OffsetRow: int
+  Width: int
+  Height: int
+}
+
+[<AutoOpen>]
+module HexLayoutHelpers =
+  let createHexSection(grid: HexGrid<'T>) : HexGridSection<'T> = {
+    BackingGrid = grid
+    OffsetCol = 0
+    OffsetRow = 0
+    Width = grid.Width
+    Height = grid.Height
+  }
+
+  let inline setHexLocal
+    (lc: int)
+    (lr: int)
+    (content: 'T)
+    (section: HexGridSection<'T>)
+    : unit =
+    let gc = section.OffsetCol + lc
+    let gr = section.OffsetRow + lr
+
+    if
+      gc >= 0
+      && gc < section.BackingGrid.Width
+      && gr >= 0
+      && gr < section.BackingGrid.Height
+    then
+      set gc gr content section.BackingGrid
+
+module HexLayout =
+  let inline run
+    ([<InlineIfLambda>] f: HexGridSection<'T> -> HexGridSection<'T>)
+    (grid: HexGrid<'T>)
+    : HexGrid<'T> =
+    let section = createHexSection grid
+    let result = f section
+    result.BackingGrid
+
+  let inline section
+    col
+    row
+    ([<InlineIfLambda>] f: HexGridSection<'T> -> HexGridSection<'T>)
+    (parent: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let col = max 0 (min parent.Width col)
+    let row = max 0 (min parent.Height row)
+
+    let childSection = {
+      BackingGrid = parent.BackingGrid
+      OffsetCol = parent.OffsetCol + col
+      OffsetRow = parent.OffsetRow + row
+      Width = max 0 (parent.Width - col)
+      Height = max 0 (parent.Height - row)
+    }
+
+    f childSection |> ignore
+    parent
+
+  let inline padding
+    n
+    ([<InlineIfLambda>] f: HexGridSection<'T> -> HexGridSection<'T>)
+    (parent: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let n = max 0 n
+
+    if n = 0 then
+      f parent |> ignore
+      parent
+    else
+      let childSection = {
+        BackingGrid = parent.BackingGrid
+        OffsetCol = parent.OffsetCol + n
+        OffsetRow = parent.OffsetRow + n
+        Width = max 0 (parent.Width - 2 * n)
+        Height = max 0 (parent.Height - 2 * n)
+      }
+
+      f childSection |> ignore
+      parent
+
+  let inline paddingEx
+    left
+    top
+    right
+    bottom
+    ([<InlineIfLambda>] f: HexGridSection<'T> -> HexGridSection<'T>)
+    (parent: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let left = max 0 left
+    let top = max 0 top
+    let right = max 0 right
+    let bottom = max 0 bottom
+
+    let childSection = {
+      BackingGrid = parent.BackingGrid
+      OffsetCol = parent.OffsetCol + left
+      OffsetRow = parent.OffsetRow + top
+      Width = max 0 (parent.Width - left - right)
+      Height = max 0 (parent.Height - top - bottom)
+    }
+
+    f childSection |> ignore
+    parent
+
+  let inline center
+    w
+    h
+    ([<InlineIfLambda>] f: HexGridSection<'T> -> HexGridSection<'T>)
+    (parent: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let w = max 0 (min parent.Width w)
+    let h = max 0 (min parent.Height h)
+    let col = (parent.Width - w) / 2
+    let row = (parent.Height - h) / 2
+
+    let childSection = {
+      BackingGrid = parent.BackingGrid
+      OffsetCol = parent.OffsetCol + col
+      OffsetRow = parent.OffsetRow + row
+      Width = w
+      Height = h
+    }
+
+    f childSection |> ignore
+    parent
+
+  let inline flowX
+    step
+    (stamps: (HexGridSection<'T> -> HexGridSection<'T>) seq)
+    (parent: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let mutable i = 0
+
+    for stamp in stamps do
+      section (i * step) 0 stamp parent |> ignore
+      i <- i + 1
+
+    parent
+
+  let inline flowY
+    step
+    (stamps: (HexGridSection<'T> -> HexGridSection<'T>) seq)
+    (parent: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let mutable i = 0
+
+    for stamp in stamps do
+      section 0 (i * step) stamp parent |> ignore
+      i <- i + 1
+
+    parent
+
+  let set col row content (section: HexGridSection<'T>) : HexGridSection<'T> =
+    setHexLocal col row content section
+    section
+
+  let repeatX
+    col
+    row
+    count
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    if row >= 0 && row < section.Height then
+      let c1 = max 0 col
+      let c2 = min section.Width (col + count)
+
+      if c2 > c1 then
+        let grid = section.BackingGrid
+        let gw = grid.Width
+        let startCol = section.OffsetCol + c1
+        let gr = section.OffsetRow + row
+        let idxBase = gr * gw + startCol
+
+        for i in 0 .. c2 - c1 - 1 do
+          grid.Cells.[idxBase + i] <- ValueSome content
+
+    section
+
+  let repeatY
+    col
+    row
+    count
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    if col >= 0 && col < section.Width then
+      let r1 = max 0 row
+      let r2 = min section.Height (row + count)
+
+      if r2 > r1 then
+        let grid = section.BackingGrid
+        let gw = grid.Width
+        let gc = section.OffsetCol + col
+        let startRow = section.OffsetRow + r1
+        let idxBase = startRow * gw + gc
+
+        for i in 0 .. r2 - r1 - 1 do
+          grid.Cells.[idxBase + i * gw] <- ValueSome content
+
+    section
+
+  let fill
+    col
+    row
+    width
+    height
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let c1 = max 0 col
+    let r1 = max 0 row
+    let c2 = min section.Width (col + width)
+    let r2 = min section.Height (row + height)
+
+    if c2 > c1 && r2 > r1 then
+      let grid = section.BackingGrid
+      let gw = grid.Width
+      let startCol = section.OffsetCol + c1
+      let startRow = section.OffsetRow + r1
+      let fillW = c2 - c1
+      let fillH = r2 - r1
+
+      for fr in 0 .. fillH - 1 do
+        let rowStart = startCol + (startRow + fr) * gw
+
+        for fc in 0 .. fillW - 1 do
+          grid.Cells.[rowStart + fc] <- ValueSome content
+
+    section
+
+  let border
+    col
+    row
+    width
+    height
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    if width > 0 && height > 0 then
+      section
+      |> repeatX col row width content
+      |> repeatX col (row + height - 1) width content
+      |> repeatY col (row + 1) (height - 2) content
+      |> repeatY (col + width - 1) (row + 1) (height - 2) content
+    else
+      section
+
+  let rect
+    col
+    row
+    width
+    height
+    borderContent
+    fillContent
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    section
+    |> fill col row width height fillContent
+    |> border col row width height borderContent
+
+  let corners
+    col
+    row
+    width
+    height
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    section
+    |> set col row content
+    |> set (col + width - 1) row content
+    |> set col (row + height - 1) content
+    |> set (col + width - 1) (row + height - 1) content
+
+  let scatterBorder
+    col
+    row
+    width
+    height
+    count
+    seed
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let rng = System.Random(seed)
+
+    for _ in 1..count do
+      let side = rng.Next(0, 4)
+
+      match side with
+      | 0 -> setHexLocal (col + rng.Next(0, width)) row content section
+      | 1 ->
+        setHexLocal
+          (col + rng.Next(0, width))
+          (row + height - 1)
+          content
+          section
+      | 2 -> setHexLocal col (row + rng.Next(0, height)) content section
+      | 3 ->
+        setHexLocal
+          (col + width - 1)
+          (row + rng.Next(0, height))
+          content
+          section
+      | _ -> ()
+
+    section
+
+  let scatterLine
+    c1
+    r1
+    c2
+    r2
+    count
+    seed
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let dc = abs(c2 - c1)
+    let dr = abs(r2 - r1)
+    let dm = max dc dr
+
+    if dm > 0 then
+      let rng = System.Random(seed)
+
+      for _ in 1..count do
+        let t = rng.NextDouble()
+        let lc = c1 + int(float(c2 - c1) * t)
+        let lr = r1 + int(float(r2 - r1) * t)
+        setHexLocal lc lr content section
+
+    section
+
+  let checkerBorder
+    col
+    row
+    width
+    height
+    odd
+    even
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    for bc in 0 .. width - 1 do
+      let top = if bc % 2 = 0 then odd else even
+      let bottom = if (bc + height - 1) % 2 = 0 then odd else even
+      setHexLocal (col + bc) row top section |> ignore
+      setHexLocal (col + bc) (row + height - 1) bottom section |> ignore
+
+    for br in 1 .. height - 2 do
+      let left = if br % 2 = 0 then odd else even
+      let right = if (br + width - 1) % 2 = 0 then odd else even
+      setHexLocal col (row + br) left section |> ignore
+      setHexLocal (col + width - 1) (row + br) right section |> ignore
+
+    section
+
+  let inline generate
+    col
+    row
+    width
+    height
+    ([<InlineIfLambda>] generator: int -> int -> 'T)
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let c1 = max 0 col
+    let r1 = max 0 row
+    let c2 = min section.Width (col + width)
+    let r2 = min section.Height (row + height)
+
+    if c2 > c1 && r2 > r1 then
+      let grid = section.BackingGrid
+      let gw = grid.Width
+      let startCol = section.OffsetCol + c1
+      let startRow = section.OffsetRow + r1
+      let fillW = c2 - c1
+      let fillH = r2 - r1
+
+      for fr in 0 .. fillH - 1 do
+        let lr = r1 + fr
+        let rowStart = startCol + (startRow + fr) * gw
+
+        for fc in 0 .. fillW - 1 do
+          let lc = c1 + fc
+          grid.Cells.[rowStart + fc] <- ValueSome(generator lc lr)
+
+    section
+
+  let inline iter
+    col
+    row
+    width
+    height
+    ([<InlineIfLambda>] action: int -> int -> 'T voption -> unit)
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let w = section.BackingGrid.Width
+
+    for fc in col .. col + width - 1 do
+      for fr in row .. row + height - 1 do
+        let gc = section.OffsetCol + fc
+        let gr = section.OffsetRow + fr
+
+        if
+          gc >= 0
+          && gc < section.BackingGrid.Width
+          && gr >= 0
+          && gr < section.BackingGrid.Height
+        then
+          let idx = gc + gr * w
+          let cell = section.BackingGrid.Cells.[idx]
+          action fc fr cell
+
+    section
+
+  let inline map
+    col
+    row
+    width
+    height
+    ([<InlineIfLambda>] mapping: 'T -> 'T)
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let w = section.BackingGrid.Width
+
+    for fc in col .. col + width - 1 do
+      for fr in row .. row + height - 1 do
+        let gc = section.OffsetCol + fc
+        let gr = section.OffsetRow + fr
+
+        if
+          gc >= 0
+          && gc < section.BackingGrid.Width
+          && gr >= 0
+          && gr < section.BackingGrid.Height
+        then
+          let idx = gc + gr * w
+
+          match section.BackingGrid.Cells.[idx] with
+          | ValueSome content ->
+            section.BackingGrid.Cells.[idx] <- ValueSome(mapping content)
+          | ValueNone -> ()
+
+    section
+
+  let line
+    c1
+    r1
+    c2
+    r2
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let dc = abs(c2 - c1)
+    let dr = -abs(r2 - r1)
+    let sc = if c1 < c2 then 1 else -1
+    let sr = if r1 < r2 then 1 else -1
+    let mutable err = dc + dr
+    let mutable cc = c1
+    let mutable cr = r1
+
+    while not(cc = c2 && cr = r2) do
+      setHexLocal cc cr content section
+      let e2 = 2 * err
+
+      if e2 >= dr then
+        err <- err + dr
+        cc <- cc + sc
+
+      if e2 <= dc then
+        err <- err + dc
+        cr <- cr + sr
+
+    setHexLocal cc cr content section
+    section
+
+  let circle
+    cc
+    cr
+    radius
+    filled
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let mutable x = radius
+    let mutable y = 0
+    let mutable err = 1 - x
+
+    let plot cx cy x y =
+      if filled then
+        let drawLine x1 x2 y =
+          let startX = min x1 x2
+          let endX = max x1 x2
+
+          for i in startX..endX do
+            setHexLocal (cx + i) (cy + y) content section
+
+        drawLine (-x) x y
+        drawLine (-x) x (-y)
+        drawLine (-y) y x
+        drawLine (-y) y (-x)
+      else
+        setHexLocal (cx + x) (cy + y) content section
+        setHexLocal (cx - x) (cy + y) content section
+        setHexLocal (cx + x) (cy - y) content section
+        setHexLocal (cx - x) (cy - y) content section
+        setHexLocal (cx + y) (cy + x) content section
+        setHexLocal (cx - y) (cy + x) content section
+        setHexLocal (cx + y) (cy - x) content section
+        setHexLocal (cx - y) (cy - x) content section
+
+    while x >= y do
+      plot cc cr x y
+      y <- y + 1
+
+      if err < 0 then
+        err <- err + 2 * y + 1
+      else
+        x <- x - 1
+        err <- err + 2 * (y - x) + 1
+
+    section
+
+  let polygon
+    (points: struct (int * int)[])
+    filled
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    if points.Length = 0 then
+      section
+    else
+      if filled then
+        let mutable minY = System.Int32.MaxValue
+        let mutable maxY = System.Int32.MinValue
+
+        for i in 0 .. points.Length - 1 do
+          let struct (_, y) = points.[i]
+
+          if y < minY then
+            minY <- y
+
+          if y > maxY then
+            maxY <- y
+
+        for y in max 0 minY .. min (section.Height - 1) maxY do
+          let nodes = System.Collections.Generic.List<int>()
+          let mutable j = points.Length - 1
+
+          for i in 0 .. points.Length - 1 do
+            let struct (xi, yi) = points.[i]
+            let struct (xj, yj) = points.[j]
+
+            if (yi <= y && yj > y) || (yj <= y && yi > y) then
+              let x = float xi + float(y - yi) / float(yj - yi) * float(xj - xi)
+              nodes.Add(int x)
+
+            j <- i
+
+          nodes.Sort()
+          let count = nodes.Count
+          let mutable i = 0
+
+          while i < count - 1 do
+            for x in nodes.[i] .. nodes.[i + 1] do
+              if x >= 0 && x < section.Width then
+                setHexLocal x y content section
+
+            i <- i + 2
+      else
+        let drawLineSegment (x1, y1) (x2, y2) =
+          let dx = abs(x2 - x1)
+          let dy = -abs(y2 - y1)
+          let sx = if x1 < x2 then 1 else -1
+          let sy = if y1 < y2 then 1 else -1
+          let mutable err = dx + dy
+          let mutable cx = x1
+          let mutable cy = y1
+
+          while not(cx = x2 && cy = y2) do
+            setHexLocal cx cy content section
+            let e2 = 2 * err
+
+            if e2 >= dy then
+              err <- err + dy
+              cx <- cx + sx
+
+            if e2 <= dx then
+              err <- err + dx
+              cy <- cy + sy
+
+          setHexLocal cx cy content section
+
+        if points.Length > 1 then
+          for i in 0 .. points.Length - 2 do
+            let struct (x1, y1) = points.[i]
+            let struct (x2, y2) = points.[i + 1]
+            drawLineSegment (x1, y1) (x2, y2)
+
+          let struct (lastX, lastY) = points.[points.Length - 1]
+          let struct (firstX, firstY) = points.[0]
+          drawLineSegment (lastX, lastY) (firstX, firstY)
+
+      section
+
+  let checker odd even (section: HexGridSection<'T>) : HexGridSection<'T> =
+    let grid = section.BackingGrid
+    let gw = grid.Width
+    let startCol = section.OffsetCol
+    let startRow = section.OffsetRow
+
+    for fr in 0 .. section.Height - 1 do
+      let rowStart = startCol + (startRow + fr) * gw
+
+      for fc in 0 .. section.Width - 1 do
+        let content = if (fc + fr) % 2 = 0 then odd else even
+        grid.Cells.[rowStart + fc] <- ValueSome content
+
+    section
+
+  let scatter
+    count
+    seed
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let rng = System.Random(seed)
+
+    for _ in 1..count do
+      let c = rng.Next(0, section.Width)
+      let r = rng.Next(0, section.Height)
+      setHexLocal c r content section
+
+    section
+
+  let clear
+    col
+    row
+    width
+    height
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let c1 = max 0 col
+    let r1 = max 0 row
+    let c2 = min section.Width (col + width)
+    let r2 = min section.Height (row + height)
+
+    if c2 > c1 && r2 > r1 then
+      let grid = section.BackingGrid
+      let gw = grid.Width
+      let startCol = section.OffsetCol + c1
+      let startRow = section.OffsetRow + r1
+      let fillW = c2 - c1
+      let fillH = r2 - r1
+
+      for fr in 0 .. fillH - 1 do
+        let rowStart = startCol + (startRow + fr) * gw
+
+        for fc in 0 .. fillW - 1 do
+          grid.Cells.[rowStart + fc] <- ValueNone
+
+    section
+
+  let replace
+    oldContent
+    newContent
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let w = section.BackingGrid.Width
+
+    for c in 0 .. section.Width - 1 do
+      for r in 0 .. section.Height - 1 do
+        let gc = section.OffsetCol + c
+        let gr = section.OffsetRow + r
+
+        if
+          gc >= 0
+          && gc < section.BackingGrid.Width
+          && gr >= 0
+          && gr < section.BackingGrid.Height
+        then
+          let idx = gc + gr * w
+
+          match section.BackingGrid.Cells.[idx] with
+          | ValueSome cc when cc = oldContent ->
+            section.BackingGrid.Cells.[idx] <- ValueSome newContent
+          | _ -> ()
+
+    section
+
+  let replaceScatter
+    oldContent
+    newContent
+    (probability: float32)
+    seed
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let rng = System.Random(seed)
+
+    for c in 0 .. section.Width - 1 do
+      for r in 0 .. section.Height - 1 do
+        let gc = section.OffsetCol + c
+        let gr = section.OffsetRow + r
+
+        if
+          gc >= 0
+          && gc < section.BackingGrid.Width
+          && gr >= 0
+          && gr < section.BackingGrid.Height
+        then
+          let idx = gc + gr * section.BackingGrid.Width
+
+          match section.BackingGrid.Cells.[idx] with
+          | ValueSome cc when cc = oldContent ->
+            if float32(rng.NextDouble()) < probability then
+              section.BackingGrid.Cells.[idx] <- ValueSome newContent
+          | _ -> ()
+
+    section
+
+  let inline scatterStamp
+    count
+    seed
+    ([<InlineIfLambda>] stamp: HexGridSection<'T> -> HexGridSection<'T>)
+    (section': HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let rng = System.Random(seed)
+
+    for _ in 1..count do
+      let c = rng.Next(0, section'.Width)
+      let r = rng.Next(0, section'.Height)
+      section' |> section c r stamp |> ignore
+
+    section'
+
+  let setIfEmpty
+    col
+    row
+    content
+    (section: HexGridSection<'T>)
+    : HexGridSection<'T> =
+    let gc = section.OffsetCol + col
+    let gr = section.OffsetRow + row
+
+    if
+      gc >= 0
+      && gc < section.BackingGrid.Width
+      && gr >= 0
+      && gr < section.BackingGrid.Height
+    then
+      let w = section.BackingGrid.Width
+      let idx = gc + gr * w
+      let cell = &section.BackingGrid.Cells.[idx]
+
+      if cell.IsNone then
+        cell <- ValueSome content
+
+    section

--- a/src/Mibo.Raylib/Layout/LayeredHex.fs
+++ b/src/Mibo.Raylib/Layout/LayeredHex.fs
@@ -1,0 +1,60 @@
+namespace Mibo.Layout
+
+open System.Collections.Generic
+open System.Numerics
+
+type LayeredHexGrid<'T> = {
+  Width: int
+  Height: int
+  Size: float32
+  Origin: Vector2
+  Orientation: HexOrientation
+  Layers: Dictionary<int, HexGrid<'T>>
+}
+
+module LayeredHexGrid =
+  let create
+    width
+    height
+    (size: float32)
+    (origin: Vector2)
+    (orientation: HexOrientation)
+    : LayeredHexGrid<'T> =
+    {
+      Width = width
+      Height = height
+      Size = size
+      Origin = origin
+      Orientation = orientation
+      Layers = Dictionary()
+    }
+
+  let getOrAddLayer
+    index
+    (grid: LayeredHexGrid<'T>)
+    : HexGrid<'T> * LayeredHexGrid<'T> =
+    match grid.Layers.TryGetValue index with
+    | true, thing -> thing, grid
+    | _ ->
+      let newGrid =
+        HexGrid.create
+          grid.Width
+          grid.Height
+          grid.Size
+          grid.Origin
+          grid.Orientation
+
+      grid.Layers.Add(index, newGrid)
+      newGrid, grid
+
+module LayeredHexLayout =
+  let inline layer
+    index
+    ([<InlineIfLambda>] f: HexGridSection<'T> -> HexGridSection<'T>)
+    (grid: LayeredHexGrid<'T>)
+    : LayeredHexGrid<'T> =
+    let targetGrid, updatedContainer = LayeredHexGrid.getOrAddLayer index grid
+
+    HexLayout.run f targetGrid |> ignore
+
+    updatedContainer

--- a/src/Mibo.Raylib/Layout/Layout.fs
+++ b/src/Mibo.Raylib/Layout/Layout.fs
@@ -294,17 +294,20 @@ module Layout =
     content
     (section: GridSection2D<'T>)
     : GridSection2D<'T> =
-    let rng = System.Random(seed)
+    if width > 0 && height > 0 then
+      let rng = System.Random(seed)
 
-    for _ in 1..count do
-      let side = rng.Next(0, 4)
+      for _ in 1..count do
+        let side = rng.Next(0, 4)
 
-      match side with
-      | 0 -> setLocal (x + rng.Next(0, width)) y content section
-      | 1 -> setLocal (x + rng.Next(0, width)) (y + height - 1) content section
-      | 2 -> setLocal x (y + rng.Next(0, height)) content section
-      | 3 -> setLocal (x + width - 1) (y + rng.Next(0, height)) content section
-      | _ -> ()
+        match side with
+        | 0 -> setLocal (x + rng.Next(0, width)) y content section
+        | 1 ->
+          setLocal (x + rng.Next(0, width)) (y + height - 1) content section
+        | 2 -> setLocal x (y + rng.Next(0, height)) content section
+        | 3 ->
+          setLocal (x + width - 1) (y + rng.Next(0, height)) content section
+        | _ -> ()
 
     section
 

--- a/src/Mibo.Raylib/Layout3D/Layout3D.fs
+++ b/src/Mibo.Raylib/Layout3D/Layout3D.fs
@@ -425,28 +425,29 @@ module Layout3D =
     content
     (section: GridSection3D<'T>)
     : GridSection3D<'T> =
-    let rng = System.Random(seed)
+    if w > 0 && h > 0 && d > 0 then
+      let rng = System.Random(seed)
 
-    for _ in 1..count do
-      let edge = rng.Next(0, 12)
+      for _ in 1..count do
+        let edge = rng.Next(0, 12)
 
-      match edge with
-      | 0 -> setLocal (x + rng.Next(0, w)) y z content section
-      | 1 -> setLocal (x + rng.Next(0, w)) (y + h - 1) z content section
-      | 2 -> setLocal (x + rng.Next(0, w)) y (z + d - 1) content section
-      | 3 ->
-        setLocal (x + rng.Next(0, w)) (y + h - 1) (z + d - 1) content section
-      | 4 -> setLocal x (y + rng.Next(0, h)) z content section
-      | 5 -> setLocal (x + w - 1) (y + rng.Next(0, h)) z content section
-      | 6 -> setLocal x (y + rng.Next(0, h)) (z + d - 1) content section
-      | 7 ->
-        setLocal (x + w - 1) (y + rng.Next(0, h)) (z + d - 1) content section
-      | 8 -> setLocal x y (z + rng.Next(0, d)) content section
-      | 9 -> setLocal (x + w - 1) y (z + rng.Next(0, d)) content section
-      | 10 -> setLocal x (y + h - 1) (z + rng.Next(0, d)) content section
-      | 11 ->
-        setLocal (x + w - 1) (y + h - 1) (z + rng.Next(0, d)) content section
-      | _ -> ()
+        match edge with
+        | 0 -> setLocal (x + rng.Next(0, w)) y z content section
+        | 1 -> setLocal (x + rng.Next(0, w)) (y + h - 1) z content section
+        | 2 -> setLocal (x + rng.Next(0, w)) y (z + d - 1) content section
+        | 3 ->
+          setLocal (x + rng.Next(0, w)) (y + h - 1) (z + d - 1) content section
+        | 4 -> setLocal x (y + rng.Next(0, h)) z content section
+        | 5 -> setLocal (x + w - 1) (y + rng.Next(0, h)) z content section
+        | 6 -> setLocal x (y + rng.Next(0, h)) (z + d - 1) content section
+        | 7 ->
+          setLocal (x + w - 1) (y + rng.Next(0, h)) (z + d - 1) content section
+        | 8 -> setLocal x y (z + rng.Next(0, d)) content section
+        | 9 -> setLocal (x + w - 1) y (z + rng.Next(0, d)) content section
+        | 10 -> setLocal x (y + h - 1) (z + rng.Next(0, d)) content section
+        | 11 ->
+          setLocal (x + w - 1) (y + h - 1) (z + rng.Next(0, d)) content section
+        | _ -> ()
 
     section
 

--- a/src/Mibo.Raylib/Mibo.Raylib.fsproj
+++ b/src/Mibo.Raylib/Mibo.Raylib.fsproj
@@ -8,6 +8,9 @@
   <ItemGroup>
     <Compile Include="Properties/AssemblyInfo.fs" />
     <Compile Include="Layout/Grid2D.fs" />
+    <Compile Include="Layout/HexGrid.fs" />
+    <Compile Include="Layout/HexLayout.fs" />
+    <Compile Include="Layout/LayeredHex.fs" />
     <Compile Include="Layout/Layout.fs" />
     <Compile Include="Layout/Platformer.fs" />
     <Compile Include="Layout/TopDown.fs" />


### PR DESCRIPTION
# Add HexGrid with Layout DSL and Layered Grid

## Summary

Adds `HexGrid<'T>` — a flat-array hex grid matching the exact API surface of `CellGrid2D<'T>` and `CellGrid3D<'T>`. Supports both **PointyTop** and **FlatTop** orientations. Also adds the missing `CellGrid2D.clear` function.

## What's New

### HexGrid (`Mibo.Layout.HexGrid`)

- `HexOrientation` DU: `PointyTop | FlatTop`
- `HexGrid<'T>` struct with flat `'T voption[]` storage
- Module functions: `create`, `set`, `get`, `clear`, `getWorldPos`, `iter`, `iterVisible`

### HexLayout DSL (`Mibo.Layout.HexLayout`)

- `HexGridSection<'T>` struct mirroring `GridSection2D<'T>`
- Full DSL matching `Layout` module: `run`, `section`, `padding`, `paddingEx`, `center`, `flowX`, `flowY`, `set`, `setIfEmpty`, `repeatX`, `repeatY`, `fill`, `border`, `rect`, `corners`, `clear`, `generate`, `iter`, `map`, `replace`, `replaceScatter`, `line`, `circle`, `polygon`, `checker`, `checkerBorder`, `scatter`, `scatterBorder`, `scatterLine`, `scatterStamp`

### LayeredHexGrid (`Mibo.Layout.LayeredHexGrid`)

- `LayeredHexGrid<'T>` with `Dictionary<int, HexGrid<'T>>` layers
- `LayeredHexLayout.layer` for composable per-layer DSL

### CellGrid2D fix

- Added missing `CellGrid2D.clear` function for parity with `CellGrid3D.clear`

## Tests

72 new tests covering both orientations across all API surface:

- **HexGridTests**: create, set/get, clear, getWorldPos (pointy-top & flat-top), iterVisible (both orientations)
- **HexLayoutTests**: DSL (both orientations), geometry (both), procedural (both), transformation (both), flow (both), composition (both)
- **LayeredHexTests**: layered access (both orientations)

Full suite: 499 tests passing.

## Files Changed

| File | Change |
|---|---|
| `src/Mibo.Raylib/Layout/HexGrid.fs` | New — core hex grid type |
| `src/Mibo.Raylib/Layout/HexLayout.fs` | New — layout DSL |
| `src/Mibo.Raylib/Layout/LayeredHex.fs` | New — layered hex grid |
| `src/Mibo.Raylib/Layout/Grid2D.fs` | Added `clear` function |
| `src/Mibo.Raylib/Mibo.Raylib.fsproj` | Added 3 new files |
| `src/Mibo.Raylib.Tests/HexGridTests.fs` | New — 20 tests |
| `src/Mibo.Raylib.Tests/HexLayoutTests.fs` | New — 50 tests |
| `src/Mibo.Raylib.Tests/LayeredHexTests.fs` | New — 2 tests |
| `src/Mibo.Raylib.Tests/LayoutTests.fs` | Added CellGrid2D.clear tests |
| `src/Mibo.Raylib.Tests/Mibo.Raylib.Tests.fsproj` | Added 3 new test files |
