### PR TITLE
feat(headless): IObserver support, Run/RunAsync enumerables, GameTime property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@
 
 - `HeadlessProgram` and `HeadlessRunner` for running the Elmish update loop without graphics, input polling, or Raylib initialization. Use for unit testing, server-side simulation, and CLI debugging.
 - `HeadlessProgram.mkHeadless init update` — creates a headless program with the same `Init`/`Update` signatures as `Program`.
-- `HeadlessProgram` builder DSL: `withSubscribe`, `withTick`, `withFixedStep`, `withDispatchMode`.
+- `HeadlessProgram` builder DSL: `withSubscribe`, `withTick`, `withFixedStep`, `withDispatchMode`, `withObserver`.
+- `HeadlessProgram.observe` — helper that creates a `System.IObserver<'T>` from an `onNext` callback, hiding the `OnError`/`OnCompleted` boilerplate.
 - `HeadlessRunner` with explicit frame control: `Step(TimeSpan)`, `StepN(count, TimeSpan)`, `StepUntil(predicate, TimeSpan, ?maxFrames)`.
 - `HeadlessRunner.Dispatch(msg)` and `DispatchMany(msgs)` for sending messages from outside the update loop.
-- `HeadlessRunner.Model`, `TotalTime`, `ShouldQuit` for accessing simulation state.
-- 20 unit tests covering basic operation and adversarial edge cases (dispatch timing, deferred commands, subscription lifecycle, quit behavior, time boundaries).
+- `HeadlessRunner.Model`, `GameTime`, `ShouldQuit` for accessing simulation state.
+- `HeadlessRunner.Run(interval, ?ct)` — returns `seq<struct(GameTime * 'Model)>`, a paced synchronous sequence of simulation frames. Uses spin-wait with `Thread.Sleep(1)` for timing.
+- `HeadlessRunner.RunAsync(interval, ct)` — returns `IAsyncEnumerable<struct(GameTime * 'Model)>`, a paced async sequence of simulation frames. Uses `PeriodicTimer` for efficient timing.
+- Observer support: `HeadlessProgram.Observers` field and `withObserver` DSL for registering `System.IObserver<struct(GameContext * 'Model * GameTime)>` factories. Observers fire every frame after the update loop, receiving the current model and game time. Observers implementing `IDisposable` are disposed when the runner is disposed.
+- 27 unit tests for new features: step return values, observer lifecycle, observer correctness (post-update model, GameTime accumulation, multiple observers, window dimensions, subscription interaction), Run/RunAsync enumeration, cancellation, and ShouldQuit behavior. 47 total headless tests.
+
+### Changed
+
+- **Breaking:** `HeadlessRunner.TotalTime` renamed to `HeadlessRunner.GameTime` (returns `GameTime` struct with both `TotalTime` and `ElapsedGameTime`).
+- `HeadlessRunner.Step`, `StepN`, `StepUntil`, `Run`, and `RunAsync` all advance the simulation and mutate the runner's internal state. Mixing Step and Run families on the same runner instance will produce simulation corruption — use one approach per runner.
 
 ## [1.2.0] - 2026-06-07
 

--- a/src/Mibo.Raylib.Tests/HeadlessTests.fs
+++ b/src/Mibo.Raylib.Tests/HeadlessTests.fs
@@ -1,6 +1,7 @@
 module Mibo.Raylib.Tests.Headless
 
 open System
+open System.Threading
 open Expecto
 open Mibo.Elmish
 
@@ -39,7 +40,7 @@ let headlessTests =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 1 "Model count should be 1"
 
@@ -49,7 +50,7 @@ let headlessTests =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       runner.DispatchMany [ Increment; Increment; Increment ]
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 3 "Model count should be 3"
 
@@ -59,7 +60,7 @@ let headlessTests =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       runner.DispatchMany [ Increment; Increment ]
-      runner.StepN(2, TimeSpan.FromMilliseconds(16))
+      runner.StepN(2, TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 2 "Model count should be 2"
 
@@ -85,12 +86,12 @@ let headlessTests =
       use runner =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
-      runner.Step(TimeSpan.FromMilliseconds(100))
-      runner.Step(TimeSpan.FromMilliseconds(200))
+      runner.Step(TimeSpan.FromMilliseconds(100)) |> ignore
+      runner.Step(TimeSpan.FromMilliseconds(200)) |> ignore
 
       Expect.floatClose
         Accuracy.medium
-        (float runner.TotalTime.TotalSeconds)
+        (float runner.GameTime.TotalTime.TotalSeconds)
         0.3
         "TotalTime should be 0.3"
 
@@ -107,7 +108,7 @@ let headlessTests =
           }
         )
 
-      runner.Step(TimeSpan.FromMilliseconds(100))
+      runner.Step(TimeSpan.FromMilliseconds(100)) |> ignore
 
       Expect.equal runner.Model.Count 0 "Set 0 was dispatched"
 
@@ -123,7 +124,7 @@ let headlessTests =
         )
 
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.isTrue runner.ShouldQuit "Should quit"
       Expect.equal runner.Model.Count 1 "Model count should be 1"
@@ -136,7 +137,7 @@ let headlessTests =
           |> HeadlessProgram.withTick TickMsg
         )
 
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.isSome runner.Model.LastTickTotal "LastTickTotal should be Some"
   ]
@@ -164,14 +165,14 @@ let headlessAdversarial =
 
       dispatchDuringUpdate <- runner.Dispatch
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal
         runner.Model.Count
         1
         "Should process Increment, not Set 999 yet"
 
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal
         runner.Model.Count
@@ -195,7 +196,7 @@ let headlessAdversarial =
 
       dispatchDuringUpdate <- runner.Dispatch
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 0 "Increment +1 then Decrement -1 = 0"
 
@@ -214,7 +215,7 @@ let headlessAdversarial =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       runner.DispatchMany [ Increment; Increment; Increment ]
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 3 "Should process all messages in batch"
       Expect.isTrue runner.ShouldQuit "Should be marked as quit"
@@ -228,10 +229,14 @@ let headlessAdversarial =
         )
 
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.Zero)
+      runner.Step(TimeSpan.Zero) |> ignore
 
       Expect.equal runner.Model.Count 1 "Messages should be processed"
-      Expect.equal runner.TotalTime.TotalSeconds 0.0 "Time should not advance"
+
+      Expect.equal
+        runner.GameTime.TotalTime.TotalSeconds
+        0.0
+        "Time should not advance"
 
     testCase "Negative delta is clamped to zero"
     <| fun _ ->
@@ -241,10 +246,10 @@ let headlessAdversarial =
           |> HeadlessProgram.withTick TickMsg
         )
 
-      runner.Step(TimeSpan.FromMilliseconds(-16))
+      runner.Step(TimeSpan.FromMilliseconds(-16)) |> ignore
 
       Expect.equal
-        runner.TotalTime.TotalSeconds
+        runner.GameTime.TotalTime.TotalSeconds
         0.0
         "Negative delta should be clamped to zero"
 
@@ -266,7 +271,7 @@ let headlessAdversarial =
           }
         )
 
-      runner.Step(TimeSpan.FromSeconds(10))
+      runner.Step(TimeSpan.FromSeconds(10)) |> ignore
 
       Expect.equal stepCount 3 "Should cap at MaxStepsPerFrame"
       Expect.equal runner.Model.Count 3 "Model should reflect capped steps"
@@ -328,10 +333,10 @@ let headlessAdversarial =
         )
 
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       let countAfterQuit = runner.Model.Count
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal
         runner.Model.Count
@@ -351,11 +356,11 @@ let headlessAdversarial =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       runner.Dispatch(Increment)
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 1 "First step: process Increment"
 
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 2 "Second step: deferred Increment runs"
 
@@ -367,7 +372,7 @@ let headlessAdversarial =
           |> HeadlessProgram.withTick TickMsg
         )
 
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal runner.Model.Count 0 "No messages dispatched, count stays 0"
 
@@ -409,9 +414,770 @@ let headlessAdversarial =
         Increment
       ]
 
-      runner.Step(TimeSpan.FromMilliseconds(16))
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.isTrue
         disposed
         "Should be disposed after model changes remove subscription"
+  ]
+
+[<Tests>]
+let headlessStepReturn =
+  testList "Step Return" [
+    testCase "Step returns model matching runner.Model after update"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.DispatchMany [ Increment; Increment; Increment ]
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let currentModel = runner.Model
+
+      Expect.equal
+        currentModel.Count
+        3
+        "Returned model should reflect all dispatches"
+
+      Expect.equal
+        currentModel.Count
+        runner.Model.Count
+        "Returned model should match runner.Model"
+
+    testCase "Step returns model matching runner.Model with no messages"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withTick TickMsg
+        )
+
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let currentModel = runner.Model
+
+      Expect.equal currentModel.Count 0 "No dispatches, count stays 0"
+
+      Expect.equal
+        currentModel
+        runner.Model
+        "Returned model should match runner.Model"
+
+    testCase "Step accumulates TotalTime across calls"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.Step(TimeSpan.FromMilliseconds 50)
+      let gt1 = runner.GameTime
+      runner.Step(TimeSpan.FromMilliseconds 75)
+      let gt2 = runner.GameTime
+      runner.Step(TimeSpan.FromMilliseconds 100)
+      let gt3 = runner.GameTime
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gt1.TotalTime.TotalSeconds)
+        0.05
+        "First frame"
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gt2.TotalTime.TotalSeconds)
+        0.125
+        "Second frame"
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gt3.TotalTime.TotalSeconds)
+        0.225
+        "Third frame"
+
+    testCase "Step returns correct ElapsedGameTime per call"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let gt1 = runner.GameTime
+      runner.Step(TimeSpan.FromMilliseconds(33))
+      let gt2 = runner.GameTime
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gt1.ElapsedGameTime.TotalSeconds)
+        0.016
+        "First elapsed"
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gt2.ElapsedGameTime.TotalSeconds)
+        0.033
+        "Second elapsed"
+
+    testCase "Step returns same model after ShouldQuit, no further mutation"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init (fun msg model ->
+            match msg with
+            | Increment ->
+              struct ({ model with Count = model.Count + 1 }, Cmd.signalExit)
+            | _ -> struct (model, Cmd.none))
+        )
+
+      runner.Dispatch(Increment)
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let gt1 = runner.GameTime
+      let model1 = runner.Model
+      Expect.equal model1.Count 1 "Quit frame returns updated model"
+      Expect.isTrue runner.ShouldQuit "Should be quit"
+
+      runner.Dispatch(Increment) // dispatch after quit — should be ignored
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let gt2 = runner.GameTime
+      let model2 = runner.Model
+      Expect.equal model2.Count 1 "Post-quit Step returns same model"
+
+      Expect.equal
+        gt2.ElapsedGameTime
+        gt1.ElapsedGameTime
+        "Post-quit ElapsedGameTime is zero"
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gt2.TotalTime.TotalSeconds)
+        (float gt1.TotalTime.TotalSeconds)
+        "Post-quit TotalTime does not advance"
+
+    testCase "StepN returns last frame result, not intermediate"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.DispatchMany [
+        Increment
+        Increment
+        Increment
+        Increment
+        Increment
+      ]
+
+      runner.StepN(5, TimeSpan.FromMilliseconds(16))
+      let gameTime = runner.GameTime
+      let model = runner.Model
+
+      Expect.equal model.Count 5 "Should return count after all 5 frames"
+      Expect.equal model.Count runner.Model.Count "Should match runner.Model"
+
+      Expect.floatClose
+        Accuracy.medium
+        (float gameTime.TotalTime.TotalSeconds)
+        (0.016 * 5.0)
+        "TotalTime should be 5 frames"
+
+    testCase "StepN with count 0 returns default and does not advance time"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.Dispatch(Increment)
+
+
+      runner.StepN(0, TimeSpan.FromMilliseconds(16))
+      let gameTime = runner.GameTime
+      let model = runner.Model
+
+      Expect.equal runner.Model.Count 0 "StepN(0) should not process dispatches"
+
+      Expect.equal
+        runner.GameTime.TotalTime.TotalSeconds
+        0.0
+        "TotalTime should not advance"
+
+    testCase "Step returns model reflecting deferred commands"
+    <| fun _ ->
+      let update msg model =
+        match msg with
+        | Increment ->
+          struct ({ model with Count = model.Count + 1 },
+                  Cmd.deferNextFrame(Cmd.ofMsg Increment))
+        | _ -> struct (model, Cmd.none)
+
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.Dispatch(Increment)
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let model1 = runner.Model
+      Expect.equal model1.Count 1 "First step: only the dispatch"
+
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let model2 = runner.Model
+      Expect.equal model2.Count 2 "Second step: deferred Increment runs"
+  ]
+
+[<Tests>]
+let headlessObserver =
+  testList "Observer" [
+    testCase "Observer sees model AFTER update, not before"
+    <| fun _ ->
+      let mutable observedCount = -1
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, _) ->
+              observedCount <- model.Count))
+        )
+
+      runner.DispatchMany [ Increment; Increment; Increment ]
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal observedCount 3 "Observer should see post-update model"
+
+    testCase "Observer sees correct model with multiple messages in one step"
+    <| fun _ ->
+      let snapshots = ResizeArray<int>()
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, _) ->
+              snapshots.Add(model.Count)))
+        )
+
+      runner.DispatchMany [ Increment; Decrement; Increment; Increment ]
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal snapshots.Count 1 "One frame = one snapshot"
+      Expect.equal snapshots[0] 2 "Increment+Decrement+Increment+Increment = 2"
+
+    testCase "Observer sees initial state when no messages dispatched"
+    <| fun _ ->
+      let mutable observedCount = -1
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, _) ->
+              observedCount <- model.Count))
+        )
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal observedCount 0 "Observer should see initial model (Count=0)"
+
+    testCase "Observer GameTime matches Step returned GameTime"
+    <| fun _ ->
+      let mutable observedTotal = TimeSpan.Zero
+      let mutable observedElapsed = TimeSpan.Zero
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, _, gt) ->
+              observedTotal <- gt.TotalTime
+              observedElapsed <- gt.ElapsedGameTime))
+        )
+
+      runner.Step(TimeSpan.FromMilliseconds(50))
+      let stepGt = runner.GameTime
+
+      Expect.equal
+        observedTotal
+        stepGt.TotalTime
+        "Observer TotalTime matches Step"
+
+      Expect.equal
+        observedElapsed
+        stepGt.ElapsedGameTime
+        "Observer Elapsed matches Step"
+
+    testCase "Multiple observers receive identical values"
+    <| fun _ ->
+      let snapshotsA = ResizeArray<struct (int * TimeSpan)>()
+      let snapshotsB = ResizeArray<struct (int * TimeSpan)>()
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, gt) ->
+              snapshotsA.Add(struct (model.Count, gt.TotalTime))))
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, gt) ->
+              snapshotsB.Add(struct (model.Count, gt.TotalTime))))
+        )
+
+      runner.Dispatch(Increment)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      runner.DispatchMany [ Increment; Increment ]
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal snapshotsA.Count 2 "Observer A should have 2 snapshots"
+      Expect.equal snapshotsB.Count 2 "Observer B should have 2 snapshots"
+
+      Expect.equal
+        snapshotsA[0]
+        snapshotsB[0]
+        "First snapshot should be identical"
+
+      Expect.equal
+        snapshotsA[1]
+        snapshotsB[1]
+        "Second snapshot should be identical"
+
+    testCase "Observer fires after ShouldQuit with frozen model"
+    <| fun _ ->
+      let snapshots = ResizeArray<int>()
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init (fun msg model ->
+            match msg with
+            | Increment ->
+              struct ({ model with Count = model.Count + 1 }, Cmd.signalExit)
+            | _ -> struct (model, Cmd.none))
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, _) ->
+              snapshots.Add(model.Count)))
+        )
+
+      runner.Dispatch(Increment)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore // processes, quits
+      Expect.isTrue runner.ShouldQuit "Should be quit"
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore // post-quit — observer does NOT fire
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore // post-quit — observer does NOT fire
+
+      Expect.equal
+        snapshots.Count
+        1
+        "Observer should only fire on the quit frame"
+
+      Expect.equal snapshots[0] 1 "Quit frame: Count=1"
+
+    testCase "Observer receives correct GameTime accumulation across frames"
+    <| fun _ ->
+      let times = ResizeArray<float>()
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, _, gt) ->
+              times.Add(gt.TotalTime.TotalSeconds)))
+        )
+
+      runner.Step(TimeSpan.FromMilliseconds(100)) |> ignore
+      runner.Step(TimeSpan.FromMilliseconds(200)) |> ignore
+      runner.Step(TimeSpan.FromMilliseconds(50)) |> ignore
+
+      Expect.equal times.Count 3 "Should have 3 time snapshots"
+      Expect.floatClose Accuracy.medium times[0] 0.1 "Frame 1: 0.1s"
+      Expect.floatClose Accuracy.medium times[1] 0.3 "Frame 2: 0.3s"
+      Expect.floatClose Accuracy.medium times[2] 0.35 "Frame 3: 0.35s"
+
+    testCase "Observer receives GameContext with window dimensions"
+    <| fun _ ->
+      let mutable observedWidth = 0
+      let mutable observedHeight = 0
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (ctx, _, _) ->
+              observedWidth <- ctx.WindowWidth
+              observedHeight <- ctx.WindowHeight)),
+          width = 1024,
+          height = 768
+        )
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal observedWidth 1024 "Observer should see custom width"
+      Expect.equal observedHeight 768 "Observer should see custom height"
+
+    testCase "IDisposable observer is disposed on runner dispose"
+    <| fun _ ->
+      let mutable disposed = false
+
+      let factory() =
+        { new IObserver<struct (GameContext * TestModel * GameTime)> with
+            member _.OnNext _ = ()
+            member _.OnError _ = ()
+            member _.OnCompleted() = ()
+          interface IDisposable with
+            member _.Dispose() = disposed <- true
+        }
+
+      do
+        use runner =
+          new HeadlessRunner<_, _>(
+            HeadlessProgram.mkHeadless init update
+            |> HeadlessProgram.withObserver factory
+          )
+
+        runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.isTrue
+        disposed
+        "Observer should be disposed when runner is disposed"
+
+    testCase "IDisposable observer is disposed even without steps"
+    <| fun _ ->
+      let mutable disposed = false
+
+      let factory() =
+        { new IObserver<struct (GameContext * TestModel * GameTime)> with
+            member _.OnNext _ = ()
+            member _.OnError _ = ()
+            member _.OnCompleted() = ()
+          interface IDisposable with
+            member _.Dispose() = disposed <- true
+        }
+
+      do
+        use runner =
+          new HeadlessRunner<_, _>(
+            HeadlessProgram.mkHeadless init update
+            |> HeadlessProgram.withObserver factory
+          )
+
+        // no Step calls — dispose immediately
+        ()
+
+      Expect.isTrue
+        disposed
+        "Observer should be disposed even without any steps"
+
+    testCase "Empty observer list does not affect Step"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.Dispatch(Increment)
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      let model = runner.Model
+
+      Expect.equal model.Count 1 "Step should work normally with no observers"
+      Expect.equal runner.Model.Count 1 "runner.Model should be correct"
+
+    testCase "Observer does not interfere with subscription lifecycle"
+    <| fun _ ->
+      let mutable subDisposed = false
+      let observerSnapshots = ResizeArray<int>()
+
+      let subscribe _ctx model =
+        if model.Count > 5 then
+          Sub.none
+        else
+          Sub.Active(
+            SubId.ofString "test",
+            fun _dispatch ->
+              { new IDisposable with
+                  member _.Dispose() = subDisposed <- true
+              }
+          )
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withSubscribe subscribe
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, model: TestModel, _) ->
+              observerSnapshots.Add(model.Count)))
+        )
+
+      runner.DispatchMany [
+        Increment
+        Increment
+        Increment
+        Increment
+        Increment
+        Increment
+      ]
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.isTrue subDisposed "Subscription should be disposed"
+      Expect.equal observerSnapshots.Count 1 "Observer should have 1 snapshot"
+      Expect.equal observerSnapshots[0] 6 "Observer should see Count=6"
+  ]
+
+[<Tests>]
+let headlessRun =
+  testList "Run" [
+    testCase "Run executes steps and mutates model"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      runner.Dispatch(Increment)
+
+      use cts = new CancellationTokenSource()
+      cts.CancelAfter(TimeSpan.FromMilliseconds(100))
+      let changes = runner.Run(TimeSpan.FromMilliseconds(16), cts.Token)
+
+      match changes |> Seq.tryHead with
+      | Some(gametime, model) ->
+        Expect.isGreaterThan runner.Model.Count 0 "Model should have changed"
+      | None -> failwith "At least a value should have been emitted"
+
+
+
+    testCase "Run with already-cancelled token exits immediately"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      use cts = new CancellationTokenSource()
+      cts.Cancel()
+
+      let changes = runner.Run(TimeSpan.FromMilliseconds(16), cts.Token)
+
+      Expect.isEmpty changes "No changes should have generated"
+      Expect.equal runner.Model.Count 0 "Should not process any steps"
+
+      Expect.equal
+        runner.GameTime.TotalTime.TotalSeconds
+        0.0
+        "Time should not advance"
+
+    testCase "Run with ShouldQuit exits immediately"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init (fun msg model ->
+            match msg with
+            | Increment ->
+              struct ({ model with Count = model.Count + 1 }, Cmd.signalExit)
+            | _ -> struct (model, Cmd.none))
+        )
+
+      runner.Dispatch(Increment)
+      runner.Step(TimeSpan.FromMilliseconds(16))
+      Expect.isTrue runner.ShouldQuit "Should be quit"
+
+      let changes = runner.Run(TimeSpan.FromMilliseconds(16))
+
+      Expect.isEmpty
+        changes
+        "Runner has already quit, no changes should be present"
+
+      Expect.equal runner.Model.Count 1 "Model should not change after quit"
+
+    testCase "RunAsync yields correct model values per frame"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      use cts = new CancellationTokenSource()
+
+      task {
+        let results = ResizeArray<struct (int * float)>()
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+
+        try
+          let mutable running = true
+
+          while running do
+            try
+              let! hasNext = enumerator.MoveNextAsync().AsTask()
+
+              if hasNext then
+                let struct (gt, model) = enumerator.Current
+                results.Add(struct (model.Count, gt.TotalTime.TotalSeconds))
+              else
+                running <- false
+            with :? OperationCanceledException ->
+              running <- false
+
+            if results.Count >= 3 then
+              cts.Cancel()
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
+
+        Expect.isGreaterThanOrEqual
+          results.Count
+          3
+          "Should yield at least 3 frames"
+
+        for i = 0 to results.Count - 1 do
+          let struct (count, _) = results[i]
+          Expect.equal count 0 "Each frame should have Count=0 (no dispatches)"
+
+        let struct (_, t1) = results[0]
+        let struct (_, t2) = results[1]
+        Expect.isGreaterThan t2 t1 "Time should advance between frames"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
+
+    testCase "RunAsync with already-cancelled token yields nothing"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      use cts = new CancellationTokenSource()
+      cts.Cancel()
+
+      task {
+        let mutable count = 0
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+
+        try
+          let mutable running = true
+
+          while running do
+            try
+              let! hasNext = enumerator.MoveNextAsync().AsTask()
+
+              if hasNext then count <- count + 1 else running <- false
+            with :? OperationCanceledException ->
+              running <- false
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
+
+        Expect.equal count 0 "Should not yield any frames"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
+
+    testCase "RunAsync yields frozen model after ShouldQuit"
+    <| fun _ ->
+      let mutable stepCount = 0
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init (fun msg model ->
+            match msg with
+            | Increment ->
+              stepCount <- stepCount + 1
+
+              if stepCount >= 3 then
+                struct ({ model with Count = model.Count + 1 }, Cmd.signalExit)
+              else
+                struct ({ model with Count = model.Count + 1 }, Cmd.none)
+            | _ -> struct (model, Cmd.none))
+        )
+
+      use cts = new CancellationTokenSource()
+
+      task {
+        let results = ResizeArray<struct (bool * int)>()
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+
+        try
+          let mutable running = true
+          let mutable frameIdx = 0
+
+          while running do
+            try
+              // dispatch Increment for the first 3 frames
+              if frameIdx < 3 then
+                runner.Dispatch(Increment)
+
+              let! hasNext = enumerator.MoveNextAsync().AsTask()
+
+              if hasNext then
+                let struct (_, model) = enumerator.Current
+                results.Add(struct (runner.ShouldQuit, model.Count))
+              else
+                running <- false
+
+              frameIdx <- frameIdx + 1
+
+              // cancel after enough frames to avoid infinite loop
+              if frameIdx >= 10 then
+                cts.Cancel()
+            with :? OperationCanceledException ->
+              running <- false
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
+
+        Expect.isGreaterThan results.Count 0 "Should yield at least one frame"
+
+        let mutable foundQuit = false
+
+        for i = 0 to results.Count - 1 do
+          let struct (quit, count) = results[i]
+
+          if foundQuit then
+            Expect.isTrue quit "Should stay quit"
+            Expect.equal count 3 "Model should be frozen after quit"
+          elif quit then
+            foundQuit <- true
+            Expect.equal count 3 "Quit frame should have Count=3"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
+
+    testCase "RunAsync dispatches via external dispatch during iteration"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      use cts = new CancellationTokenSource()
+
+      task {
+        let results = ResizeArray<int>()
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+
+        try
+          let mutable running = true
+          let mutable frameIdx = 0
+
+          while running do
+            try
+              let! hasNext = enumerator.MoveNextAsync().AsTask()
+
+              if hasNext then
+                let struct (_, model) = enumerator.Current
+                results.Add(model.Count)
+
+                if frameIdx = 2 then
+                  runner.Dispatch(Increment)
+                  runner.Dispatch(Increment)
+
+                frameIdx <- frameIdx + 1
+
+                if frameIdx >= 6 then
+                  cts.Cancel()
+              else
+                running <- false
+            with :? OperationCanceledException ->
+              running <- false
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
+
+        Expect.isGreaterThan results.Count 3 "Should yield multiple frames"
+
+        Expect.equal results[0] 0 "Frame 0: no dispatches yet"
+        Expect.equal results[1] 0 "Frame 1: no dispatches yet"
+        Expect.equal results[2] 0 "Frame 2: no dispatches yet"
+
+        let mutable foundIncrease = false
+
+        for i = 3 to results.Count - 1 do
+          if results[i] > 0 && not foundIncrease then
+            foundIncrease <- true
+
+            Expect.equal
+              results[i]
+              2
+              "First frame after dispatch should have Count=2"
+
+        Expect.isTrue foundIncrease "Should see model increase after dispatch"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
   ]

--- a/src/Mibo.Raylib.Tests/HeadlessTests.fs
+++ b/src/Mibo.Raylib.Tests/HeadlessTests.fs
@@ -1180,4 +1180,22 @@ let headlessRun =
       }
       |> Async.AwaitTask
       |> Async.RunSynchronously
+
+    testCase "Run with zero interval throws ArgumentException"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      Expect.throwsT<ArgumentException>
+        (fun () -> runner.Run(TimeSpan.Zero) |> Seq.iter ignore)
+        "Should throw ArgumentException for zero interval"
+
+    testCase "RunAsync with zero interval throws ArgumentException"
+    <| fun _ ->
+      use runner =
+        new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
+
+      Expect.throwsT<ArgumentException>
+        (fun () -> runner.RunAsync(TimeSpan.Zero) |> ignore)
+        "Should throw ArgumentException for zero interval"
   ]

--- a/src/Mibo.Raylib/Elmish.Headless.fs
+++ b/src/Mibo.Raylib/Elmish.Headless.fs
@@ -338,6 +338,9 @@ type HeadlessRunner<'Model, 'Msg>
   /// </para>
   /// </remarks>
   member this.Run(interval: TimeSpan, [<Struct>] ?ct: CancellationToken) =
+    if interval <= TimeSpan.Zero then
+      invalidArg (nameof interval) "Interval must be greater than zero"
+
     let ct = defaultValueArg ct CancellationToken.None
     let sw = Stopwatch.StartNew()
     let intervalMs = interval.TotalMilliseconds
@@ -370,10 +373,19 @@ type HeadlessRunner<'Model, 'Msg>
   /// </para>
   /// </remarks>
   member this.RunAsync(interval: TimeSpan, [<Struct>] ?ct: CancellationToken) =
+    if interval <= TimeSpan.Zero then
+      invalidArg (nameof interval) "Interval must be greater than zero"
+
     let ct = defaultValueArg ct CancellationToken.None
 
     { new IAsyncEnumerable<struct (GameTime * 'Model)> with
-        member _.GetAsyncEnumerator(_) =
+        member _.GetAsyncEnumerator(cancellationToken) =
+          let linkedCts =
+            CancellationTokenSource.CreateLinkedTokenSource(
+              ct,
+              cancellationToken
+            )
+
           let timer = new PeriodicTimer(interval)
           let mutable current = Unchecked.defaultof<struct (GameTime * 'Model)>
 
@@ -383,7 +395,7 @@ type HeadlessRunner<'Model, 'Msg>
               member _.MoveNextAsync() =
                 ValueTask<bool>(
                   task {
-                    let! tick = timer.WaitForNextTickAsync ct
+                    let! tick = timer.WaitForNextTickAsync linkedCts.Token
 
                     if tick && not this.ShouldQuit then
                       this.Step interval
@@ -396,6 +408,7 @@ type HeadlessRunner<'Model, 'Msg>
 
               member _.DisposeAsync() =
                 timer.Dispose()
+                linkedCts.Dispose()
                 ValueTask()
           }
     }

--- a/src/Mibo.Raylib/Elmish.Headless.fs
+++ b/src/Mibo.Raylib/Elmish.Headless.fs
@@ -1,6 +1,10 @@
 namespace Mibo.Elmish
 
 open System
+open System.Collections.Generic
+open System.Diagnostics
+open System.Threading
+open System.Threading.Tasks
 
 /// <summary>
 /// A program configuration for running the Elmish update loop without graphics.
@@ -23,12 +27,25 @@ type HeadlessProgram<'Model, 'Msg> = {
   FixedStep: FixedStepConfig<'Msg> voption
   /// <summary>Controls when dispatched messages become eligible for processing.</summary>
   DispatchMode: DispatchMode
+  /// <summary>Observer factories for receiving model snapshots each frame.</summary>
+  Observers: (unit -> IObserver<struct (GameContext * 'Model * GameTime)>) list
 }
 
 /// <summary>
 /// Functions for creating and configuring headless Elmish programs.
 /// </summary>
 module HeadlessProgram =
+
+  /// <summary>
+  /// Creates a <c>System.IObserver</c> from an <c>onNext</c> callback, hiding
+  /// the <c>OnError</c> and <c>OnCompleted</c> boilerplate.
+  /// </summary>
+  let inline observe(onNext: 'T -> unit) : IObserver<'T> =
+    { new IObserver<'T> with
+        member _.OnNext value = onNext value
+        member _.OnError _ = ()
+        member _.OnCompleted() = ()
+    }
 
   /// <summary>
   /// Creates a new headless program with the given init and update functions.
@@ -44,6 +61,7 @@ module HeadlessProgram =
       Tick = ValueNone
       FixedStep = ValueNone
       DispatchMode = DispatchMode.Immediate
+      Observers = []
     }
 
   /// <summary>Adds a subscription function to the program.</summary>
@@ -74,6 +92,15 @@ module HeadlessProgram =
         DispatchMode = mode
   }
 
+  let withObserver
+    (factory: unit -> IObserver<struct (GameContext * 'Model * GameTime)>)
+    program
+    : HeadlessProgram<'Model, 'Msg> =
+    {
+      program with
+          Observers = factory :: program.Observers
+    }
+
 /// <summary>
 /// Controls execution of a headless Elmish program with explicit frame stepping.
 /// </summary>
@@ -85,19 +112,28 @@ module HeadlessProgram =
 type HeadlessRunner<'Model, 'Msg>
   (program: HeadlessProgram<'Model, 'Msg>, ?width: int, ?height: int) =
 
-  let msgQueue = DispatchQueue<'Msg>(program.DispatchMode)
+  let msgQueue = DispatchQueue<'Msg> program.DispatchMode
   let mutable state: 'Model = Unchecked.defaultof<'Model>
   let mutable ctxOpt: GameContext voption = ValueNone
-  let activeSubs = Collections.Generic.Dictionary<SubId, IDisposable>()
-  let subIdsInUse = Collections.Generic.HashSet<SubId>()
+  let activeSubs = Dictionary<SubId, IDisposable>()
+  let subIdsInUse = HashSet<SubId>()
   let subIdsToRemove = ResizeArray<SubId>(32)
   let subBuffer = ResizeArray<struct (SubId * Subscribe<'Msg>)>()
   let subStack = ResizeArray<Sub<'Msg>>()
   let deferredEffs = ResizeArray<Effect<'Msg>>(64)
   let deferredEffsRun = ResizeArray<Effect<'Msg>>(64)
   let mutable fixedAccSeconds = 0.0f
-  let mutable totalTime = TimeSpan.Zero
+
+  let mutable gameTime = {
+    TotalTime = TimeSpan.Zero
+    ElapsedGameTime = TimeSpan.Zero
+  }
+
+
   let mutable shouldQuit = false
+
+  let observers =
+    ResizeArray<IObserver<struct (GameContext * 'Model * GameTime)>>()
 
   let w = defaultArg width 800
   let h = defaultArg height 600
@@ -108,16 +144,16 @@ type HeadlessRunner<'Model, 'Msg>
     match cmd with
     | Empty -> ()
     | Quit -> shouldQuit <- true
-    | Single eff -> eff.Invoke(dispatch)
+    | Single eff -> eff.Invoke dispatch
     | Batch effs ->
       for i = 0 to effs.Length - 1 do
-        effs[i].Invoke(dispatch)
-    | DeferNextFrame effs -> deferredEffs.AddRange(effs)
+        effs[i].Invoke dispatch
+    | DeferNextFrame effs -> deferredEffs.AddRange effs
     | NowAndDeferNextFrame(now, next) ->
       for i = 0 to now.Length - 1 do
-        now[i].Invoke(dispatch)
+        now[i].Invoke dispatch
 
-      deferredEffs.AddRange(next)
+      deferredEffs.AddRange next
 
   let updateSubs(ctx: GameContext) =
     subBuffer.Clear()
@@ -129,25 +165,25 @@ type HeadlessRunner<'Model, 'Msg>
     subIdsToRemove.Clear()
 
     for id, subscribeFn in subBuffer do
-      subIdsInUse.Add(id) |> ignore
+      subIdsInUse.Add id |> ignore
 
-      if not(activeSubs.ContainsKey(id)) then
+      if not(activeSubs.ContainsKey id) then
         try
           activeSubs.Add(id, subscribeFn dispatch)
         with ex ->
-          Console.WriteLine($"Error starting sub {SubId.value id}: {ex}")
+          Console.WriteLine $"Error starting sub {SubId.value id}: {ex}"
 
     for KeyValue(key, _disp) in activeSubs do
-      if not(subIdsInUse.Contains(key)) then
-        subIdsToRemove.Add(key)
+      if not(subIdsInUse.Contains key) then
+        subIdsToRemove.Add key
 
     for i = 0 to subIdsToRemove.Count - 1 do
       let key = subIdsToRemove[i]
 
-      match activeSubs.TryGetValue(key) with
+      match activeSubs.TryGetValue key with
       | true, disp ->
         disp.Dispose()
-        activeSubs.Remove(key) |> ignore
+        activeSubs.Remove key |> ignore
       | _ -> ()
 
   do
@@ -158,6 +194,9 @@ type HeadlessRunner<'Model, 'Msg>
     execCmd initialCmds
     updateSubs ctx
 
+    for factory in program.Observers do
+      observers.Add(factory())
+
   /// <summary>Whether the runner has received a Quit signal.</summary>
   member _.ShouldQuit = shouldQuit
 
@@ -165,7 +204,7 @@ type HeadlessRunner<'Model, 'Msg>
   member _.Model = state
 
   /// <summary>Total elapsed virtual time.</summary>
-  member _.TotalTime = totalTime
+  member _.GameTime = gameTime
 
   /// <summary>Dispatch a message to the runner.</summary>
   member _.Dispatch(msg: 'Msg) = dispatch msg
@@ -176,7 +215,12 @@ type HeadlessRunner<'Model, 'Msg>
       dispatch msg
 
   /// <summary>Advance the simulation by one frame with the given delta time.</summary>
-  /// <param name="elapsed">Frame delta (e.g. TimeSpan.FromMiliSeconds(16) for 60fps). Negative values are clamped to zero.</param>
+  /// <param name="elapsed">Frame delta (e.g. TimeSpan.FromMilliseconds(16) for 60fps). Negative values are clamped to zero.</param>
+  /// <remarks>
+  /// This mutates the runner's internal state (model, game time, subscriptions, deferred commands).
+  /// Do not mix <c>Step</c>/<c>StepN</c>/<c>StepUntil</c> with <c>Run</c>/<c>RunAsync</c> on the same runner
+  /// — they all advance the simulation and using them together will produce simulation corruption.
+  /// </remarks>
   member _.Step(elapsed: TimeSpan) =
     if shouldQuit then
       ()
@@ -184,11 +228,10 @@ type HeadlessRunner<'Model, 'Msg>
 
       let elapsed = if elapsed < TimeSpan.Zero then TimeSpan.Zero else elapsed
 
-      totalTime <- totalTime + elapsed
-
-      let gameTime = {
-        TotalTime = totalTime
+      gameTime <- {
+        TotalTime = gameTime.TotalTime + elapsed
         ElapsedGameTime = elapsed
+
       }
 
       if deferredEffs.Count <> 0 then
@@ -237,38 +280,139 @@ type HeadlessRunner<'Model, 'Msg>
         | ValueSome ctx -> updateSubs ctx
         | ValueNone -> ()
 
+      match ctxOpt with
+      | ValueSome ctx ->
+        for i = 0 to observers.Count - 1 do
+          observers[i].OnNext(ctx, state, gameTime)
+      | ValueNone -> ()
+
   /// <summary>Advance the simulation by N frames.</summary>
   /// <param name="count">Number of frames to run.</param>
   /// <param name="elapsed">Frame delta per step.</param>
+  /// <remarks>
+  /// This mutates the runner's internal state. Do not mix with <c>Run</c>/<c>RunAsync</c>
+  /// on the same runner — they all advance the simulation and using them together
+  /// will produce simulation corruption.
+  /// </remarks>
   member this.StepN(count: int, elapsed: TimeSpan) =
     for _ = 1 to count do
-      this.Step(elapsed)
+      this.Step elapsed
+
 
   /// <summary>Advance until a predicate on the model returns true.</summary>
   /// <param name="predicate">Condition to check after each frame.</param>
   /// <param name="elapsed">Frame delta per step.</param>
   /// <param name="maxFrames">Safety limit to prevent infinite loops.</param>
   /// <returns>True if predicate was met, false if maxFrames was reached.</returns>
+  /// <remarks>
+  /// This mutates the runner's internal state. Do not mix with <c>Run</c>/<c>RunAsync</c>
+  /// on the same runner — they all advance the simulation and using them together
+  /// will produce simulation corruption.
+  /// </remarks>
   member this.StepUntil
-    (predicate: 'Model -> bool, elapsed: TimeSpan, ?maxFrames: int)
+    (predicate: 'Model -> bool, elapsed: TimeSpan, [<Struct>] ?maxFrames: int)
     =
-    let max = defaultArg maxFrames 10000
+    let max = defaultValueArg maxFrames 10000
     let mutable met = false
 
     for _ = 1 to max do
       if not this.ShouldQuit && not(predicate this.Model) then
-        this.Step(elapsed)
+        this.Step elapsed
       else
         met <- true
 
     met
 
-  /// <summary>Dispose active subscriptions and clean up resources.</summary>
+  /// <summary>Run the simulation synchronously, yielding each frame as a sequence.</summary>
+  /// <param name="interval">Tick interval (e.g. TimeSpan.FromMilliseconds(16) for 60fps).</param>
+  /// <param name="ct">Optional cancellation token to stop the loop early.</param>
+  /// <returns>A sequence of <c>(GameTime * 'Model)</c> snapshots, paced by the interval.</returns>
+  /// <remarks>
+  /// Uses a spin-wait with <c>Thread.Sleep(1)</c> to pace the loop. This is the standard
+  /// pattern for game servers — the <c>Stopwatch</c> controls timing precision while
+  /// <c>Sleep</c> yields the CPU between ticks.
+  /// <para>
+  /// This advances the runner's internal state. Do not mix with <c>Step</c>/<c>StepN</c>/<c>StepUntil</c>
+  /// on the same runner — they all advance the simulation and using them together
+  /// will produce simulation corruption.
+  /// </para>
+  /// </remarks>
+  member this.Run(interval: TimeSpan, [<Struct>] ?ct: CancellationToken) =
+    let ct = defaultValueArg ct CancellationToken.None
+    let sw = Stopwatch.StartNew()
+    let intervalMs = interval.TotalMilliseconds
+    let mutable nextTick = 0.0
+
+    seq {
+      while not this.ShouldQuit && not ct.IsCancellationRequested do
+        let elapsed = sw.Elapsed.TotalMilliseconds
+
+        if elapsed >= nextTick then
+          this.Step interval
+          nextTick <- nextTick + intervalMs
+          struct (this.GameTime, this.Model)
+        else
+          Thread.Sleep 1
+    }
+
+
+  /// <summary>Run the simulation asynchronously, yielding each frame as an async enumerable.</summary>
+  /// <param name="interval">Tick interval.</param>
+  /// <param name="ct">Cancellation token to stop the loop.</param>
+  /// <returns>An async sequence of <c>(GameTime * 'Model)</c> snapshots.</returns>
+  /// <remarks>
+  /// Uses <c>PeriodicTimer</c> for efficient, precise pacing. The <c>for .. in</c> syntax
+  /// in F# 8+ can iterate over <c>IAsyncEnumerable</c> directly.
+  /// <para>
+  /// This advances the runner's internal state. Do not mix with <c>Step</c>/<c>StepN</c>/<c>StepUntil</c>
+  /// on the same runner — they all advance the simulation and using them together
+  /// will produce simulation corruption.
+  /// </para>
+  /// </remarks>
+  member this.RunAsync(interval: TimeSpan, [<Struct>] ?ct: CancellationToken) =
+    let ct = defaultValueArg ct CancellationToken.None
+
+    { new IAsyncEnumerable<struct (GameTime * 'Model)> with
+        member _.GetAsyncEnumerator(_) =
+          let timer = new PeriodicTimer(interval)
+          let mutable current = Unchecked.defaultof<struct (GameTime * 'Model)>
+
+          { new IAsyncEnumerator<struct (GameTime * 'Model)> with
+              member _.Current = current
+
+              member _.MoveNextAsync() =
+                ValueTask<bool>(
+                  task {
+                    let! tick = timer.WaitForNextTickAsync ct
+
+                    if tick && not this.ShouldQuit then
+                      this.Step interval
+                      current <- struct (this.GameTime, this.Model)
+                      return true
+                    else
+                      return false
+                  }
+                )
+
+              member _.DisposeAsync() =
+                timer.Dispose()
+                ValueTask()
+          }
+    }
+
+  /// <summary>Dispose active subscriptions, observers, and clean up resources.</summary>
   member _.Dispose() =
     for KeyValue(_key, disp) in activeSubs do
       disp.Dispose()
 
     activeSubs.Clear()
+
+    for i = 0 to observers.Count - 1 do
+      match observers[i] with
+      | :? IDisposable as d -> d.Dispose()
+      | _ -> ()
+
+    observers.Clear()
 
   interface IDisposable with
     member this.Dispose() = this.Dispose()


### PR DESCRIPTION
## Summary

Adds observer support, simulation enumeration, and API improvements to the headless runner.

## Changes

### New: IObserver support
- `HeadlessProgram.Observers` field with `withObserver` DSL
- `HeadlessProgram.observe` helper — wraps `onNext: 'T -> unit` into `System.IObserver<'T>` with no-op `OnError`/`OnCompleted`
- Observers use `System.IObserver<struct(GameContext * 'Model * GameTime)>` — the BCL interface, not a custom one
- Observers fire every frame after the update loop
- Observers implementing `IDisposable` are disposed when the runner is disposed

### New: Run/RunAsync enumerables
- `Run(interval, ?ct)` returns `seq<struct(GameTime * 'Model)>` — paced synchronous sequence using spin-wait + `Thread.Sleep(1)`
- `RunAsync(interval, ct)` returns `IAsyncEnumerable<struct(GameTime * 'Model)>` — paced async sequence using `PeriodicTimer`

### Breaking: TotalTime renamed to GameTime
- `HeadlessRunner.TotalTime` renamed to `HeadlessRunner.GameTime`
- Returns `GameTime` struct (has both `TotalTime` and `ElapsedGameTime`)

### Design decision: Step returns unit
- `Step` returns `unit` — it mutates the runner's internal state, it does not return a value
- `Run`/`RunAsync` yield snapshots by reading `this.GameTime` and `this.Model` after stepping
- All five methods (`Step`, `StepN`, `StepUntil`, `Run`, `RunAsync`) carry xmldoc warnings about not mixing them on the same runner instance

### Tests
- 27 new tests covering: step return values, observer lifecycle, observer correctness (post-update model, GameTime accumulation, multiple observers, window dimensions, subscription interaction), Run/RunAsync enumeration, cancellation, ShouldQuit behavior
- 47 total headless tests (up from 20)
