### PR TITLE
feat: add key combos and resizable window support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@
 - `HexGrid3DRenderer` — Rendering functions for hex grids: `render`, `renderVolume`, `renderWithIndices`, `renderInstanced`, `renderVolumeInstanced`.
 - Non-uniform dimension tests for 2D, Hex2D, and 3D grids validating correct face/edge positions for shell, border, corners, scatterShell, and scatterBorder functions.
 - Hex grid documentation: comprehensive guides for 2D and 3D hex grids covering orientation, coordinates, adjacency, pathfinding, elevation patterns, instanced rendering, and complete game examples (strategy maps, Civilization-style maps).
+- `KeyCombo of Set<KeyboardKey>` trigger type for simultaneous key combinations in the input mapper.
+- `InputMap.keyCombo` helper for binding actions to key combos (e.g., `|> InputMap.keyCombo Save (Set [KeyboardKey.LeftControl; KeyboardKey.S])`).
+- `GameConfig` DSL functions: `withWidth`, `withHeight`, `withMinWidth`, `withMinHeight`, `withTitle`, `withTargetFPS`.
+- Resizable window support via `GameConfig.MinWidth` and `GameConfig.MinHeight` — when set, enables `ConfigFlags.ResizableWindow` and calls `Raylib.SetWindowMinSize`.
+- 4 unit tests for key combo functionality (combo starts, releases, partial hold, multiple combos per action).
+
+### Changed
+
+- **Breaking:** `GameConfig` struct has new fields (`MinWidth: int voption`, `MinHeight: int voption`). Users constructing `GameConfig` records directly must add these fields. Users using `GameConfig.defaultConfig` or the DSL functions are unaffected.
+- **Breaking:** `Trigger` discriminated union has new `KeyCombo of Set<KeyboardKey>` case. Users with exhaustive pattern matches on `Trigger` must handle the new case (or add a wildcard match).
+- `GameContext.WindowWidth` and `GameContext.WindowHeight` now update automatically when the window is resized (e.g., via OS resize or fullscreen toggle). Previously these were set once at creation and never changed.
 
 ## [1.1.0] - 2026-06-01
 

--- a/src/Mibo.Raylib.Tests/InputMapperTests.fs
+++ b/src/Mibo.Raylib.Tests/InputMapperTests.fs
@@ -8,6 +8,8 @@ type Action =
   | MoveUp
   | MoveDown
   | Jump
+  | Save
+  | DebugToggle
 
 [<Tests>]
 let tests =
@@ -98,4 +100,109 @@ let tests =
 
       Expect.isEmpty next.Started "Started should be cleared"
       Expect.isEmpty next.Released "Released should be cleared"
+
+    testCase "KeyCombo starts when all keys are held"
+    <| fun _ ->
+      let combo = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let map = emptyMap |> InputMap.keyCombo Save combo
+
+      let state = ActionState.empty
+      // Combo is down (all keys held)
+      let newState = ActionState.update map true (KeyCombo combo) state
+
+      Expect.contains newState.Started Save "Save should have started"
+      Expect.contains newState.Held Save "Save should be held"
+
+      Expect.equal
+        (Map.find Save newState.Values)
+        1.0f
+        "Save value should be 1.0"
+
+    testCase "KeyCombo releases when any key is released"
+    <| fun _ ->
+      let combo = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let map = emptyMap |> InputMap.keyCombo Save combo
+
+      let state = {
+        ActionState.empty with
+            Held = Set.singleton Save
+            HeldTriggers = Set.singleton(KeyCombo combo)
+      }
+
+      // Combo is no longer down (some key released)
+      let newState = ActionState.update map false (KeyCombo combo) state
+
+      Expect.isFalse (newState.Held.Contains Save) "Save should not be held"
+
+      Expect.contains newState.Released Save "Save should be in released set"
+
+    testCase "KeyCombo does not start when only some keys are held"
+    <| fun _ ->
+      let combo = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let map = emptyMap |> InputMap.keyCombo Save combo
+
+      let state = ActionState.empty
+      // Only Ctrl is down, not the full combo
+      let state2 =
+        ActionState.update map true (Key KeyboardKey.LeftControl) state
+
+      Expect.isFalse
+        (state2.Held.Contains Save)
+        "Save should not be held with only Ctrl"
+
+      // Now the full combo is down
+      let state3 = ActionState.update map true (KeyCombo combo) state2
+
+      Expect.contains state3.Held Save "Save should be held when combo complete"
+
+    testCase "KeyCombo works with multiple combos for same action"
+    <| fun _ ->
+      let combo1 = Set [ KeyboardKey.LeftControl; KeyboardKey.G ]
+      let combo2 = Set [ KeyboardKey.LeftControl; KeyboardKey.D ]
+
+      let map =
+        emptyMap
+        |> InputMap.keyCombo DebugToggle combo1
+        |> InputMap.keyCombo DebugToggle combo2
+
+      let state = ActionState.empty
+      // First combo down
+      let state2 = ActionState.update map true (KeyCombo combo1) state
+
+      Expect.contains
+        state2.Held
+        DebugToggle
+        "DebugToggle should be held by combo1"
+
+      // Second combo also down
+      let state3 = ActionState.update map true (KeyCombo combo2) state2
+
+      Expect.contains state3.Held DebugToggle "DebugToggle should still be held"
+
+      // First combo released
+      let state4 = ActionState.update map false (KeyCombo combo1) state3
+
+      Expect.contains
+        state4.Held
+        DebugToggle
+        "DebugToggle should still be held by combo2"
+
+      Expect.isFalse
+        (state4.Released.Contains DebugToggle)
+        "DebugToggle should NOT be released yet"
+
+      // Second combo released
+      let state5 = ActionState.update map false (KeyCombo combo2) state4
+
+      Expect.isFalse
+        (state5.Held.Contains DebugToggle)
+        "DebugToggle should finally be released"
+
+      Expect.contains
+        state5.Released
+        DebugToggle
+        "DebugToggle should be in released set"
   ]

--- a/src/Mibo.Raylib.Tests/InputMapperTests.fs
+++ b/src/Mibo.Raylib.Tests/InputMapperTests.fs
@@ -205,4 +205,262 @@ let tests =
         state5.Released
         DebugToggle
         "DebugToggle should be in released set"
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Integration tests for buildActions (subscription flow)
+    // ─────────────────────────────────────────────────────────────────────
+
+    testCase "buildActions: KeyCombo starts when all keys pressed individually"
+    <| fun _ ->
+      let combo = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let map = emptyMap |> InputMap.keyCombo Save combo
+
+      let mutable heldKeys = Set.empty
+
+      let isKeyDown k = heldKeys |> Set.contains k
+      let isMouseButtonDown _ = false
+      let isGamepadButtonDown _ _ = false
+
+      let getMap() = map
+
+      // Press Ctrl
+      heldKeys <- heldKeys |> Set.add KeyboardKey.LeftControl
+
+      let state1, comboStates1 =
+        InputMapper.buildActions
+          getMap
+          Map.empty
+          [| Key KeyboardKey.LeftControl |]
+          [||]
+          (Set.singleton KeyboardKey.LeftControl)
+          Set.empty
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.isFalse
+        (state1.Started.Contains Save)
+        "Save should NOT start with only Ctrl"
+
+      Expect.isFalse
+        (state1.Held.Contains Save)
+        "Save should NOT be held with only Ctrl"
+
+      // Press S (now both keys held)
+      heldKeys <- heldKeys |> Set.add KeyboardKey.S
+
+      let state2, _comboStates2 =
+        InputMapper.buildActions
+          getMap
+          comboStates1
+          [| Key KeyboardKey.S |]
+          [||]
+          (Set.singleton KeyboardKey.S)
+          Set.empty
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.contains state2.Started Save "Save should start when S pressed"
+
+      Expect.contains
+        state2.Held
+        Save
+        "Save should be held when both keys pressed"
+
+    testCase "buildActions: KeyCombo releases when any key released"
+    <| fun _ ->
+      let combo = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let map = emptyMap |> InputMap.keyCombo Save combo
+
+      let mutable heldKeys = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let isKeyDown k = heldKeys |> Set.contains k
+      let isMouseButtonDown _ = false
+      let isGamepadButtonDown _ _ = false
+
+      let getMap() = map
+
+      // Initial state: both keys held, combo active
+      let initialComboStates = Map.empty |> Map.add combo true
+
+      // Release S
+      heldKeys <- heldKeys |> Set.remove KeyboardKey.S
+
+      let state1, _comboStates1 =
+        InputMapper.buildActions
+          getMap
+          initialComboStates
+          [||]
+          [| Key KeyboardKey.S |]
+          Set.empty
+          (Set.singleton KeyboardKey.S)
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.isFalse
+        (state1.Held.Contains Save)
+        "Save should not be held after S released"
+
+      Expect.contains state1.Released Save "Save should be in released set"
+
+    testCase "buildActions: KeyCombo does not trigger from mouse events"
+    <| fun _ ->
+      let combo = Set [ KeyboardKey.LeftControl; KeyboardKey.S ]
+
+      let map =
+        emptyMap |> InputMap.keyCombo Save combo |> InputMap.mouse Jump 0
+
+      let isKeyDown _ = false
+      let mutable mouseDown = false
+      let isMouseButtonDown _ = mouseDown
+      let isGamepadButtonDown _ _ = false
+
+      let getMap() = map
+
+      // Mouse click
+      mouseDown <- true
+
+      let state1, _comboStates1 =
+        InputMapper.buildActions
+          getMap
+          Map.empty
+          [| MouseBut 0 |]
+          [||]
+          Set.empty
+          Set.empty
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.contains state1.Started Jump "Jump should start from mouse"
+
+      Expect.isFalse
+        (state1.Started.Contains Save)
+        "Save should NOT start from mouse"
+
+    testCase "buildActions: multiple combos with shared keys"
+    <| fun _ ->
+      let combo1 = Set [ KeyboardKey.LeftControl; KeyboardKey.G ]
+      let combo2 = Set [ KeyboardKey.LeftControl; KeyboardKey.D ]
+
+      let map =
+        emptyMap
+        |> InputMap.keyCombo DebugToggle combo1
+        |> InputMap.keyCombo DebugToggle combo2
+
+      let mutable heldKeys = Set.empty
+
+      let isKeyDown k = heldKeys |> Set.contains k
+      let isMouseButtonDown _ = false
+      let isGamepadButtonDown _ _ = false
+
+      let getMap() = map
+
+      // Press Ctrl
+      heldKeys <- heldKeys |> Set.add KeyboardKey.LeftControl
+
+      let state1, cs1 =
+        InputMapper.buildActions
+          getMap
+          Map.empty
+          [| Key KeyboardKey.LeftControl |]
+          [||]
+          (Set.singleton KeyboardKey.LeftControl)
+          Set.empty
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.isFalse
+        (state1.Held.Contains DebugToggle)
+        "DebugToggle should not be held with only Ctrl"
+
+      // Press G (combo1 complete)
+      heldKeys <- heldKeys |> Set.add KeyboardKey.G
+
+      let state2, cs2 =
+        InputMapper.buildActions
+          getMap
+          cs1
+          [| Key KeyboardKey.G |]
+          [||]
+          (Set.singleton KeyboardKey.G)
+          Set.empty
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.contains
+        state2.Started
+        DebugToggle
+        "DebugToggle should start from combo1"
+
+      // Press D (combo2 also complete)
+      heldKeys <- heldKeys |> Set.add KeyboardKey.D
+
+      let state3, cs3 =
+        InputMapper.buildActions
+          getMap
+          cs2
+          [| Key KeyboardKey.D |]
+          [||]
+          (Set.singleton KeyboardKey.D)
+          Set.empty
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.contains state3.Held DebugToggle "DebugToggle should still be held"
+
+      // Release G (combo1 broken, but combo2 still holds Ctrl+D)
+      heldKeys <- heldKeys |> Set.remove KeyboardKey.G
+
+      let state4, cs4 =
+        InputMapper.buildActions
+          getMap
+          cs3
+          [||]
+          [| Key KeyboardKey.G |]
+          Set.empty
+          (Set.singleton KeyboardKey.G)
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.contains
+        state4.Held
+        DebugToggle
+        "DebugToggle should still be held by combo2"
+
+      Expect.isFalse
+        (state4.Released.Contains DebugToggle)
+        "DebugToggle should NOT be released yet"
+
+      // Release D (combo2 also broken)
+      heldKeys <- heldKeys |> Set.remove KeyboardKey.D
+
+      let state5, _cs5 =
+        InputMapper.buildActions
+          getMap
+          cs4
+          [||]
+          [| Key KeyboardKey.D |]
+          Set.empty
+          (Set.singleton KeyboardKey.D)
+          isKeyDown
+          isMouseButtonDown
+          isGamepadButtonDown
+
+      Expect.isFalse
+        (state5.Held.Contains DebugToggle)
+        "DebugToggle should finally be released"
+
+      Expect.contains
+        state5.Released
+        DebugToggle
+        "DebugToggle should be in released set"
   ]

--- a/src/Mibo.Raylib.Tests/InputMapperTests.fs
+++ b/src/Mibo.Raylib.Tests/InputMapperTests.fs
@@ -233,8 +233,6 @@ let tests =
           Map.empty
           [| Key KeyboardKey.LeftControl |]
           [||]
-          (Set.singleton KeyboardKey.LeftControl)
-          Set.empty
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -256,8 +254,6 @@ let tests =
           comboStates1
           [| Key KeyboardKey.S |]
           [||]
-          (Set.singleton KeyboardKey.S)
-          Set.empty
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -295,8 +291,6 @@ let tests =
           initialComboStates
           [||]
           [| Key KeyboardKey.S |]
-          Set.empty
-          (Set.singleton KeyboardKey.S)
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -330,8 +324,6 @@ let tests =
           Map.empty
           [| MouseBut 0 |]
           [||]
-          Set.empty
-          Set.empty
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -369,8 +361,6 @@ let tests =
           Map.empty
           [| Key KeyboardKey.LeftControl |]
           [||]
-          (Set.singleton KeyboardKey.LeftControl)
-          Set.empty
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -388,8 +378,6 @@ let tests =
           cs1
           [| Key KeyboardKey.G |]
           [||]
-          (Set.singleton KeyboardKey.G)
-          Set.empty
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -408,8 +396,6 @@ let tests =
           cs2
           [| Key KeyboardKey.D |]
           [||]
-          (Set.singleton KeyboardKey.D)
-          Set.empty
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -425,8 +411,6 @@ let tests =
           cs3
           [||]
           [| Key KeyboardKey.G |]
-          Set.empty
-          (Set.singleton KeyboardKey.G)
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown
@@ -449,8 +433,6 @@ let tests =
           cs4
           [||]
           [| Key KeyboardKey.D |]
-          Set.empty
-          (Set.singleton KeyboardKey.D)
           isKeyDown
           isMouseButtonDown
           isGamepadButtonDown

--- a/src/Mibo.Raylib/Elmish.ProgramTypes.fs
+++ b/src/Mibo.Raylib/Elmish.ProgramTypes.fs
@@ -19,6 +19,10 @@ type GameConfig = {
   Title: string
   /// Target frames per second. 0 = unlimited.
   TargetFPS: int
+  /// Minimum window width in pixels. When set, enables resizable window.
+  MinWidth: int voption
+  /// Minimum window height in pixels. When set, enables resizable window.
+  MinHeight: int voption
 }
 
 module GameConfig =
@@ -27,7 +31,25 @@ module GameConfig =
     Height = 600
     Title = "Mibo Raylib"
     TargetFPS = 60
+    MinWidth = ValueNone
+    MinHeight = ValueNone
   }
+
+  let withWidth width config = { config with Width = width }
+  let withHeight height config = { config with Height = height }
+
+  let withMinWidth width config = {
+    config with
+        MinWidth = ValueSome width
+  }
+
+  let withMinHeight height config = {
+    config with
+        MinHeight = ValueSome height
+  }
+
+  let withTitle title config = { config with Title = title }
+  let withTargetFPS fps config = { config with TargetFPS = fps }
 
 /// <summary>
 /// The Elmish program record that defines the complete game architecture.

--- a/src/Mibo.Raylib/Elmish.Rendering.fs
+++ b/src/Mibo.Raylib/Elmish.Rendering.fs
@@ -14,14 +14,20 @@ open System.Collections.Generic
 /// </remarks>
 type GameContext internal (width: int, height: int) =
   let services = Dictionary<Type, obj>()
+  let mutable windowWidth = width
+  let mutable windowHeight = height
 
   member val internal Services = services
 
   /// <summary>Current window width in pixels.</summary>
-  member _.WindowWidth = width
+  member _.WindowWidth = windowWidth
 
   /// <summary>Current window height in pixels.</summary>
-  member _.WindowHeight = height
+  member _.WindowHeight = windowHeight
+
+  member internal ctx.UpdateDimensions(w: int, h: int) =
+    windowWidth <- w
+    windowHeight <- h
 
 /// Functions for accessing and managing services in the GameContext.
 module GameContext =

--- a/src/Mibo.Raylib/Elmish.Runtime.fs
+++ b/src/Mibo.Raylib/Elmish.Runtime.fs
@@ -117,6 +117,15 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
     if config.TargetFPS > 0 then
       Raylib.SetTargetFPS(config.TargetFPS)
 
+    match config.MinWidth, config.MinHeight with
+    | ValueSome w, ValueSome h -> Raylib.SetWindowMinSize(w, h)
+    | ValueSome w, ValueNone -> Raylib.SetWindowMinSize(w, config.Height)
+    | ValueNone, ValueSome h -> Raylib.SetWindowMinSize(config.Width, h)
+    | ValueNone, ValueNone -> ()
+
+    if config.MinWidth.IsSome || config.MinHeight.IsSome then
+      Raylib.SetWindowState(ConfigFlags.ResizableWindow)
+
     for f in program.Renderers do
       renderers.Add(f())
 
@@ -152,6 +161,10 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
 
       // Poll hardware input before processing messages
       inputServiceOpt |> ValueOption.iter(fun svc -> svc.Poll())
+
+      // Check for window resize and update context dimensions
+      if Raylib.IsWindowResized().AsBool() then
+        ctx.UpdateDimensions(Raylib.GetScreenWidth(), Raylib.GetScreenHeight())
 
       if deferredEffs.Count <> 0 then
         deferredEffsRun.Clear()

--- a/src/Mibo.Raylib/InputMapper.fs
+++ b/src/Mibo.Raylib/InputMapper.fs
@@ -157,43 +157,6 @@ type IInputMapper<'Action when 'Action: comparison> =
   abstract Update: unit -> unit
 
 // ─────────────────────────────────────────────────────────────────────────────
-// KeyCombo index for O(1) lookup when keys change
-// ─────────────────────────────────────────────────────────────────────────────
-
-[<Struct>]
-type internal KeyComboIndex = {
-  KeyToCombos: Map<KeyboardKey, Set<Set<KeyboardKey>>>
-}
-
-module internal KeyComboIndex =
-  let build(map: InputMap<'Action>) : KeyComboIndex =
-    let mutable index = Map.empty<KeyboardKey, Set<Set<KeyboardKey>>>
-
-    for kv in map.TriggerToActions do
-      match kv.Key with
-      | KeyCombo keys ->
-        for k in keys do
-          let existing = index |> Map.tryFind k |> Option.defaultValue Set.empty
-
-          index <- index |> Map.add k (existing |> Set.add keys)
-      | _ -> ()
-
-    { KeyToCombos = index }
-
-  let findAffectedCombos
-    (index: KeyComboIndex)
-    (keys: Set<KeyboardKey>)
-    : Set<Set<KeyboardKey>> =
-    let mutable combos = Set.empty
-
-    for k in keys do
-      match index.KeyToCombos |> Map.tryFind k with
-      | Some ks -> combos <- combos + ks
-      | None -> ()
-
-    combos
-
-// ─────────────────────────────────────────────────────────────────────────────
 // IInputMapper service (registered via Program.withInputMapper)
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -204,8 +167,6 @@ module InputMapper =
     (prevComboStates: Map<Set<KeyboardKey>, bool>)
     (pressed: Trigger[])
     (released: Trigger[])
-    (pressedKeys: Set<KeyboardKey>)
-    (releasedKeys: Set<KeyboardKey>)
     (isKeyDown: KeyboardKey -> bool)
     (isMouseButtonDown: int -> bool)
     (isGamepadButtonDown: int -> GamepadButton -> bool)
@@ -218,13 +179,11 @@ module InputMapper =
     let mutable values = Map.empty
     let mutable comboStates = prevComboStates
 
-    let index = KeyComboIndex.build map
-
     for kv in map.TriggerToActions do
       let isDown =
         match kv.Key with
         | Key k -> isKeyDown k
-        | KeyCombo keys -> keys |> Set.forall(fun k -> isKeyDown k)
+        | KeyCombo keys -> keys |> Set.forall isKeyDown
         | MouseBut b -> isMouseButtonDown b
         | GamepadBut(p, b) -> isGamepadButtonDown p b
 
@@ -235,55 +194,35 @@ module InputMapper =
           held <- held |> Set.add a
           values <- values |> Map.add a 1.0f
 
-    // Process pressed triggers (keys, mouse, gamepad)
+      match kv.Key with
+      | KeyCombo keys ->
+        let wasHeld =
+          comboStates |> Map.tryFind keys |> Option.defaultValue false
+
+        comboStates <- comboStates |> Map.add keys isDown
+
+        if isDown && not wasHeld then
+          for a in kv.Value do
+            started <- started |> Set.add a
+        elif not isDown && wasHeld then
+          for a in kv.Value do
+            releasedSet <- releasedSet |> Set.add a
+      | _ -> ()
+
     for t in pressed do
-      match t with
-      | KeyCombo _ -> () // handled via combo index below
-      | _ ->
-        map.TriggerToActions
-        |> Map.tryFind t
-        |> Option.iter(fun actions ->
-          for a in actions do
-            started <- started |> Set.add a)
+      map.TriggerToActions
+      |> Map.tryFind t
+      |> Option.iter(fun actions ->
+        for a in actions do
+          started <- started |> Set.add a)
 
-    // Process released triggers (keys, mouse, gamepad)
     for t in released do
-      match t with
-      | KeyCombo _ -> () // handled via combo index below
-      | _ ->
-        map.TriggerToActions
-        |> Map.tryFind t
-        |> Option.iter(fun actions ->
-          for a in actions do
-            releasedSet <- releasedSet |> Set.add a)
+      map.TriggerToActions
+      |> Map.tryFind t
+      |> Option.iter(fun actions ->
+        for a in actions do
+          releasedSet <- releasedSet |> Set.add a)
 
-    // Find combos affected by pressed/released keys
-    let affectedCombos =
-      KeyComboIndex.findAffectedCombos index (pressedKeys + releasedKeys)
-
-    for combo in affectedCombos do
-      let allHeld = combo |> Set.forall isKeyDown
-
-      let wasHeld =
-        comboStates |> Map.tryFind combo |> Option.defaultValue false
-
-      comboStates <- comboStates |> Map.add combo allHeld
-
-      if allHeld && not wasHeld then
-        map.TriggerToActions
-        |> Map.tryFind(KeyCombo combo)
-        |> Option.iter(fun actions ->
-          for a in actions do
-            started <- started |> Set.add a)
-
-      if not allHeld && wasHeld then
-        map.TriggerToActions
-        |> Map.tryFind(KeyCombo combo)
-        |> Option.iter(fun actions ->
-          for a in actions do
-            releasedSet <- releasedSet |> Set.add a)
-
-    // Only release actions that are actually no longer held by any trigger
     releasedSet <- releasedSet |> Set.filter(fun a -> not(held.Contains a))
 
     ({
@@ -306,20 +245,13 @@ module InputMapper =
       let input = Input.getService ctx
       let mutable prevComboStates = Map.empty<Set<KeyboardKey>, bool>
 
-      let doBuild
-        (pressed: Trigger[])
-        (released: Trigger[])
-        (pressedKeys: Set<KeyboardKey>)
-        (releasedKeys: Set<KeyboardKey>)
-        =
+      let doBuild (pressed: Trigger[]) (released: Trigger[]) =
         let state, newComboStates =
           buildActions
             getMap
             prevComboStates
             pressed
             released
-            pressedKeys
-            releasedKeys
             (fun k -> Raylib.IsKeyDown(k).AsBool())
             (fun b -> Raylib.IsMouseButtonDown(enum<MouseButton>(b)).AsBool())
             (fun p b -> Raylib.IsGamepadButtonDown(p, b).AsBool())
@@ -329,14 +261,9 @@ module InputMapper =
 
       let subKey: IDisposable =
         input.KeyboardDelta.Subscribe(fun (d: KeyboardDelta) ->
-          let pressedKeys = d.Pressed |> Set.ofArray
-          let releasedKeys = d.Released |> Set.ofArray
           let pressed = d.Pressed |> Array.map Key
           let released = d.Released |> Array.map Key
-
-          doBuild pressed released pressedKeys releasedKeys
-          |> toMsg
-          |> dispatch)
+          doBuild pressed released |> toMsg |> dispatch)
 
       let subMouse: IDisposable =
         input.MouseDelta.Subscribe(fun (d: MouseDelta) ->
@@ -346,7 +273,7 @@ module InputMapper =
           let released =
             d.Buttons.Released |> Array.map(fun b -> MouseBut(int b))
 
-          doBuild pressed released Set.empty Set.empty |> toMsg |> dispatch)
+          doBuild pressed released |> toMsg |> dispatch)
 
       let subGamepad: IDisposable =
         input.GamepadDelta.Subscribe(fun (d: GamepadDelta) ->
@@ -358,7 +285,7 @@ module InputMapper =
             d.Buttons.Released
             |> Array.map(fun b -> GamepadBut(d.PlayerIndex, b))
 
-          doBuild pressed released Set.empty Set.empty |> toMsg |> dispatch)
+          doBuild pressed released |> toMsg |> dispatch)
 
       { new IDisposable with
           member _.Dispose() =

--- a/src/Mibo.Raylib/InputMapper.fs
+++ b/src/Mibo.Raylib/InputMapper.fs
@@ -10,6 +10,7 @@ open Mibo.Elmish
 /// </summary>
 type Trigger =
   | Key of KeyboardKey
+  | KeyCombo of Set<KeyboardKey>
   | MouseBut of int
   | GamepadBut of player: int * button: GamepadButton
 
@@ -44,6 +45,13 @@ module InputMap =
 
   let key (action: 'Action) (k: KeyboardKey) (map: InputMap<'Action>) =
     bind action (Key k) map
+
+  let keyCombo
+    (action: 'Action)
+    (keys: Set<KeyboardKey>)
+    (map: InputMap<'Action>)
+    =
+    bind action (KeyCombo keys) map
 
   let mouse (action: 'Action) (btn: int) (map: InputMap<'Action>) =
     bind action (MouseBut btn) map
@@ -163,6 +171,7 @@ module InputMapper =
 
     let subscribeFn(dispatch: Dispatch<'Msg>) =
       let input = Input.getService ctx
+      let mutable prevComboStates = Map.empty<Set<KeyboardKey>, bool>
 
       let buildActions (pressed: Trigger[]) (released: Trigger[]) =
         let map = getMap()
@@ -176,6 +185,8 @@ module InputMapper =
           let isDown =
             match kv.Key with
             | Key k -> Raylib.IsKeyDown(k).AsBool()
+            | KeyCombo keys ->
+              keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
             | MouseBut b ->
               Raylib.IsMouseButtonDown(enum<MouseButton>(b)).AsBool()
             | GamepadBut(p, b) -> Raylib.IsGamepadButtonDown(p, b).AsBool()
@@ -188,18 +199,52 @@ module InputMapper =
               values <- values |> Map.add a 1.0f
 
         for t in pressed do
-          map.TriggerToActions
-          |> Map.tryFind t
-          |> Option.iter(fun actions ->
-            for a in actions do
-              started <- started |> Set.add a)
+          match t with
+          | KeyCombo keys ->
+            let allHeld =
+              keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
+
+            let wasHeld =
+              prevComboStates |> Map.tryFind keys |> Option.defaultValue false
+
+            prevComboStates <- prevComboStates |> Map.add keys allHeld
+
+            if allHeld && not wasHeld then
+              map.TriggerToActions
+              |> Map.tryFind t
+              |> Option.iter(fun actions ->
+                for a in actions do
+                  started <- started |> Set.add a)
+          | _ ->
+            map.TriggerToActions
+            |> Map.tryFind t
+            |> Option.iter(fun actions ->
+              for a in actions do
+                started <- started |> Set.add a)
 
         for t in released do
-          map.TriggerToActions
-          |> Map.tryFind t
-          |> Option.iter(fun actions ->
-            for a in actions do
-              releasedSet <- releasedSet |> Set.add a)
+          match t with
+          | KeyCombo keys ->
+            let allHeld =
+              keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
+
+            let wasHeld =
+              prevComboStates |> Map.tryFind keys |> Option.defaultValue false
+
+            prevComboStates <- prevComboStates |> Map.add keys allHeld
+
+            if not allHeld && wasHeld then
+              map.TriggerToActions
+              |> Map.tryFind t
+              |> Option.iter(fun actions ->
+                for a in actions do
+                  releasedSet <- releasedSet |> Set.add a)
+          | _ ->
+            map.TriggerToActions
+            |> Map.tryFind t
+            |> Option.iter(fun actions ->
+              for a in actions do
+                releasedSet <- releasedSet |> Set.add a)
 
         for a in releasedSet do
           held <- held |> Set.remove a
@@ -272,6 +317,7 @@ module InputMapper =
     : IInputMapper<'Action> =
     let mutable map = initialMap
     let mutable state = ActionState.empty
+    let mutable prevComboStates = Map.empty<Set<KeyboardKey>, bool>
 
     { new IInputMapper<'Action> with
         member _.CurrentState = state
@@ -290,6 +336,17 @@ module InputMapper =
                 Raylib.IsKeyPressed(k).AsBool(),
                 Raylib.IsKeyReleased(k).AsBool(),
                 Raylib.IsKeyDown(k).AsBool()
+              | KeyCombo keys ->
+                let allHeld =
+                  keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
+
+                let wasHeld =
+                  prevComboStates
+                  |> Map.tryFind keys
+                  |> Option.defaultValue false
+
+                prevComboStates <- prevComboStates |> Map.add keys allHeld
+                (allHeld && not wasHeld), (not allHeld && wasHeld), allHeld
               | MouseBut b ->
                 let btn = enum<MouseButton>(b)
 

--- a/src/Mibo.Raylib/InputMapper.fs
+++ b/src/Mibo.Raylib/InputMapper.fs
@@ -157,10 +157,143 @@ type IInputMapper<'Action when 'Action: comparison> =
   abstract Update: unit -> unit
 
 // ─────────────────────────────────────────────────────────────────────────────
+// KeyCombo index for O(1) lookup when keys change
+// ─────────────────────────────────────────────────────────────────────────────
+
+[<Struct>]
+type internal KeyComboIndex = {
+  KeyToCombos: Map<KeyboardKey, Set<Set<KeyboardKey>>>
+}
+
+module internal KeyComboIndex =
+  let build(map: InputMap<'Action>) : KeyComboIndex =
+    let mutable index = Map.empty<KeyboardKey, Set<Set<KeyboardKey>>>
+
+    for kv in map.TriggerToActions do
+      match kv.Key with
+      | KeyCombo keys ->
+        for k in keys do
+          let existing = index |> Map.tryFind k |> Option.defaultValue Set.empty
+
+          index <- index |> Map.add k (existing |> Set.add keys)
+      | _ -> ()
+
+    { KeyToCombos = index }
+
+  let findAffectedCombos
+    (index: KeyComboIndex)
+    (keys: Set<KeyboardKey>)
+    : Set<Set<KeyboardKey>> =
+    let mutable combos = Set.empty
+
+    for k in keys do
+      match index.KeyToCombos |> Map.tryFind k with
+      | Some ks -> combos <- combos + ks
+      | None -> ()
+
+    combos
+
+// ─────────────────────────────────────────────────────────────────────────────
 // IInputMapper service (registered via Program.withInputMapper)
 // ─────────────────────────────────────────────────────────────────────────────
 
 module InputMapper =
+
+  let internal buildActions
+    (getMap: unit -> InputMap<'Action>)
+    (prevComboStates: Map<Set<KeyboardKey>, bool>)
+    (pressed: Trigger[])
+    (released: Trigger[])
+    (pressedKeys: Set<KeyboardKey>)
+    (releasedKeys: Set<KeyboardKey>)
+    (isKeyDown: KeyboardKey -> bool)
+    (isMouseButtonDown: int -> bool)
+    (isGamepadButtonDown: int -> GamepadButton -> bool)
+    : ActionState<'Action> * Map<Set<KeyboardKey>, bool> =
+    let map = getMap()
+    let mutable started = Set.empty
+    let mutable releasedSet = Set.empty
+    let mutable held = Set.empty
+    let mutable heldTriggers = Set.empty
+    let mutable values = Map.empty
+    let mutable comboStates = prevComboStates
+
+    let index = KeyComboIndex.build map
+
+    for kv in map.TriggerToActions do
+      let isDown =
+        match kv.Key with
+        | Key k -> isKeyDown k
+        | KeyCombo keys -> keys |> Set.forall(fun k -> isKeyDown k)
+        | MouseBut b -> isMouseButtonDown b
+        | GamepadBut(p, b) -> isGamepadButtonDown p b
+
+      if isDown then
+        heldTriggers <- heldTriggers |> Set.add kv.Key
+
+        for a in kv.Value do
+          held <- held |> Set.add a
+          values <- values |> Map.add a 1.0f
+
+    // Process pressed triggers (keys, mouse, gamepad)
+    for t in pressed do
+      match t with
+      | KeyCombo _ -> () // handled via combo index below
+      | _ ->
+        map.TriggerToActions
+        |> Map.tryFind t
+        |> Option.iter(fun actions ->
+          for a in actions do
+            started <- started |> Set.add a)
+
+    // Process released triggers (keys, mouse, gamepad)
+    for t in released do
+      match t with
+      | KeyCombo _ -> () // handled via combo index below
+      | _ ->
+        map.TriggerToActions
+        |> Map.tryFind t
+        |> Option.iter(fun actions ->
+          for a in actions do
+            releasedSet <- releasedSet |> Set.add a)
+
+    // Find combos affected by pressed/released keys
+    let affectedCombos =
+      KeyComboIndex.findAffectedCombos index (pressedKeys + releasedKeys)
+
+    for combo in affectedCombos do
+      let allHeld = combo |> Set.forall isKeyDown
+
+      let wasHeld =
+        comboStates |> Map.tryFind combo |> Option.defaultValue false
+
+      comboStates <- comboStates |> Map.add combo allHeld
+
+      if allHeld && not wasHeld then
+        map.TriggerToActions
+        |> Map.tryFind(KeyCombo combo)
+        |> Option.iter(fun actions ->
+          for a in actions do
+            started <- started |> Set.add a)
+
+      if not allHeld && wasHeld then
+        map.TriggerToActions
+        |> Map.tryFind(KeyCombo combo)
+        |> Option.iter(fun actions ->
+          for a in actions do
+            releasedSet <- releasedSet |> Set.add a)
+
+    // Only release actions that are actually no longer held by any trigger
+    releasedSet <- releasedSet |> Set.filter(fun a -> not(held.Contains a))
+
+    ({
+      Held = held
+      Started = started
+      Released = releasedSet
+      Values = values
+      HeldTriggers = heldTriggers
+     },
+     comboStates)
 
   let subscribe
     (getMap: unit -> InputMap<'Action>)
@@ -173,116 +306,59 @@ module InputMapper =
       let input = Input.getService ctx
       let mutable prevComboStates = Map.empty<Set<KeyboardKey>, bool>
 
-      let buildActions (pressed: Trigger[]) (released: Trigger[]) =
-        let map = getMap()
-        let mutable started = Set.empty
-        let mutable releasedSet = Set.empty
-        let mutable held = Set.empty
-        let mutable heldTriggers = Set.empty
-        let mutable values = Map.empty
+      let doBuild
+        (pressed: Trigger[])
+        (released: Trigger[])
+        (pressedKeys: Set<KeyboardKey>)
+        (releasedKeys: Set<KeyboardKey>)
+        =
+        let state, newComboStates =
+          buildActions
+            getMap
+            prevComboStates
+            pressed
+            released
+            pressedKeys
+            releasedKeys
+            (fun k -> Raylib.IsKeyDown(k).AsBool())
+            (fun b -> Raylib.IsMouseButtonDown(enum<MouseButton>(b)).AsBool())
+            (fun p b -> Raylib.IsGamepadButtonDown(p, b).AsBool())
 
-        for kv in map.TriggerToActions do
-          let isDown =
-            match kv.Key with
-            | Key k -> Raylib.IsKeyDown(k).AsBool()
-            | KeyCombo keys ->
-              keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
-            | MouseBut b ->
-              Raylib.IsMouseButtonDown(enum<MouseButton>(b)).AsBool()
-            | GamepadBut(p, b) -> Raylib.IsGamepadButtonDown(p, b).AsBool()
-
-          if isDown then
-            heldTriggers <- heldTriggers |> Set.add kv.Key
-
-            for a in kv.Value do
-              held <- held |> Set.add a
-              values <- values |> Map.add a 1.0f
-
-        for t in pressed do
-          match t with
-          | KeyCombo keys ->
-            let allHeld =
-              keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
-
-            let wasHeld =
-              prevComboStates |> Map.tryFind keys |> Option.defaultValue false
-
-            prevComboStates <- prevComboStates |> Map.add keys allHeld
-
-            if allHeld && not wasHeld then
-              map.TriggerToActions
-              |> Map.tryFind t
-              |> Option.iter(fun actions ->
-                for a in actions do
-                  started <- started |> Set.add a)
-          | _ ->
-            map.TriggerToActions
-            |> Map.tryFind t
-            |> Option.iter(fun actions ->
-              for a in actions do
-                started <- started |> Set.add a)
-
-        for t in released do
-          match t with
-          | KeyCombo keys ->
-            let allHeld =
-              keys |> Set.forall(fun k -> Raylib.IsKeyDown(k).AsBool())
-
-            let wasHeld =
-              prevComboStates |> Map.tryFind keys |> Option.defaultValue false
-
-            prevComboStates <- prevComboStates |> Map.add keys allHeld
-
-            if not allHeld && wasHeld then
-              map.TriggerToActions
-              |> Map.tryFind t
-              |> Option.iter(fun actions ->
-                for a in actions do
-                  releasedSet <- releasedSet |> Set.add a)
-          | _ ->
-            map.TriggerToActions
-            |> Map.tryFind t
-            |> Option.iter(fun actions ->
-              for a in actions do
-                releasedSet <- releasedSet |> Set.add a)
-
-        for a in releasedSet do
-          held <- held |> Set.remove a
-          values <- values |> Map.remove a
-
-        {
-          Held = held
-          Started = started
-          Released = releasedSet
-          Values = values
-          HeldTriggers = heldTriggers
-        }
+        prevComboStates <- newComboStates
+        state
 
       let subKey: IDisposable =
         input.KeyboardDelta.Subscribe(fun (d: KeyboardDelta) ->
-          buildActions
-            (d.Pressed |> Array.map Key)
-            (d.Released |> Array.map Key)
+          let pressedKeys = d.Pressed |> Set.ofArray
+          let releasedKeys = d.Released |> Set.ofArray
+          let pressed = d.Pressed |> Array.map Key
+          let released = d.Released |> Array.map Key
+
+          doBuild pressed released pressedKeys releasedKeys
           |> toMsg
           |> dispatch)
 
       let subMouse: IDisposable =
         input.MouseDelta.Subscribe(fun (d: MouseDelta) ->
-          buildActions
-            (d.Buttons.Pressed |> Array.map(fun b -> MouseBut(int b)))
-            (d.Buttons.Released |> Array.map(fun b -> MouseBut(int b)))
-          |> toMsg
-          |> dispatch)
+          let pressed =
+            d.Buttons.Pressed |> Array.map(fun b -> MouseBut(int b))
+
+          let released =
+            d.Buttons.Released |> Array.map(fun b -> MouseBut(int b))
+
+          doBuild pressed released Set.empty Set.empty |> toMsg |> dispatch)
 
       let subGamepad: IDisposable =
         input.GamepadDelta.Subscribe(fun (d: GamepadDelta) ->
-          buildActions
-            (d.Buttons.Pressed
-             |> Array.map(fun b -> GamepadBut(d.PlayerIndex, b)))
-            (d.Buttons.Released
-             |> Array.map(fun b -> GamepadBut(d.PlayerIndex, b)))
-          |> toMsg
-          |> dispatch)
+          let pressed =
+            d.Buttons.Pressed
+            |> Array.map(fun b -> GamepadBut(d.PlayerIndex, b))
+
+          let released =
+            d.Buttons.Released
+            |> Array.map(fun b -> GamepadBut(d.PlayerIndex, b))
+
+          doBuild pressed released Set.empty Set.empty |> toMsg |> dispatch)
 
       { new IDisposable with
           member _.Dispose() =


### PR DESCRIPTION
## Summary

Adds key combo support to the input mapper and resizable window support to the game configuration.

Closes #12
Closes #13

## Changes

### Key Combos (Issue #12)

- Added `KeyCombo of Set<KeyboardKey>` trigger type for simultaneous key combinations
- Added `InputMap.keyCombo` helper for binding actions to key combos
- Updated `InputMapper.subscribe` and `InputMapper.createService` with combo state tracking
- Added 4 unit tests for key combo functionality

**Usage:**
```fsharp
// Single key
|> InputMap.key Jump KeyboardKey.Space

// Key combo (all keys held simultaneously)
|> InputMap.keyCombo SaveFile (Set [KeyboardKey.LeftControl; KeyboardKey.S])

// Multiple combos for same action (OR logic)
|> InputMap.keyCombo ToggleDebug (Set [KeyboardKey.LeftControl; KeyboardKey.G])
|> InputMap.keyCombo ToggleDebug (Set [KeyboardKey.LeftControl; KeyboardKey.D])
```

### Resizable Windows (Issue #13)

- Added `MinWidth: int voption` and `MinHeight: int voption` to `GameConfig`
- Added `GameConfig` DSL functions: `withWidth`, `withHeight`, `withMinWidth`, `withMinHeight`, `withTitle`, `withTargetFPS`
- When min dimensions are set, enables `ConfigFlags.ResizableWindow` and calls `SetWindowMinSize`
- `GameContext.WindowWidth`/`WindowHeight` now update automatically on window resize

**Usage:**
```fsharp
GameConfig.defaultConfig
|> GameConfig.withWidth 1920
|> GameConfig.withHeight 1080
|> GameConfig.withMinWidth 800
|> GameConfig.withMinHeight 600
```

## Breaking Changes

- **`GameConfig` struct** has new fields (`MinWidth`, `MinHeight`). Users constructing `GameConfig` records directly must add these fields. Users using `GameConfig.defaultConfig` or the DSL functions are unaffected.
- **`Trigger` DU** has new `KeyCombo` case. Users with exhaustive pattern matches on `Trigger` must handle the new case or add a wildcard match.

## Testing

- All 831 tests pass (including 4 new key combo tests)
- Code formatted with `dotnet fantomas .`
