### PR TITLE
docs: add hex grid documentation for 2D and 3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `LayeredHexGrid3D<'T>` — Layered variant with `Dictionary<int, HexGrid3D<'T>>` layers and `LayeredHexLayout3D.layer` for composable per-layer DSL.
 - `HexGrid3DRenderer` — Rendering functions for hex grids: `render`, `renderVolume`, `renderWithIndices`, `renderInstanced`, `renderVolumeInstanced`.
 - Non-uniform dimension tests for 2D, Hex2D, and 3D grids validating correct face/edge positions for shell, border, corners, scatterShell, and scatterBorder functions.
+- Hex grid documentation: comprehensive guides for 2D and 3D hex grids covering orientation, coordinates, adjacency, pathfinding, elevation patterns, instanced rendering, and complete game examples (strategy maps, Civilization-style maps).
 
 ## [1.1.0] - 2026-06-01
 

--- a/docs/level-design/2d/hex.md
+++ b/docs/level-design/2d/hex.md
@@ -1,0 +1,560 @@
+---
+title: Hex Grid Layout (2D)
+category: Level Design
+categoryindex: 2
+index: 27
+---
+
+# Hex Grid Layout (2D)
+
+Hex grids trade the simplicity of rectangles for **equal-distance neighbors** and more natural-looking terrain. If your game needs 6-directional movement, strategy-map aesthetics, or organic-looking levels, hexes are the right tool.
+
+## When to Use Hex vs Rect
+
+| Use Case | Rect Grid | Hex Grid |
+|----------|-----------|----------|
+| Platformers, top-down RPGs | ✅ Natural fit | ❌ Awkward edges |
+| Strategy / tactics games | ❌ Diagonal advantage | ✅ Equal neighbors |
+| Wargames, board game ports | ❌ Looks wrong | ✅ Authentic |
+| Procedural terrain | ❌ Grid lines show | ✅ Organic feel |
+| 4/8-directional movement | ✅ Built-in | ❌ Needs adaptation |
+| 6-directional movement | ❌ Impossible | ✅ Natural |
+
+**The trade-off:** Hex grids are harder to align with screen edges and rectangular sprites. If your game is tile-based with axis-aligned art, stick with rect. If adjacency or aesthetics matter more, hex wins.
+
+## Orientation: Pointy vs Flat Top
+
+Hexes come in two rotations. The choice affects both visuals and coordinate math:
+
+```
+    Pointy Top              Flat Top
+      /\                    ______
+     /  \                  /      \
+    /    \                /        \
+    \    /                \        /
+     \  /                  \      /
+      \/                    ------
+```
+
+**When to pick which:**
+- **Pointy top** — Strategy maps, tactical RPGs. Rows align horizontally, natural for "marching" armies left-to-right.
+- **Flat top** — Isometric-style games, board game adaptations. Columns align vertically, natural for scrolling maps.
+
+```fsharp
+open Mibo.Layout
+
+// Strategy map with pointy-top hexes
+let grid = HexGrid.create 20 15 32f Vector2.Zero PointyTop
+
+// Isometric board with flat-top hexes
+let board = HexGrid.create 12 10 48f Vector2.Zero FlatTop
+```
+
+The `size` parameter is the radius of the hex (center to corner). A `size` of 32f gives you hexes roughly 56px wide (pointy) or 64px wide (flat).
+
+## Coordinate System
+
+Hex grids use **offset coordinates** — a standard column/row pair, but with a visual offset to make hexes tessellate:
+
+```
+Pointy-top:      Flat-top:
+  0 1 2 3          0 1 2
+0 . . . .        0 . . .
+1  . . . .       1 . . .
+2 . . . .        2 . . .
+3  . . . .       3 . . .
+```
+
+Odd rows (pointy-top) or odd columns (flat-top) are shifted by half a hex width. This is handled automatically by `getWorldPos` — you don't need to think about it when placing content.
+
+**What this means for you:** Use `(col, row)` to address cells. The visual offset is a rendering concern, not a logical one.
+
+## Basic Operations
+
+```fsharp
+open Mibo.Layout
+open System.Numerics
+
+let grid = HexGrid.create 20 15 32f Vector2.Zero PointyTop
+
+// Place content
+HexGrid.set 5 3 myTile grid
+
+// Read content (returns voption — no heap allocation)
+match HexGrid.get 5 3 grid with
+| ValueSome tile -> // handle tile
+| ValueNone -> // empty cell
+
+// Remove content
+HexGrid.clear 5 3 grid
+
+// Get world position for rendering
+let worldPos = HexGrid.getWorldPos 5 3 grid  // Vector2
+```
+
+## Iteration
+
+### All Cells
+
+```fsharp
+// Process every populated cell
+grid |> HexGrid.iter (fun col row tile ->
+    let pos = HexGrid.getWorldPos col row grid
+    renderTile pos tile
+)
+```
+
+### Visible Only (Frustum Culling)
+
+For large maps, you only want to process cells on screen. `iterVisible` takes screen-space bounds and skips off-screen hexes:
+
+```fsharp
+// Screen bounds in world coordinates
+let screenLeft = cameraX - viewportWidth / 2f
+let screenTop = cameraY - viewportHeight / 2f
+let screenRight = cameraX + viewportWidth / 2f
+let screenBottom = cameraY + viewportHeight / 2f
+
+grid |> HexGrid.iterVisible screenLeft screenTop screenRight screenBottom
+    (fun col row tile ->
+        let pos = HexGrid.getWorldPos col row grid
+        renderTile pos tile
+    )
+```
+
+**Performance note:** For a 100×100 hex grid, `iterVisible` typically processes only 50-200 cells instead of 10,000. Always use it for gameplay rendering.
+
+## The DSL: Building Levels with Stamps
+
+The `HexLayout` module lets you build levels declaratively. Think of it as painting content onto the grid using composable functions.
+
+### Running the DSL
+
+```fsharp
+let grid =
+    HexGrid.create 30 20 32f Vector2.Zero PointyTop
+    |> HexLayout.run (fun section ->
+        section
+        |> HexLayout.fill 0 0 30 20 GrassTile
+        |> HexLayout.border 0 0 30 20 WaterTile
+        |> HexLayout.set 15 10 CastleTile
+    )
+```
+
+### Sections: Relative Positioning
+
+Sections let you work in local coordinates. A section at `(5, 3)` means "start from column 5, row 3 in the parent":
+
+```fsharp
+section
+|> HexLayout.section 5 3 (fun inner ->
+    // (0, 0) here = (5, 3) in parent
+    inner |> HexLayout.fill 0 0 4 3 ForestTile
+)
+|> HexLayout.section 12 8 (fun inner ->
+    // (0, 0) here = (12, 8) in parent
+    inner |> HexLayout.fill 0 0 3 3 MountainTile
+)
+```
+
+Sections are zero-copy — they don't allocate new grids. They're just windows into the same backing data.
+
+### Structural Helpers
+
+```fsharp
+// Shrink section by N on all sides (useful for borders)
+section |> HexLayout.padding 2 (fun inner ->
+    inner |> HexLayout.fill 0 0 8 6 GrassTile  // 8×6 inside a 12×10 section
+)
+
+// Explicit padding per side: left, top, right, bottom
+section |> HexLayout.paddingEx 1 2 1 2 (fun inner -> ...)
+
+// Center a fixed-size block within the section
+section |> HexLayout.center 4 4 (fun inner ->
+    inner |> HexLayout.set 2 2 ThroneTile  // Centered in parent
+)
+
+// Place stamps in a row with spacing
+section |> HexLayout.flowX 5 [
+    tower 3 5
+    tower 3 5
+    tower 3 5
+]
+
+// Place stamps in a column with spacing
+section |> HexLayout.flowY 4 [
+    platform 6
+    platform 6
+    platform 6
+]
+```
+
+## Primitives: Placing Content
+
+### Single Cells and Lines
+
+```fsharp
+// Single cell
+HexLayout.set col row content section
+
+// Horizontal line
+HexLayout.repeatX col row count content section
+
+// Vertical line
+HexLayout.repeatY col row count content section
+```
+
+### Filled Regions
+
+```fsharp
+// Fill a rectangle
+HexLayout.fill col row width height content section
+
+// Hollow rectangle (border only)
+HexLayout.border col row width height content section
+
+// Filled rectangle with different border
+HexLayout.rect col row width height borderContent fillContent section
+
+// Only the four corners
+HexLayout.corners col row width height content section
+
+// Clear a region
+HexLayout.clear col row width height section
+```
+
+### Conditional Placement
+
+```fsharp
+// Only set if cell is empty (won't overwrite existing content)
+HexLayout.setIfEmpty col row content section
+```
+
+## Geometry: Lines, Circles, Polygons
+
+These work in grid coordinates, not world space. They're useful for marking paths, areas of effect, or procedural shapes.
+
+```fsharp
+// Line between two hexes (Bresenham's algorithm)
+HexLayout.line 2 3 18 12 PathTile section
+
+// Circle (midpoint algorithm)
+HexLayout.circle 10 8 5 true AreaTile section   // Filled circle
+HexLayout.circle 10 8 5 false BorderTile section // Ring only
+
+// Arbitrary polygon (vertex list in grid coordinates)
+let vertices = [| struct(5, 2); struct(12, 2); struct(15, 8); struct(8, 10); struct(2, 6) |]
+HexLayout.polygon vertices true ZoneTile section   // Filled
+HexLayout.polygon vertices false EdgeTile section  // Outline only
+```
+
+**When to use geometry:**
+- **Lines** — Paths, roads, rivers, laser beams
+- **Circles** — Area-of-effect markers, tower ranges, blast radii
+- **Polygons** — Territory boundaries, influence zones, procedural regions
+
+## Patterns: Decorative and Procedural
+
+### Checkerboard
+
+```fsharp
+// Full checkerboard pattern
+HexLayout.checker LightGrass DarkGrass section
+
+// Checkerboard on border only
+HexLayout.checkerBorder col row width height LightStone DarkStone section
+```
+
+### Random Scatter
+
+```fsharp
+// Scatter N random tiles (same seed = same pattern every time)
+HexLayout.scatter 50 42 FlowerTile section
+
+// Scatter on border only
+HexLayout.scatterBorder col row width height 10 42 RockTile section
+
+// Scatter along a line
+HexLayout.scatterLine 2 3 18 12 8 42 TreeTile section
+
+// Scatter an entire stamp at random positions
+HexLayout.scatterStamp 5 42 (fun s ->
+    s |> HexLayout.fill 0 0 2 2 BushTile
+) section
+```
+
+**Seed usage:** Use the same seed for deterministic results (replay, testing). Use different seeds for variety. Combine multiple scatter calls with different seeds for layered randomness.
+
+### Procedural Generation
+
+```fsharp
+// Generate content from a function
+HexLayout.generate col row width height (fun c r ->
+    if (c + r) % 3 = 0 then DenseForest else SparseForest
+) section
+```
+
+### Find and Replace
+
+```fsharp
+// Replace all instances of one content type
+HexLayout.replace GrassTile SnowTile section
+
+// Probabilistic replace (30% chance per cell)
+HexLayout.replaceScatter GrassTile SnowTile 0.3f 42 section
+```
+
+### Iteration and Transformation
+
+```fsharp
+// Read existing content without modifying
+HexLayout.iter col row width height (fun c r tile ->
+    match tile with
+    | ValueSome t -> printfn "Found %A at (%d, %d)" t c r
+    | ValueNone -> ()
+) section
+
+// Transform existing content
+HexLayout.map col row width height (fun tile ->
+    match tile with
+    | Tree age -> Tree(age + 1)
+    | other -> other
+) section
+```
+
+## Building Stamps: Reusable Components
+
+A **stamp** is a function `HexGridSection<'T> -> HexGridSection<'T>`. Build your level design vocabulary by creating stamps for common patterns.
+
+### Simple Stamp
+
+```fsharp
+/// A small campfire clearing
+let campfire (section: HexGridSection<Tile>) =
+    section
+    |> HexLayout.fill 0 0 3 3 GrassTile
+    |> HexLayout.set 1 1 CampfireTile
+    |> HexLayout.set 0 1 LogTile
+    |> HexLayout.set 2 1 LogTile
+```
+
+### Parameterized Stamp
+
+```fsharp
+/// A configurable watchtower
+let watchtower height baseTile midTile topTile (section: HexGridSection<Tile>) =
+    section
+    |> HexLayout.set 1 0 baseTile
+    |> List.init (height - 2) (fun i -> i + 1)
+    |> List.fold (fun s i -> s |> HexLayout.set 1 i midTile) section
+    |> HexLayout.set 1 (height - 1) topTile
+```
+
+### Composing Stamps
+
+Stamps compose with `>>` (function composition):
+
+```fsharp
+let outpost =
+    watchtower 6 StoneBase StoneMid TorchTop
+    >> HexLayout.section 0 7 campfire
+    >> HexLayout.border -1 -1 4 8 FenceTile
+```
+
+### Domain Modules
+
+Organize stamps into namespaces for your game:
+
+```fsharp
+module Fantasy =
+    module Structures =
+        let house w h = ...
+        let tavern = house 8 6 >> interior ...
+        let castle w h = ...
+    
+    module Nature =
+        let forestCluster count = ...
+        let river width = ...
+        let mountain radius = ...
+    
+    module Combat =
+        let coverWall length = ...
+        let trench width depth = ...
+        let barricade = ...
+```
+
+## Adjacency and Pathfinding
+
+Hex grids shine when adjacency matters. Each hex has exactly 6 neighbors (vs 4 or 8 for rects). This makes pathfinding and movement ranges more natural.
+
+### Getting Neighbors
+
+```fsharp
+/// Get the 6 neighbor coordinates for a hex
+let neighbors col row =
+    // For pointy-top hexes
+    let isOddRow = row % 2 = 1
+    if isOddRow then
+        [| (col, row - 1); (col + 1, row - 1)
+           (col - 1, row); (col + 1, row)
+           (col, row + 1); (col + 1, row + 1) |]
+    else
+        [| (col - 1, row - 1); (col, row - 1)
+           (col - 1, row); (col + 1, row)
+           (col - 1, row + 1); (col, row + 1) |]
+
+/// Check if a hex is walkable
+let isWalkable col row (grid: HexGrid<Tile>) =
+    match HexGrid.get col row grid with
+    | ValueSome tile -> tile.IsWalkable
+    | ValueNone -> false
+
+/// Get walkable neighbors
+let walkableNeighbors col row grid =
+    neighbors col row
+    |> Array.filter (fun (c, r) -> isWalkable c r grid)
+```
+
+### Movement Range
+
+```fsharp
+/// Find all hexes within N movement steps
+let movementRange startCol startRow steps (grid: HexGrid<Tile>) =
+    let visited = HashSet<int * int>()
+    let current = Queue<int * int * int>()  // col, row, remaining steps
+    current.Enqueue(startCol, startRow, steps)
+    
+    while current.Count > 0 do
+        let col, row, remaining = current.Dequeue()
+        if remaining >= 0 && not (visited.Contains(col, row)) then
+            visited.Add(col, row)
+            for nc, nr in neighbors col row do
+                if isWalkable nc nr grid then
+                    current.Enqueue(nc, nr, remaining - 1)
+    
+    visited
+```
+
+## Layered Composition
+
+For games with multiple visual layers (terrain, objects, fog of war), use `LayeredHexGrid`:
+
+```fsharp
+let level =
+    LayeredHexGrid.create 20 15 32f Vector2.Zero PointyTop
+    |> LayeredHexLayout.layer 0 (fun section ->
+        // Layer 0: Base terrain
+        section
+        |> HexLayout.fill 0 0 20 15 GrassTile
+        |> HexLayout.scatter 30 42 ForestTile
+    )
+    |> LayeredHexLayout.layer 1 (fun section ->
+        // Layer 1: Structures and units
+        section
+        |> HexLayout.set 5 3 CastleTile
+        |> HexLayout.set 10 8 BarracksTile
+        |> HexLayout.set 15 12 FarmTile
+    )
+    |> LayeredHexLayout.layer 2 (fun section ->
+        // Layer 2: Fog of war (initially all hidden)
+        section
+        |> HexLayout.fill 0 0 20 15 FogTile
+    )
+```
+
+**Layer usage patterns:**
+- Layer 0: Terrain (grass, water, mountains)
+- Layer 1: Structures, resources, units
+- Layer 2: Overlays (fog, highlights, movement range)
+
+Layers are created on-demand — empty layers cost nothing.
+
+## Rendering
+
+Hex grids don't have a dedicated 2D renderer module because the iteration pattern is simple enough to use directly:
+
+```fsharp
+// Basic rendering
+grid |> HexGrid.iter (fun col row tile ->
+    let pos = HexGrid.getWorldPos col row grid
+    // Draw your sprite/tile at pos
+    buffer.Sprite(sprite {
+        texture (getTexture tile)
+        at pos.X pos.Y
+    })
+)
+
+// Performance rendering (only visible hexes)
+grid |> HexGrid.iterVisible screenLeft screenTop screenRight screenBottom
+    (fun col row tile ->
+        let pos = HexGrid.getWorldPos col row grid
+        buffer.Sprite(sprite {
+            texture (getTexture tile)
+            at pos.X pos.Y
+        })
+    )
+```
+
+## Complete Example: Strategy Map
+
+```fsharp
+type TerrainType =
+    | Grass | Forest | Mountain | Water | Sand | Road
+
+let strategyMap =
+    HexGrid.create 30 20 32f Vector2.Zero FlatTop
+    |> HexLayout.run (fun section ->
+        section
+        // Base terrain
+        |> HexLayout.fill 0 0 30 20 GrassTile
+        
+        // Mountain range (natural barrier)
+        |> HexLayout.section 10 5 (fun s ->
+            s |> HexLayout.fill 0 0 8 3 MountainTile
+              |> HexLayout.scatter 5 42 ForestTile
+        )
+        
+        // River (winding path)
+        |> HexLayout.line 0 10 29 15 WaterTile
+        
+        // Forest clusters
+        |> HexLayout.section 2 2 (fun s -> s |> HexLayout.scatter 15 101 ForestTile)
+        |> HexLayout.section 20 12 (fun s -> s |> HexLayout.scatter 20 202 ForestTile)
+        
+        // Roads connecting settlements
+        |> HexLayout.line 5 3 15 10 RoadTile
+        |> HexLayout.line 15 10 25 17 RoadTile
+        
+        // Settlements
+        |> HexLayout.section 5 3 (fun s ->
+            s |> HexLayout.fill 0 0 2 2 CastleTile
+              |> HexLayout.border -1 -1 4 4 WallTile
+        )
+        |> HexLayout.section 15 10 (fun s ->
+            s |> HexLayout.fill 0 0 3 2 TownTile
+        )
+        |> HexLayout.section 25 17 (fun s ->
+            s |> HexLayout.fill 0 0 2 2 VillageTile
+        )
+        
+        // Desert region
+        |> HexLayout.section 22 2 (fun s ->
+            s |> HexLayout.fill 0 0 6 4 SandTile
+              |> HexLayout.scatter 3 301 CactusTile
+        )
+    )
+```
+
+## Performance Considerations
+
+- **Flat array storage** — O(1) cell access, cache-friendly iteration
+- **Struct voption** — No heap allocation per cell
+- **Zero-copy sections** — Sections don't duplicate the grid
+- **Inline lambdas** — DSL functions compile away closures
+- **Use `iterVisible`** — Always cull for gameplay rendering
+- **Use `generate`** — For procedural content, it's faster than individual `set` calls
+
+## API Reference
+
+For complete function signatures, see the [API Reference](../../reference/index.html).

--- a/docs/level-design/2d/hex.md
+++ b/docs/level-design/2d/hex.md
@@ -419,6 +419,8 @@ let walkableNeighbors col row grid =
 ### Movement Range
 
 ```fsharp
+open System.Collections.Generic
+
 /// Find all hexes within N movement steps
 let movementRange startCol startRow steps (grid: HexGrid<Tile>) =
     let visited = HashSet<int * int>()

--- a/docs/level-design/3d/hex.md
+++ b/docs/level-design/3d/hex.md
@@ -47,6 +47,7 @@ Like 2D hex grids, 3D hex supports both orientations via `HexOrientation`:
 ```fsharp
 open Mibo.Layout3D
 open Mibo.Layout
+open System.Numerics
 
 // Strategy map with pointy-top hex columns
 let grid = HexGrid3D.create 20 10 15 32f 2f Vector3.Zero PointyTop
@@ -361,7 +362,7 @@ let house width height depth floor wall roof (section: HexGrid3DSection<Cell>) =
     section
     |> HexLayout3D.floorHex 0 0 0 width depth floor
     |> HexLayout3D.shell 0 0 0 width height depth wall
-    |> HexLayout3D.floorHex 0 (height - 1) 0 width depth roof
+    |> HexLayout3D.floorHex 0 0 (height - 1) width depth roof
     |> HexLayout3D.clear 1 0 1 (width - 2) (height - 1) (depth - 2)  // Interior
 ```
 
@@ -402,7 +403,7 @@ module StrategyGame =
 
 ```fsharp
 /// Create terrain from a height function
-let terrainFromHeightmap heightFn surfaceContent subsurfaceContent subsurfaceDepth =
+let terrainFromHeightmap maxHeight heightFn surfaceContent subsurfaceContent subsurfaceDepth =
     HexLayout3D.generateHexLayer 0 (fun col row ->
         let height = heightFn col row
         // Surface tile at the top
@@ -417,7 +418,7 @@ let terrainFromHeightmap heightFn surfaceContent subsurfaceContent subsurfaceDep
                     subsurfaceContent
                 else
                     surfaceContent
-            )
+            ) |> ignore
         section
 ```
 
@@ -427,8 +428,8 @@ let terrainFromHeightmap heightFn surfaceContent subsurfaceContent subsurfaceDep
 /// A raised plateau
 let plateau width depth height surface side (section: HexGrid3DSection<Cell>) =
     section
-    |> HexLayout3D.fill 0 0 0 width height depth sideCell     // Sides
-    |> HexLayout3D.floorHex 0 (height - 1) 0 width depth surfaceCell  // Top
+    |> HexLayout3D.fill 0 0 0 width height depth side      // Sides
+    |> HexLayout3D.floorHex 0 0 (height - 1) width depth surface  // Top
 
 /// A pit/crater
 let pit width depth drop (section: HexGrid3DSection<Cell>) =
@@ -443,7 +444,7 @@ let pit width depth drop (section: HexGrid3DSection<Cell>) =
 let rampX length width rise (section: HexGrid3DSection<Cell>) =
     for i in 0 .. length - 1 do
         let layerHeight = int (float rise * float i / float length)
-        section |> HexLayout3D.floorHex i layerHeight 0 1 width RampCell
+        section |> HexLayout3D.floorHex i 0 layerHeight 1 width RampCell
     section
 ```
 
@@ -602,7 +603,7 @@ let civMap =
         // Mountain range (barrier)
         |> HexLayout3D.section 15 0 10 (fun s ->
             s |> HexLayout3D.fill 0 0 0 8 5 3 MountainCell
-              |> HexLayout3D.floorHex 0 4 0 8 3 SnowCell
+              |> HexLayout3D.floorHex 0 0 4 8 3 SnowCell
         )
         
         // River (winding)
@@ -632,7 +633,7 @@ let civMap =
         // Cities
         |> HexLayout3D.section 5 0 5 (fun s ->
             s |> HexLayout3D.fill 0 0 0 2 2 2 CityCell
-              |> HexLayout3D.hexRing 0 0 0 3 WallCell  // Defensive wall
+              |> HexLayout3D.border 0 0 0 3 3 3 WallCell  // Defensive wall
         )
         |> HexLayout3D.section 20 0 15 (fun s ->
             s |> HexLayout3D.fill 0 0 0 3 2 3 CityCell

--- a/docs/level-design/3d/hex.md
+++ b/docs/level-design/3d/hex.md
@@ -1,0 +1,664 @@
+---
+title: Hex Grid Layout (3D)
+category: Level Design
+categoryindex: 2
+index: 28
+---
+
+# Hex Grid Layout (3D)
+
+3D hex grids extend hexagonal positioning with a vertical axis, creating hex columns instead of flat hexagons. This is the grid for **strategy games with elevation** — Civilization-style maps, wargames with height advantage, or any game where hex adjacency meets terrain height.
+
+## When to Use 3D Hex vs Rect
+
+| Use Case | Rect 3D | Hex 3D |
+|----------|---------|--------|
+| Voxel worlds (Minecraft-like) | ✅ Axis-aligned | ❌ Gaps between columns |
+| FPS dungeon crawlers | ✅ Box rooms | ❌ Awkward walls |
+| Strategy with elevation | ❌ No hex adjacency | ✅ Natural fit |
+| Wargames with terrain | ❌ Wrong feel | ✅ Authentic |
+| Board game ports | ❌ Doesn't match | ✅ Matches rules |
+| Civilization-style maps | ❌ Square tiles | ✅ Hex tiles |
+
+**The trade-off:** Hex 3D grids are hexagonal in XZ but rectangular in Y. Each "column" is a stack of hex cells. This gives you hex adjacency for ground movement while keeping vertical stacking simple.
+
+## Core Concepts
+
+The system is built on three primitives:
+
+- `HexGrid3D<'T>` — Storage for hex column data (hex grid + vertical layers)
+- `HexGrid3DSection<'T>` — A cursor/view into the grid for relative positioning
+- Stamps — Functions that transform sections (`HexGrid3DSection<'T> -> HexGrid3DSection<'T>`)
+
+## Orientation and Axes
+
+Like 2D hex grids, 3D hex supports both orientations via `HexOrientation`:
+
+| Orientation | XZ Shape | Best for |
+|---|---|---|
+| `PointyTop` | Pointed at top/bottom | Strategy maps, tactical RPGs |
+| `FlatTop` | Flat at top/bottom | Isometric-style games, board games |
+
+**Axis Convention:**
+- X = width (left/right)
+- Z = depth (forward/back) — this is the hex grid plane
+- Y = height / layers (up/down) — this is the vertical stacking axis
+
+```fsharp
+open Mibo.Layout3D
+open Mibo.Layout
+
+// Strategy map with pointy-top hex columns
+let grid = HexGrid3D.create 20 10 15 32f 2f Vector3.Zero PointyTop
+
+// Board game with flat-top hex columns
+let board = HexGrid3D.create 12 5 10 48f 1.5f Vector3.Zero FlatTop
+```
+
+**Parameters:**
+- `width` — Number of columns (X axis)
+- `height` — Number of vertical layers (Y axis)
+- `depth` — Number of rows (Z axis)
+- `hexSize` — Radius of hex (center to corner)
+- `layerHeight` — World-space height of each vertical layer
+- `origin` — World-space origin point
+- `orientation` — PointyTop or FlatTop
+
+## Basic Operations
+
+```fsharp
+open Mibo.Layout3D
+open Mibo.Layout
+
+let grid = HexGrid3D.create 20 10 15 32f 2f Vector3.Zero PointyTop
+
+// Place content at column 5, row 3, layer 2
+HexGrid3D.set 5 3 2 myCell grid
+
+// Read content (returns voption — no heap allocation)
+match HexGrid3D.get 5 3 2 grid with
+| ValueSome cell -> // handle cell
+| ValueNone -> // empty
+
+// Remove content
+HexGrid3D.clear 5 3 2 grid
+
+// Get world position for rendering
+let worldPos = HexGrid3D.getWorldPos 5 3 2 grid  // Vector3
+```
+
+## Iteration
+
+### All Cells
+
+```fsharp
+grid |> HexGrid3D.iter (fun col row layer cell ->
+    let pos = HexGrid3D.getWorldPos col row layer grid
+    spawnModel pos cell
+)
+```
+
+### Volume-Culled (Frustum Culling)
+
+For large worlds, only process cells within a bounding volume:
+
+```fsharp
+let bounds = {
+    Min = Vector3(cameraX - viewDist, cameraY - viewHeight, cameraZ - viewDist)
+    Max = Vector3(cameraX + viewDist, cameraY + viewHeight, cameraZ + viewDist)
+}
+
+grid |> HexGrid3D.iterVolume bounds (fun col row layer cell ->
+    let pos = HexGrid3D.getWorldPos col row layer grid
+    spawnModel pos cell
+)
+```
+
+**Performance note:** For a 50×20×50 hex grid (50,000 cells), `iterVolume` typically processes only 500-2000 cells. Always use it for gameplay rendering.
+
+## The DSL: Building Levels with Stamps
+
+The `HexLayout3D` module provides a fluent DSL for placing content. All functions return the section for pipeline composition.
+
+### Running the DSL
+
+```fsharp
+let grid =
+    HexGrid3D.create 30 10 20 32f 2f Vector3.Zero PointyTop
+    |> HexLayout3D.run (fun section ->
+        section
+        |> HexLayout3D.fill 0 0 0 30 10 20 AirCell
+        |> HexLayout3D.floorHex 0 0 0 30 20 GrassCell
+        |> HexLayout3D.shell 0 0 0 30 10 20 StoneCell
+    )
+```
+
+### Sections: Relative Positioning
+
+```fsharp
+section
+|> HexLayout3D.section 5 0 3 (fun inner ->
+    // (0, 0, 0) here = (5, 0, 3) in parent
+    inner |> HexLayout3D.fill 0 0 0 4 3 4 WoodCell
+)
+|> HexLayout3D.section 15 0 8 (fun inner ->
+    // (0, 0, 0) here = (15, 0, 8) in parent
+    inner |> HexLayout3D.fill 0 0 0 3 2 3 StoneCell
+)
+```
+
+### Structural Helpers
+
+```fsharp
+// Shrink by N on all sides
+section |> HexLayout3D.padding 2 (fun inner -> ...)
+
+// Explicit padding: left, bottom, back, right, top, front
+section |> HexLayout3D.paddingEx 1 1 1 1 1 1 (fun inner -> ...)
+
+// Center a block within the section
+section |> HexLayout3D.center 4 3 4 (fun inner -> ...)
+
+// Place stamps along axes with spacing
+section |> HexLayout3D.flowX 5 [tower; tower; tower]   // Horizontal row
+section |> HexLayout3D.flowY 3 [floor; floor; floor]   // Vertical stack
+section |> HexLayout3D.flowZ 4 [house; house; house]   // Depth row
+```
+
+## Primitives: Placing Content
+
+### Single Cells and Lines
+
+```fsharp
+// Single cell
+HexLayout3D.set col row layer content section
+
+// Lines along axes
+HexLayout3D.repeatX col row layer count content section  // Along X
+HexLayout3D.repeatY col row layer count content section  // Along Y (vertical)
+HexLayout3D.repeatZ col row layer count content section  // Along Z
+
+// Alias for vertical column
+HexLayout3D.column col row layer height content section
+```
+
+### Volumes
+
+```fsharp
+// Fill a box volume
+HexLayout3D.fill col row layer w h d content section
+
+// Clear a volume
+HexLayout3D.clear col row layer w h d section
+```
+
+### Planes (Single-Cell Thickness)
+
+```fsharp
+// Horizontal floor (XZ plane)
+HexLayout3D.floorHex col row layer width depth content section
+
+// Vertical wall (XY plane) — faces forward/back
+HexLayout3D.wallXY col row layer width height content section
+
+// Vertical wall (YZ plane) — faces left/right
+HexLayout3D.wallYZ col row layer height depth content section
+```
+
+### 3D Shapes
+
+```fsharp
+// Hollow box (6 faces)
+HexLayout3D.shell col row layer w h d content section
+
+// 12 edges only
+HexLayout3D.edges col row layer w h d content section
+
+// Sphere
+HexLayout3D.sphere cx cy cz radius true content section   // Filled
+HexLayout3D.sphere cx cy cz radius false content section  // Shell only
+
+// Cylinder (Y-aligned)
+HexLayout3D.cylinder cx cz layer radius height true content section   // Filled
+HexLayout3D.cylinder cx cz layer radius height false content section  // Shell only
+```
+
+### Combined Shapes
+
+```fsharp
+// Filled box with different border
+HexLayout3D.border col row layer w h d borderContent section
+
+// Filled box with border content
+HexLayout3D.rect col row layer w h d borderContent fillContent section
+
+// Only the 8 corners
+HexLayout3D.corners col row layer w h d content section
+```
+
+## Geometry: 3D Lines
+
+```fsharp
+// 3D line between two points
+HexLayout3D.line x1 y1 z1 x2 y2 z2 content section
+```
+
+**When to use:** Roads, tunnels, rivers, laser beams, flight paths — anything that connects two points in 3D space.
+
+## Patterns: Decorative and Procedural
+
+### Checkerboard Patterns
+
+```fsharp
+// Full 3D checkerboard
+HexLayout3D.checker3D odd even section
+
+// Single hex layer checkerboard
+HexLayout3D.checkerHexLayer layer odd even section
+
+// Planar checkers
+HexLayout3D.checkerXY row odd even section    // Vertical plane (XY)
+HexLayout3D.checkerYZ col odd even section    // Vertical plane (YZ)
+
+// Box skin checker
+HexLayout3D.checkerShell col row layer w h d odd even section
+```
+
+### Random Scatter
+
+```fsharp
+// Scatter in 3D volume
+HexLayout3D.scatter3D count seed content section
+
+// Scatter on single hex layer
+HexLayout3D.scatterHexLayer layer count seed content section
+
+// Scatter on vertical planes
+HexLayout3D.scatterXY row count seed content section
+HexLayout3D.scatterYZ col count seed content section
+
+// Scatter on box surface
+HexLayout3D.scatterShell col row layer w h d count seed content section
+
+// Scatter on edges
+HexLayout3D.scatterEdges col row layer w h d count seed content section
+
+// Scatter on border
+HexLayout3D.scatterBorder col row layer w h d count seed content section
+
+// Scatter an entire stamp at random positions
+HexLayout3D.scatterStamp count seed stamp section
+```
+
+**Seed usage:** Same seed = same pattern (deterministic). Different seeds for variety. Combine multiple scatter calls for layered randomness.
+
+### Procedural Generation
+
+```fsharp
+// Generate from 3D function
+HexLayout3D.generate col row layer w h d (fun c r l ->
+    if l < 3 then StoneCell else AirCell
+) section
+
+// Generate on single hex layer
+HexLayout3D.generateHexLayer layer (fun c r ->
+    if (c + r) % 2 = 0 then GrassTile else DirtTile
+) section
+
+// Generate on vertical planes
+HexLayout3D.generateXY row (fun c l -> ...) section
+HexLayout3D.generateYZ col (fun r l -> ...) section
+```
+
+### Find and Replace
+
+```fsharp
+// Replace all instances
+HexLayout3D.replace oldContent newContent section
+
+// Probabilistic replace
+HexLayout3D.replaceScatter oldContent newContent 0.3f seed section
+```
+
+### Iteration and Transformation
+
+```fsharp
+// Read existing content
+HexLayout3D.iter col row layer w h d (fun c r l cell ->
+    match cell with
+    | ValueSome c -> printfn "Found %A at (%d,%d,%d)" c c r l
+    | ValueNone -> ()
+) section
+
+// Transform existing content
+HexLayout3D.map col row layer w h d (fun cell ->
+    match cell with
+    | Block age -> Block(age + 1)
+    | other -> other
+) section
+
+// Conditional set (only if empty)
+HexLayout3D.setIfEmpty col row layer content section
+```
+
+## Building Stamps: Reusable Components
+
+### Simple Stamp
+
+```fsharp
+/// A hex column with grass on top and dirt below
+let grassColumn height (section: HexGrid3DSection<Cell>) =
+    section
+    |> HexLayout3D.column 0 0 0 (height - 1) DirtCell
+    |> HexLayout3D.set 0 (height - 1) 0 GrassCell
+```
+
+### Parameterized Stamp
+
+```fsharp
+/// A configurable house
+let house width height depth floor wall roof (section: HexGrid3DSection<Cell>) =
+    section
+    |> HexLayout3D.floorHex 0 0 0 width depth floor
+    |> HexLayout3D.shell 0 0 0 width height depth wall
+    |> HexLayout3D.floorHex 0 (height - 1) 0 width depth roof
+    |> HexLayout3D.clear 1 0 1 (width - 2) (height - 1) (depth - 2)  // Interior
+```
+
+### Composing Stamps
+
+```fsharp
+let village =
+    house 4 3 4 GrassFloor WoodWall ThatchRoof
+    >> HexLayout3D.section 6 0 0 (house 3 2 3 GrassFloor StoneWall TileRoof)
+    >> HexLayout3D.section 0 0 6 campfire
+    >> HexLayout3D.scatterHexLayer 0 8 42 FlowerCell
+```
+
+### Domain Modules
+
+```fsharp
+module StrategyGame =
+    module Terrain =
+        let mountain radius height = ...
+        let river width = ...
+        let forest density = ...
+    
+    module Structures =
+        let castle size = ...
+        let barracks = ...
+        let watchtower height = ...
+    
+    module Units =
+        let army unitType count = ...
+        let formation shape = ...
+```
+
+## Elevation: The Key Feature
+
+3D hex grids shine when elevation matters. The vertical axis lets you model terrain height, multi-level structures, and height-based gameplay.
+
+### Heightmap Terrain
+
+```fsharp
+/// Create terrain from a height function
+let terrainFromHeightmap heightFn surfaceContent subsurfaceContent subsurfaceDepth =
+    HexLayout3D.generateHexLayer 0 (fun col row ->
+        let height = heightFn col row
+        // Surface tile at the top
+        surfaceContent
+    )
+    >> fun section ->
+        // Fill subsurface layers
+        for layer in 0 .. maxHeight - 1 do
+            section |> HexLayout3D.generateHexLayer layer (fun col row ->
+                let surfaceHeight = heightFn col row
+                if layer < surfaceHeight - subsurfaceDepth then
+                    subsurfaceContent
+                else
+                    surfaceContent
+            )
+        section
+```
+
+### Plateaus and Depressions
+
+```fsharp
+/// A raised plateau
+let plateau width depth height surface side (section: HexGrid3DSection<Cell>) =
+    section
+    |> HexLayout3D.fill 0 0 0 width height depth sideCell     // Sides
+    |> HexLayout3D.floorHex 0 (height - 1) 0 width depth surfaceCell  // Top
+
+/// A pit/crater
+let pit width depth drop (section: HexGrid3DSection<Cell>) =
+    section
+    |> HexLayout3D.clear 0 0 0 width drop depth  // Remove cells
+```
+
+### Ramps and Slopes
+
+```fsharp
+/// A ramp going up along X
+let rampX length width rise (section: HexGrid3DSection<Cell>) =
+    for i in 0 .. length - 1 do
+        let layerHeight = int (float rise * float i / float length)
+        section |> HexLayout3D.floorHex i layerHeight 0 1 width RampCell
+    section
+```
+
+## Adjacency and Pathfinding
+
+Hex adjacency in 3D works in the XZ plane (6 neighbors at each layer), plus vertical connections (up/down).
+
+### Ground Movement (Same Layer)
+
+```fsharp
+/// Get 6 hex neighbors at the same layer
+let hexNeighbors col row =
+    let isOddRow = row % 2 = 1
+    if isOddRow then
+        [| (col, row - 1); (col + 1, row - 1)
+           (col - 1, row); (col + 1, row)
+           (col, row + 1); (col + 1, row + 1) |]
+    else
+        [| (col - 1, row - 1); (col, row - 1)
+           (col - 1, row); (col + 1, row)
+           (col - 1, row + 1); (col, row + 1) |]
+
+/// Get vertical neighbors (up/down)
+let verticalNeighbors col row layer =
+    [| (col, row, layer - 1); (col, row, layer + 1) |]
+```
+
+### Height-Based Movement Cost
+
+```fsharp
+/// Movement cost considering elevation
+let movementCost fromCol fromRow fromLayer toCol toRow toLayer grid =
+    let fromHeight = getTerrainHeight fromCol fromRow fromLayer grid
+    let toHeight = getTerrainHeight toCol toRow toLayer grid
+    let heightDiff = abs (toHeight - fromHeight)
+    
+    // Upward movement costs more
+    if heightDiff > 0 then
+        1 + heightDiff  // 2 for 1 height, 3 for 2 height, etc.
+    else
+        1  // Flat or downhill
+```
+
+## Layered Composition
+
+For complex maps with multiple data layers:
+
+```fsharp
+let level =
+    LayeredHexGrid3D.create 30 10 20 32f 2f Vector3.Zero PointyTop
+    |> LayeredHexLayout3D.layer 0 (fun section ->
+        // Layer 0: Terrain (ground, water, mountains)
+        section
+        |> HexLayout3D.floorHex 0 0 0 30 20 GrassCell
+        |> HexLayout3D.section 10 0 5 (terrain.mountain 6 8)
+        |> HexLayout3D.section 0 0 15 (terrain.river 3)
+    )
+    |> LayeredHexLayout3D.layer 1 (fun section ->
+        // Layer 1: Structures
+        section
+        |> HexLayout3D.section 5 0 3 (structures.castle 8)
+        |> HexLayout3D.section 20 0 10 (structures.barracks)
+    )
+    |> LayeredHexLayout3D.layer 2 (fun section ->
+        // Layer 2: Units
+        section
+        |> HexLayout3D.section 7 0 5 (units.army Infantry 10)
+        |> HexLayout3D.section 22 0 12 (units.army Cavalry 5)
+    )
+```
+
+## Rendering Integration
+
+### Basic Rendering
+
+```fsharp
+grid |> HexGrid3D.iter (fun col row layer cell ->
+    let pos = HexGrid3D.getWorldPos col row layer grid
+    spawnModel pos cell
+)
+```
+
+### Volume-Culled Rendering
+
+```fsharp
+let frustumBounds = {
+    Min = Vector3(minX, minY, minZ)
+    Max = Vector3(maxX, maxY, maxZ)
+}
+
+grid |> HexGrid3D.iterVolume frustumBounds (fun col row layer cell ->
+    let pos = HexGrid3D.getWorldPos col row layer grid
+    spawnModel pos cell
+)
+```
+
+### Using the Renderer Helper
+
+```fsharp
+open Mibo.Layout3D
+
+// Basic render
+HexGrid3DRenderer.render grid (fun worldPos cell ->
+    spawnModel worldPos cell
+)
+
+// Volume-culled render
+HexGrid3DRenderer.renderVolume frustumBounds grid (fun worldPos cell ->
+    spawnModel worldPos cell
+)
+
+// With indices (for debug or special logic)
+HexGrid3DRenderer.renderWithIndices grid (fun col row layer worldPos cell ->
+    spawnModel worldPos cell
+)
+```
+
+### GPU Instanced Rendering
+
+For large maps with many copies of the same mesh (trees, rocks, buildings):
+
+```fsharp
+// Create instanced context
+let instancedCtx = InstancedRenderContext(
+    getKey = fun cell -> cell.MeshKey,           // Group by mesh type
+    getMeshesAndMaterial = fun cell -> cell.Meshes,  // Get GPU resources
+    getTransform = fun worldPos cell ->            // Compute transform
+        Matrix4x4.CreateTranslation(worldPos)
+)
+
+// Render with instancing (one draw call per mesh type)
+HexGrid3DRenderer.renderInstanced instancedCtx grid renderBuffer
+
+// Volume-culled instancing
+HexGrid3DRenderer.renderVolumeInstanced instancedCtx frustumBounds grid renderBuffer
+```
+
+**When to use instancing:** If you have 100+ copies of the same mesh (trees, rocks, identical buildings), instancing reduces draw calls from 100+ to 1-2. For unique meshes, regular rendering is fine.
+
+## Complete Example: Civilization-Style Map
+
+```fsharp
+type Terrain =
+    | Grass | Plains | Desert | Tundra | Forest | Mountain | Water
+
+type Structure =
+    | City | Fort | Farm | Mine | Road
+
+let civMap =
+    HexGrid3D.create 40 8 30 32f 2f Vector3.Zero FlatTop
+    |> HexLayout3D.run (fun section ->
+        section
+        // Base terrain
+        |> HexLayout3D.floorHex 0 0 0 40 30 GrassCell
+        
+        // Mountain range (barrier)
+        |> HexLayout3D.section 15 0 10 (fun s ->
+            s |> HexLayout3D.fill 0 0 0 8 5 3 MountainCell
+              |> HexLayout3D.floorHex 0 4 0 8 3 SnowCell
+        )
+        
+        // River (winding)
+        |> HexLayout3D.line 0 0 5 39 0 25 WaterCell
+        
+        // Forests
+        |> HexLayout3D.section 2 0 2 (fun s ->
+            s |> HexLayout3D.scatterHexLayer 0 30 101 ForestCell
+        )
+        |> HexLayout3D.section 28 0 18 (fun s ->
+            s |> HexLayout3D.scatterHexLayer 0 25 202 ForestCell
+        )
+        
+        // Desert region
+        |> HexLayout3D.section 30 0 2 (fun s ->
+            s |> HexLayout3D.floorHex 0 0 0 8 6 DesertCell
+              |> HexLayout3D.scatterHexLayer 0 5 301 OasisCell
+        )
+        
+        // Tundra (north)
+        |> HexLayout3D.floorHex 0 0 0 40 3 TundraCell
+        
+        // Roads connecting cities
+        |> HexLayout3D.line 5 0 5 20 0 15 RoadCell
+        |> HexLayout3D.line 20 0 15 35 0 25 RoadCell
+        
+        // Cities
+        |> HexLayout3D.section 5 0 5 (fun s ->
+            s |> HexLayout3D.fill 0 0 0 2 2 2 CityCell
+              |> HexLayout3D.hexRing 0 0 0 3 WallCell  // Defensive wall
+        )
+        |> HexLayout3D.section 20 0 15 (fun s ->
+            s |> HexLayout3D.fill 0 0 0 3 2 3 CityCell
+        )
+        |> HexLayout3D.section 35 0 25 (fun s ->
+            s |> HexLayout3D.fill 0 0 0 2 2 2 CityCell
+        )
+        
+        // Farms near cities
+        |> HexLayout3D.scatterHexLayer 0 10 401 FarmCell
+        
+        // Resources
+        |> HexLayout3D.scatter3D 15 501 IronCell  // Scattered iron deposits
+    )
+```
+
+## Performance Considerations
+
+- **Flat array storage** — O(1) cell access, cache-friendly iteration
+- **Struct voption** — No heap allocation per cell
+- **Zero-copy sections** — Sections don't duplicate the grid
+- **Inline lambdas** — DSL functions compile away closures
+- **Use `iterVolume`** — Always cull for gameplay rendering
+- **Use `generate`** — For procedural content, faster than individual `set` calls
+- **Use instancing** — For rendering many identical meshes
+
+## API Reference
+
+For complete function signatures, see the [API Reference](../../reference/index.html).

--- a/docs/level-design/overview.md
+++ b/docs/level-design/overview.md
@@ -20,13 +20,14 @@ Mibo provides grid-based layout engines for designing game levels programmatical
 
 Mibo provides separate layout engines for 2D and 3D games:
 
-| Feature | 2D Layout | 3D Layout |
-|---------|-----------|-----------|
-| **Module** | `Mibo.Layout` | `Mibo.Layout3D` |
-| **Dimensions** | X, Y | X, Y, Z |
-| **Storage** | `CellGrid2D<'T>` | `CellGrid3D<'T>` |
-| **Cursor** | `GridSection2D<'T>` | `GridSection3D<'T>` |
-| **World Space** | `Vector2` | `Vector3` |
+| Feature | 2D Layout | 3D Layout | 2D Hex Layout | 3D Hex Layout |
+|---------|-----------|-----------|---------------|---------------|
+| **Module** | `Mibo.Layout` | `Mibo.Layout3D` | `Mibo.Layout` | `Mibo.Layout3D` |
+| **Dimensions** | X, Y | X, Y, Z | Col, Row | Col, Row, Layer |
+| **Storage** | `CellGrid2D<'T>` | `CellGrid3D<'T>` | `HexGrid<'T>` | `HexGrid3D<'T>` |
+| **Cursor** | `GridSection2D<'T>` | `GridSection3D<'T>` | `HexGridSection<'T>` | `HexGrid3DSection<'T>` |
+| **World Space** | `Vector2` | `Vector3` | `Vector2` | `Vector3` |
+| **Cell Shape** | Rectangle | Box | Hexagon | Hex Column |
 
 ## Common Patterns
 
@@ -169,11 +170,39 @@ Mibo includes pre-built stamps for common game types:
 
 - **[Platformer](2d/platformer.html)** - Boxes, platforms, ledges, walls, pillars, stairs, slopes, pits
 - **[TopDown](2d/topdown.html)** - Rooms, corridors, wall segments, doorways
+- **[Hex Grid](2d/hex.html)** - Hexagonal tile layouts for strategy and tactics games
 
 ### 3D Games
 
 - **[Interior](3d/interior.html)** - Rooms, corridors, doorways, stairs, shafts, pillars, windows
 - **[Terrain](3d/terrain.html)** - Ground, plateaus, pits, ramps, paths, heightmaps
+- **[Hex Grid](3d/hex.html)** - Hex column layouts for strategy games with elevation
+
+## Rendering Integration
+
+### 3D Grids
+
+Both `CellGrid3D` and `HexGrid3D` have dedicated renderer modules with matching API surfaces:
+
+- `CellGridRenderer3D` / `HexGrid3DRenderer` — Full rendering helpers
+- `render` — Basic iteration with world position conversion
+- `renderVolume` — Frustum-culled rendering
+- `renderWithIndices` — Access to grid coordinates during rendering
+- `renderInstanced` — GPU instancing for many copies of the same mesh
+- `renderVolumeInstanced` — GPU instancing with frustum culling
+
+See the [3D Layout Engine](3d/core.html) and [3D Hex Grid](3d/hex.html) docs for usage.
+
+### 2D Grids
+
+2D grids don't need dedicated renderer modules — use `iterVisible` directly:
+
+```fsharp
+grid |> CellGrid2D.iterVisible left top right bottom (fun x y tile ->
+    let pos = CellGrid2D.getWorldPos x y grid
+    // render at pos
+)
+```
 
 ## Choosing Between 2D and 3D
 
@@ -189,11 +218,19 @@ Use **3D Layout** for:
 - Outdoor exploration games
 - Voxel-based games
 
+Use **Hex Layout** (2D or 3D) for:
+- Strategy and tactics games
+- Wargames and board game adaptations
+- Games where 6-directional adjacency matters
+- Civilization-style games with elevation (3D hex)
+
 ## Getting Started
 
 - **[2D Layout Engine](2d/core.html)** - Core 2D concepts and DSL
 - **[Platformer Stamps](2d/platformer.html)** - 2D platformer examples
 - **[TopDown Stamps](2d/topdown.html)** - 2D top-down examples
+- **[Hex Grid Layout (2D)](2d/hex.html)** - Hexagonal 2D layouts with adjacency, pathfinding, and strategy game patterns
 - **[3D Layout Engine](3d/core.html)** - Core 3D concepts and DSL
 - **[Interior Stamps](3d/interior.html)** - 3D interior examples
 - **[Terrain Stamps](3d/terrain.html)** - 3D terrain examples
+- **[Hex Grid Layout (3D)](3d/hex.html)** - Hex column 3D layouts with elevation, instanced rendering, and strategy game patterns


### PR DESCRIPTION
## Summary

PRs #8 and #9 added the hex grid code but left the documentation gap. This PR fills that with comprehensive guides for both 2D and 3D hex grids.

## What's Added

### `docs/level-design/2d/hex.md`
- **When to use** — Decision table comparing hex vs rect grids for different game types
- **Orientation guide** — Pointy vs flat top with visual ASCII diagrams
- **Coordinate system** — Offset coordinates explained without requiring hex math knowledge
- **Adjacency & pathfinding** — Neighbor functions, movement range with BFS example
- **Complete API coverage** — All functions documented: geometry (line, circle, polygon), patterns (scatter, checker, generate), transforms (map, replace, iter)
- **Strategy map example** — Full working example with terrain, rivers, forests, roads, settlements

### `docs/level-design/3d/hex.md`
- **When to use** — Decision table comparing hex 3D vs rect 3D
- **Axis conventions** — Clear X/Y/Z explanation (XZ = hex plane, Y = vertical)
- **Elevation patterns** — Heightmap terrain, plateaus, pits, ramps
- **Instanced rendering** — Full `HexGrid3DRenderer` docs including GPU instancing with `InstancedRenderContext`
- **Adjacency & pathfinding** — Ground movement (6 neighbors) + vertical movement + height-based cost
- **Civilization-style example** — Complete example with terrain types, cities, roads, resources
- **Complete API coverage** — All functions including `flowX/Y/Z`, scatter/checker variants, planes, shapes

### `docs/level-design/overview.md`
- Added **Rendering Integration** section explaining 3D grid renderers and 2D `iterVisible` pattern

### `CHANGELOG.md`
- Added documentation entry to `[Unreleased]` section

## Why

The hex grid API surface matches the square grid API surface 1:1, but the docs were missing. Game devs need guidance on:
- When to choose hex over rect
- How offset coordinates work visually
- Adjacency patterns (the main reason to use hexes)
- Elevation patterns for 3D hex
- GPU instancing for large hex worlds
