### PR TITLE
feat: disable default ESC exit key and add Cmd.signalExit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,12 @@
 - `GameConfig` DSL functions: `withWidth`, `withHeight`, `withMinWidth`, `withMinHeight`, `withTitle`, `withTargetFPS`.
 - Resizable window support via `GameConfig.MinWidth` and `GameConfig.MinHeight` — when set, enables `ConfigFlags.ResizableWindow` and calls `Raylib.SetWindowMinSize`.
 - 4 unit tests for key combo functionality (combo starts, releases, partial hold, multiple combos per action).
+- `Cmd.signalExit` for programmatic window exit from `update` functions. Signals the runtime to exit after the current frame completes. Window close via X button or Alt+F4 continues to work independently.
 
 ### Changed
 
+- **Breaking:** Default exit key disabled (`SetExitKey(KeyboardKey.Null)`). The ESC key no longer closes the window. Games must handle window close via the OS close button (X) or Alt+F4. To re-enable a custom exit key, call `Raylib.SetExitKey(key)` in your init or use a subscription to dispatch a quit message.
+- **Breaking:** `Cmd<'Msg>` discriminated union has new `Quit` case. Users with exhaustive pattern matches on `Cmd<'Msg>` must handle the new case (or add a wildcard match).
 - **Breaking:** `GameConfig` struct has new fields (`MinWidth: int voption`, `MinHeight: int voption`). Users constructing `GameConfig` records directly must add these fields. Users using `GameConfig.defaultConfig` or the DSL functions are unaffected.
 - **Breaking:** `Trigger` discriminated union has new `KeyCombo of Set<KeyboardKey>` case. Users with exhaustive pattern matches on `Trigger` must handle the new case (or add a wildcard match).
 - `GameContext.WindowWidth` and `GameContext.WindowHeight` now update automatically when the window is resized (e.g., via OS resize or fullscreen toggle). Previously these were set once at creation and never changed.

--- a/src/Mibo.Raylib.Tests/ElmishTests.fs
+++ b/src/Mibo.Raylib.Tests/ElmishTests.fs
@@ -54,6 +54,32 @@ let tests =
           e.Invoke(fun x -> result <- x)
           Expect.equal result 11 "Mapped effect should increment and add 10"
         | _ -> Tests.failtest "Expected a Single command"
+
+      testCase "Cmd.signalExit returns Quit"
+      <| fun _ ->
+        let cmd = Cmd.signalExit
+
+        match cmd with
+        | Quit -> ()
+        | _ -> Tests.failtest "Expected Quit command"
+
+      testCase "Cmd.map preserves Quit"
+      <| fun _ ->
+        let cmd = Cmd.signalExit
+        let mapped = Cmd.map (fun x -> x + 1) cmd
+
+        match mapped with
+        | Quit -> ()
+        | _ -> Tests.failtest "Expected Quit after map"
+
+      testCase "Cmd.batch with signalExit returns Quit"
+      <| fun _ ->
+        let eff = Effect(fun dispatch -> dispatch 1)
+        let batched = Cmd.batch [ Cmd.ofEffect eff; Cmd.signalExit ]
+
+        match batched with
+        | Quit -> ()
+        | _ -> Tests.failtest "Expected Quit (Quit takes precedence in batch)"
     ]
 
     testList "Sub" [

--- a/src/Mibo.Raylib/Elmish.Commands.fs
+++ b/src/Mibo.Raylib/Elmish.Commands.fs
@@ -39,6 +39,8 @@ type Cmd<'Msg> =
   | DeferNextFrame of batch: Effect<'Msg>[]
   /// Combination of immediate and deferred effects
   | NowAndDeferNextFrame of now: Effect<'Msg>[] * next: Effect<'Msg>[]
+  /// Signals the runtime to exit after this frame
+  | Quit
 
 /// <summary>
 /// Functions for creating and composing Elmish commands.
@@ -50,6 +52,9 @@ type Cmd<'Msg> =
 module Cmd =
   /// <summary>An empty command that does nothing. Use when no side effects are needed.</summary>
   let none: Cmd<'Msg> = Empty
+
+  /// <summary>Signals the runtime to exit after the current frame completes.</summary>
+  let signalExit: Cmd<'Msg> = Quit
 
   /// <summary>Wraps a raw effect delegate into a command.</summary>
   let inline ofEffect(eff: Effect<'Msg>) = Single eff
@@ -82,6 +87,7 @@ module Cmd =
       Array.Copy(now, 0, combined, 0, now.Length)
       Array.Copy(next, 0, combined, now.Length, next.Length)
       DeferNextFrame combined
+    | Quit -> Quit
 
   let inline private split
     (cmd: Cmd<'Msg>)
@@ -92,6 +98,7 @@ module Cmd =
     | Batch effs -> struct (effs, [||])
     | DeferNextFrame effs -> struct ([||], effs)
     | NowAndDeferNextFrame(now, next) -> struct (now, next)
+    | Quit -> struct ([||], [||])
 
   /// <summary>
   /// Map a command producing messages of type 'A into a command producing messages of type 'Msg.
@@ -148,6 +155,7 @@ module Cmd =
         mapped
 
       NowAndDeferNextFrame(mapBatch now, mapBatch next)
+    | Quit -> Quit
 
   /// <summary>
   /// Combines multiple commands into a single command.
@@ -158,15 +166,21 @@ module Cmd =
   /// from a single update branch.
   /// </remarks>
   let batch(cmds: seq<Cmd<'Msg>>) : Cmd<'Msg> =
+    let mutable hasQuit = false
     let mutable nowCount = 0
     let mutable nextCount = 0
 
     for c in cmds do
-      let struct (now, next) = split c
-      nowCount <- nowCount + now.Length
-      nextCount <- nextCount + next.Length
+      match c with
+      | Quit -> hasQuit <- true
+      | _ ->
+        let struct (now, next) = split c
+        nowCount <- nowCount + now.Length
+        nextCount <- nextCount + next.Length
 
-    if nowCount = 0 && nextCount = 0 then
+    if hasQuit then
+      Quit
+    elif nowCount = 0 && nextCount = 0 then
       Empty
     elif nextCount = 0 then
       if nowCount = 1 then
@@ -224,6 +238,8 @@ module Cmd =
 
   let batch2(a: Cmd<'Msg>, b: Cmd<'Msg>) : Cmd<'Msg> =
     match a, b with
+    | Quit, _
+    | _, Quit -> Quit
     | Empty, x -> x
     | x, Empty -> x
     | _ ->

--- a/src/Mibo.Raylib/Elmish.Runtime.fs
+++ b/src/Mibo.Raylib/Elmish.Runtime.fs
@@ -55,6 +55,7 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
   let deferredEffsRun = ResizeArray<Effect<'Msg>>(64)
   let mutable fixedAccSeconds = 0.0f
 
+  let mutable shouldQuit = false
   let mutable inputServiceOpt: IInput voption = ValueNone
 
   let dispatch(msg: 'Msg) = msgQueue.Dispatch(msg)
@@ -62,6 +63,7 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
   let execCmd(cmd: Cmd<'Msg>) =
     match cmd with
     | Empty -> ()
+    | Quit -> shouldQuit <- true
     | Single eff -> eff.Invoke(dispatch)
     | Batch effs ->
       for i = 0 to effs.Length - 1 do
@@ -112,6 +114,7 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
         (List.rev program.Config)
 
     Raylib.InitWindow(config.Width, config.Height, config.Title)
+    Raylib.SetExitKey(KeyboardKey.Null)
     Raylib.InitAudioDevice()
 
     if config.TargetFPS > 0 then
@@ -150,7 +153,7 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
     execCmd initialCmds
     updateSubs ctx
 
-    while not(RaylibHelpers.windowShouldClose()) do
+    while not(shouldQuit || RaylibHelpers.windowShouldClose()) do
       let dt = Raylib.GetFrameTime()
       let elapsed = TimeSpan.FromSeconds(float dt)
 


### PR DESCRIPTION
## Changes

- **Disable ESC exit key** — raylib's default `SetExitKey(KEY_ESCAPE)` is now overridden to `KEY_NULL` in the runtime init. ESC no longer closes the window.
- **Add `Cmd.signalExit`** — new command for programmatic window exit from `update` functions. Returns `Quit` case on `Cmd<'Msg>` DU.
- **`Quit` precedence in batches** — `Cmd.batch [effects...; Cmd.signalExit]` returns `Quit`, ensuring exit signals are never lost.

## Exit paths

| Trigger | Mechanism |
|---|---|
| X button / Alt+F4 | `WindowShouldClose()` (OS signal) |
| `Cmd.signalExit` from `update` | Sets `shouldQuit` flag, loop exits after frame |
| ESC key | **No longer exits** |

## Breaking changes

- `Cmd<'Msg>` has new `Quit` case — exhaustive pattern matches need a wildcard
- ESC no longer closes the window by default

## Usage

```fsharp
// In your update function:
| QuitGame -> model, Cmd.signalExit
```
