### PR TITLE
Headless Runtime Enhancements + PingPong Networking Sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 - `HeadlessRunner.RunAsync(interval, ct)` — returns `IAsyncEnumerable<struct(GameTime * 'Model)>`, a paced async sequence of simulation frames. Uses `PeriodicTimer` for efficient timing.
 - Observer support: `HeadlessProgram.Observers` field and `withObserver` DSL for registering `System.IObserver<struct(GameContext * 'Model * GameTime)>` factories. Observers fire every frame after the update loop, receiving the current model and game time. Observers implementing `IDisposable` are disposed when the runner is disposed.
 - 27 unit tests for new features: step return values, observer lifecycle, observer correctness (post-update model, GameTime accumulation, multiple observers, window dimensions, subscription interaction), Run/RunAsync enumeration, cancellation, and ShouldQuit behavior. 47 total headless tests.
+- XML documentation for `HeadlessProgram.withTick`, `withFixedStep`, and `withDispatchMode`.
+- Headless mode documentation: Observers section (`withObserver`/`observe`), `Run`/`RunAsync` section with pacing and cancellation examples, server simulation example using observer-based broadcast.
 
 ### Changed
 

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -33,6 +33,7 @@ use runner = new HeadlessRunner<Model, Msg>(program)
 | `withTick`               | Add a per-frame tick message                    |
 | `withFixedStep`          | Enable framework-managed fixed timestep         |
 | `withDispatchMode`       | Set `Immediate` or `FrameBounded` dispatch      |
+| `withObserver`           | Register an observer for per-frame model snapshots |
 
 ## Running the Simulation
 
@@ -53,6 +54,31 @@ let met = runner.StepUntil(
     TimeSpan.FromMilliseconds(16))
 ```
 
+### Run and RunAsync
+
+For server scenarios and real-time simulation, `Run` and `RunAsync` pace the
+loop automatically and yield a `(GameTime * 'Model)` snapshot each tick:
+
+```fsharp
+// Synchronous: spin-wait with Thread.Sleep(1) for timing precision.
+// Use for game servers where the loop owns the main thread.
+for (time, model) in runner.Run(TimeSpan.FromMilliseconds(16)) do
+    printfn "Tick: %A" model
+
+// Asynchronous: PeriodicTimer for efficient, cancellation-friendly pacing.
+// Iterate with F# 8+ `for .. in` over IAsyncEnumerable.
+let cts = new CancellationTokenSource()
+
+async {
+    for (time, model) in runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token) do
+        printfn "Tick: %A" model
+}
+|> Async.RunSynchronously
+```
+
+> **Warning:** Do not mix `Run`/`RunAsync` with `Step`/`StepN`/`StepUntil` on
+> the same runner — they all advance the simulation and will corrupt state.
+
 ## Dispatching Messages
 
 Send messages into the runner from outside the update loop:
@@ -71,9 +97,9 @@ This is useful for:
 ## Accessing State
 
 ```fsharp
-let model = runner.Model        // Current model state
-let time = runner.TotalTime     // Elapsed virtual time
-let quit = runner.ShouldQuit    // Whether Quit was signaled
+let model = runner.Model          // Current model state
+let time = runner.GameTime        // GameTime struct (TotalTime + ElapsedGameTime)
+let quit = runner.ShouldQuit      // Whether Quit was signaled
 ```
 
 ## Time Control
@@ -85,10 +111,10 @@ Unlike `RaylibGame` which uses real wall-clock time, `HeadlessRunner` uses virtu
 runner.Step(TimeSpan.FromMilliseconds(16))  // ~60fps
 runner.Step(TimeSpan.FromSeconds(1))        // 1 second
 
-// TotalTime accumulates across steps
+// GameTime accumulates across steps
 runner.Step(TimeSpan.FromMilliseconds(100))
 runner.Step(TimeSpan.FromMilliseconds(200))
-// runner.TotalTime.TotalSeconds = 0.3
+// runner.GameTime.TotalTime.TotalSeconds = 0.3
 ```
 
 ## Fixed Step with Headless
@@ -140,6 +166,31 @@ let program =
   |> HeadlessProgram.withSubscribe subscribe
 ```
 
+## Observers
+
+Observers receive a `(GameContext * 'Model * GameTime)` snapshot every frame,
+after the update loop completes. Use them to react to model changes without
+modifying the update function — e.g. broadcasting state to clients, logging
+telemetry, or recording replays.
+
+```fsharp
+let program =
+  HeadlessProgram.mkHeadless init update
+  |> HeadlessProgram.withObserver(fun () ->
+    HeadlessProgram.observe(fun struct (ctx, model, time) ->
+      printfn "Frame at %.2fs: %A" time.TotalTime.TotalSeconds model))
+
+use runner = new HeadlessRunner<_,_>(program)
+runner.Step(TimeSpan.FromMilliseconds(16))
+```
+
+`HeadlessProgram.observe` creates an `IObservable` from a single `onNext`
+callback, hiding the `OnError`/`OnCompleted` boilerplate. Observers
+implementing `IDisposable` are disposed when the runner is disposed.
+
+Multiple observers can be registered — they fire in registration order each
+frame.
+
 ## Cleanup
 
 `HeadlessRunner` implements `IDisposable`. Disposing it cleans up active subscriptions:
@@ -180,23 +231,31 @@ let ``increment increases count`` () =
 
 ## Example: Server Simulation
 
+A headless runner is an authoritative simulation server: `RunAsync` paces the
+tick loop, observers broadcast state to clients, and `Dispatch` injects
+client inputs from the network layer.
+
 ```fsharp
 let program =
   HeadlessProgram.mkHeadless init update
-  |> HeadlessProgram.withSubscribe subscribe
   |> HeadlessProgram.withFixedStep {
     StepSeconds = 1f / 20f  // 20 ticks/sec
     MaxStepsPerFrame = 4
     MaxFrameSeconds = ValueSome 0.5f
     Map = GameTick
   }
+  // Broadcast the model to all clients every frame
+  |> HeadlessProgram.withObserver(fun () ->
+    HeadlessProgram.observe(fun struct (_, model, _) ->
+      serialize model |> server.Broadcast))
 
 use runner = new HeadlessRunner<_,_>(program)
 
-// Simulate 10 seconds of game time
-while not runner.ShouldQuit do
-  runner.Step(TimeSpan.FromMilliseconds(50))
+// Feed client inputs as they arrive from the network
+server.MessageReceived.Add(fun (clientId, bytes) ->
+  runner.Dispatch(ClientInput(clientId, deserialize bytes)))
 
-  // In a real server, you'd receive client inputs here
-  // runner.Dispatch(ClientInput(clientId, input))
+// Run the server loop — RunAsync paces ticks, the observer broadcasts
+for (_, _) in runner.Run(TimeSpan.FromMilliseconds(50)) do
+  () // The observer handles the broadcast
 ```

--- a/samples/PingPong/Client/Client.fsproj
+++ b/samples/PingPong/Client/Client.fsproj
@@ -6,8 +6,8 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="NetworkService.fs" />
     <Compile Include="Types.fs" />
+    <Compile Include="NetworkService.fs" />
     <Compile Include="View.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>

--- a/samples/PingPong/Client/Client.fsproj
+++ b/samples/PingPong/Client/Client.fsproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NetworkService.fs" />
+    <Compile Include="Types.fs" />
+    <Compile Include="View.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.fsproj" />
+    <ProjectReference Include="..\..\..\src\Mibo.Raylib\Mibo.Raylib.fsproj" />
+  </ItemGroup>
+</Project>

--- a/samples/PingPong/Client/NetworkService.fs
+++ b/samples/PingPong/Client/NetworkService.fs
@@ -3,81 +3,181 @@ module PingPong.Client.NetworkService
 open System
 open System.Net.WebSockets
 open System.Threading
+open FSharp.Control
 open PingPong.Shared.Types
-open FSharp.UMX
+open PingPong.Client.Types
 
-// ── WebSocket Client Implementation ────────────────────────────────────────
+type private ClientCommand =
+  | SendData of data: byte[]
+  | Shutdown
 
-type WebSocketClient() as this =
-    let mutable ws: WebSocket option = None
-    let mutable currentState: ConnectionState = Disconnected
-    let cts = new CancellationTokenSource()
+/// <summary>
+/// Creates a WebSocket client hidden behind IClientTransport.
+/// Sends are serialized through a MailboxProcessor to avoid blocking
+/// the game loop and prevent concurrent SendAsync on the socket.
+/// </summary>
+/// <param name="onHandshake">
+/// Called with the first message received after the WebSocket connects.
+/// The return value is stored and accessible via the second tuple element.
+/// The transport does not signal <c>Connected</c> until this callback
+/// returns, so handshake data is always available before any subscriber
+/// observes the connected state.
+/// </param>
+/// <returns>
+/// The transport and a getter for the handshake data.
+/// </returns>
+let createWebSocketClient
+  (onHandshake: byte[] -> 'handshake)
+  : IClientTransport * (unit -> 'handshake) =
 
-    let stateChanged = Event<ConnectionState>()
-    let messageReceived = Event<int<peerId> * byte[]>()
+  let mutable ws: WebSocket option = None
+  let mutable currentState: ConnectionState = Disconnected
+  let mutable handshakeData: 'handshake = Unchecked.defaultof<'handshake>
+  let cts = new CancellationTokenSource()
 
-    let mutable assignedPeerId: int<peerId> = 0<peerId>
+  let stateChanged = Event<ConnectionState>()
+  let messageReceived = Event<byte[]>()
 
-    let receiveLoop (ws: WebSocket) = async {
-        let buffer = Array.zeroCreate<byte> 4096
-        try
-            while ws.State = WebSocketState.Open && not cts.IsCancellationRequested do
-                let! result = ws.ReceiveAsync(ArraySegment(buffer), cts.Token) |> Async.AwaitTask
-                if result.MessageType = WebSocketMessageType.Binary then
-                    let data = buffer.[0..result.Count - 1]
-                    messageReceived.Trigger(assignedPeerId, data)
-        with _ ->
-            currentState <- Disconnected
-            stateChanged.Trigger(currentState)
+  let sendTo (s: WebSocket) (data: byte[]) = async {
+    if s.State = WebSocketState.Open then
+      try
+        do!
+          s.SendAsync(
+            ArraySegment data,
+            WebSocketMessageType.Binary,
+            true,
+            cts.Token
+          )
+          |> Async.AwaitTask
+      with
+      | :? WebSocketException
+      | :? OperationCanceledException
+      | :? ObjectDisposedException -> ()
+  }
+
+  let agentBody(inbox: MailboxProcessor<ClientCommand>) =
+    let rec loop() = async {
+      let! cmd = inbox.Receive()
+
+      match cmd with
+      | SendData(data) ->
+        match ws with
+        | Some s -> do! sendTo s data
+        | None -> ()
+
+        return! loop()
+
+      | Shutdown -> ()
     }
 
-    member _.Start(address: string) =
-        async {
-            let client = new ClientWebSocket()
-            do! client.ConnectAsync(Uri(address), cts.Token) |> Async.AwaitTask
-            ws <- Some client
-            // First message from server is our assigned peer ID (4 bytes)
-            let idBuffer = Array.zeroCreate<byte> 4
-            let! result = client.ReceiveAsync(System.ArraySegment(idBuffer), cts.Token) |> Async.AwaitTask
-            let peerId = System.BitConverter.ToInt32(idBuffer, 0) |> UMX.tag<peerId>
-            assignedPeerId <- peerId
-            currentState <- Connected peerId
-            stateChanged.Trigger(currentState)
-            Async.Start(receiveLoop client, cts.Token)
-        } |> Async.Start
+    loop()
 
-    member _.Stop() =
-        cts.Cancel()
-        match ws with
-        | Some s when s.State = WebSocketState.Open ->
-            try
-                s.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None)
-                |> fun t -> t.Wait()
-                s.Dispose()
-            with _ -> ()
-        | _ -> ()
-        ws <- None
-        currentState <- Disconnected
-        stateChanged.Trigger(currentState)
+  let agent = MailboxProcessor.Start(agentBody, cancellationToken = cts.Token)
 
-    interface INetworkService with
+  let receiveLoop(s: WebSocket) = async {
+    let buffer = Array.zeroCreate<byte> 4096
+
+    try
+      try
+        while s.State = WebSocketState.Open && not cts.IsCancellationRequested do
+          let! result =
+            s.ReceiveAsync(ArraySegment(buffer), cts.Token) |> Async.AwaitTask
+
+          if result.MessageType = WebSocketMessageType.Binary then
+            messageReceived.Trigger(buffer.[0 .. result.Count - 1])
+      with ex ->
+        Console.WriteLine $"receiveLoop error: {ex}"
+    finally
+      currentState <- Disconnected
+      stateChanged.Trigger Disconnected
+  }
+
+  let connect(address: string) =
+    async {
+      currentState <- Connecting
+      stateChanged.Trigger Connecting
+
+      let client = new ClientWebSocket()
+      do! client.ConnectAsync(Uri(address), cts.Token) |> Async.AwaitTask
+      ws <- Some client
+
+      // Consume the handshake (first message) BEFORE signaling Connected.
+      // This ensures handshake data is available before any subscriber
+      // observes the connected state, eliminating the race between
+      // early message delivery and subscription setup.
+      let handshakeBuffer = Array.zeroCreate<byte> 4096
+
+      let! result =
+        client.ReceiveAsync(ArraySegment(handshakeBuffer), cts.Token)
+        |> Async.AwaitTask
+
+      handshakeData <- onHandshake(handshakeBuffer.[0 .. result.Count - 1])
+
+      currentState <- Connected
+      stateChanged.Trigger Connected
+      Async.Start(receiveLoop client, cts.Token)
+    }
+    |> Async.Start
+
+  let disconnect() =
+    match ws with
+    | Some s when s.State = WebSocketState.Open ->
+      try
+        s.CloseOutputAsync(
+          WebSocketCloseStatus.NormalClosure,
+          "",
+          CancellationToken.None
+        )
+        |> fun t -> t.Wait()
+      with
+      | :? WebSocketException
+      | :? OperationCanceledException
+      | :? ObjectDisposedException -> ()
+    | _ -> ()
+
+    cts.Cancel()
+    agent.Post Shutdown
+
+    ws
+    |> Option.iter(fun s ->
+      try
+        s.Dispose()
+      with
+      | :? WebSocketException
+      | :? OperationCanceledException
+      | :? ObjectDisposedException -> ())
+
+    ws <- None
+    currentState <- Disconnected
+    stateChanged.Trigger Disconnected
+
+  let transport =
+    { new IClientTransport with
         member _.State = currentState
         member _.StateChanged = stateChanged.Publish :> IObservable<_>
-        member _.MessageReceived = messageReceived.Publish :> IObservable<_>
+        member _.MessageReceived = upcast messageReceived.Publish
+        member _.Send(data) = agent.Post(SendData data)
+        member _.Connect(address) = connect address
+        member _.Disconnect() = disconnect()
+    }
 
-        member _.Send(_, data) =
-            match ws with
-            | Some s when s.State = WebSocketState.Open ->
-                try
-                    s.SendAsync(
-                        ArraySegment(data),
-                        WebSocketMessageType.Binary,
-                        true,
-                        cts.Token
-                    ) |> fun t -> t.Wait()
-                with _ -> ()
-            | _ -> ()
+  (transport, fun () -> handshakeData)
 
-        member _.Broadcast(data) = (this :> INetworkService).Send(1<peerId>, data)
-        member _.Connect(address) = this.Start(address)
-        member _.Disconnect() = this.Stop()
+
+module Network =
+  open Mibo.Elmish
+  open PingPong.Shared.Serialization
+
+  let send (transport: IClientTransport) msg =
+    Cmd.ofEffect(
+      Effect<_>(fun _ ->
+        let bytes = serializeClientMsg msg
+        transport.Send(bytes))
+    )
+
+  let subscribeState (transport: IClientTransport) msg dispatch =
+    match transport.State with
+    | Connected as state -> dispatch(msg state)
+    | _ -> ()
+
+    transport.StateChanged.Subscribe(fun state -> state |> msg |> dispatch)

--- a/samples/PingPong/Client/NetworkService.fs
+++ b/samples/PingPong/Client/NetworkService.fs
@@ -98,24 +98,37 @@ let createWebSocketClient
       stateChanged.Trigger Connecting
 
       let client = new ClientWebSocket()
-      do! client.ConnectAsync(Uri(address), cts.Token) |> Async.AwaitTask
-      ws <- Some client
 
-      // Consume the handshake (first message) BEFORE signaling Connected.
-      // This ensures handshake data is available before any subscriber
-      // observes the connected state, eliminating the race between
-      // early message delivery and subscription setup.
-      let handshakeBuffer = Array.zeroCreate<byte> 4096
+      try
+        do! client.ConnectAsync(Uri(address), cts.Token) |> Async.AwaitTask
+        ws <- Some client
 
-      let! result =
-        client.ReceiveAsync(ArraySegment(handshakeBuffer), cts.Token)
-        |> Async.AwaitTask
+        // Consume the handshake (first message) BEFORE signaling Connected.
+        // This ensures handshake data is available before any subscriber
+        // observes the connected state, eliminating the race between
+        // early message delivery and subscription setup.
+        let handshakeBuffer = Array.zeroCreate<byte> 4096
 
-      handshakeData <- onHandshake(handshakeBuffer.[0 .. result.Count - 1])
+        let! result =
+          client.ReceiveAsync(ArraySegment(handshakeBuffer), cts.Token)
+          |> Async.AwaitTask
 
-      currentState <- Connected
-      stateChanged.Trigger Connected
-      Async.Start(receiveLoop client, cts.Token)
+        handshakeData <- onHandshake(handshakeBuffer.[0 .. result.Count - 1])
+
+        currentState <- Connected
+        stateChanged.Trigger Connected
+        Async.Start(receiveLoop client, cts.Token)
+      with ex ->
+        Console.WriteLine $"connect error: {ex}"
+        ws <- None
+
+        try
+          client.Dispose()
+        with _ ->
+          ()
+
+        currentState <- Disconnected
+        stateChanged.Trigger Disconnected
     }
     |> Async.Start
 

--- a/samples/PingPong/Client/NetworkService.fs
+++ b/samples/PingPong/Client/NetworkService.fs
@@ -1,0 +1,83 @@
+module PingPong.Client.NetworkService
+
+open System
+open System.Net.WebSockets
+open System.Threading
+open PingPong.Shared.Types
+open FSharp.UMX
+
+// ── WebSocket Client Implementation ────────────────────────────────────────
+
+type WebSocketClient() as this =
+    let mutable ws: WebSocket option = None
+    let mutable currentState: ConnectionState = Disconnected
+    let cts = new CancellationTokenSource()
+
+    let stateChanged = Event<ConnectionState>()
+    let messageReceived = Event<int<peerId> * byte[]>()
+
+    let mutable assignedPeerId: int<peerId> = 0<peerId>
+
+    let receiveLoop (ws: WebSocket) = async {
+        let buffer = Array.zeroCreate<byte> 4096
+        try
+            while ws.State = WebSocketState.Open && not cts.IsCancellationRequested do
+                let! result = ws.ReceiveAsync(ArraySegment(buffer), cts.Token) |> Async.AwaitTask
+                if result.MessageType = WebSocketMessageType.Binary then
+                    let data = buffer.[0..result.Count - 1]
+                    messageReceived.Trigger(assignedPeerId, data)
+        with _ ->
+            currentState <- Disconnected
+            stateChanged.Trigger(currentState)
+    }
+
+    member _.Start(address: string) =
+        async {
+            let client = new ClientWebSocket()
+            do! client.ConnectAsync(Uri(address), cts.Token) |> Async.AwaitTask
+            ws <- Some client
+            // First message from server is our assigned peer ID (4 bytes)
+            let idBuffer = Array.zeroCreate<byte> 4
+            let! result = client.ReceiveAsync(System.ArraySegment(idBuffer), cts.Token) |> Async.AwaitTask
+            let peerId = System.BitConverter.ToInt32(idBuffer, 0) |> UMX.tag<peerId>
+            assignedPeerId <- peerId
+            currentState <- Connected peerId
+            stateChanged.Trigger(currentState)
+            Async.Start(receiveLoop client, cts.Token)
+        } |> Async.Start
+
+    member _.Stop() =
+        cts.Cancel()
+        match ws with
+        | Some s when s.State = WebSocketState.Open ->
+            try
+                s.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None)
+                |> fun t -> t.Wait()
+                s.Dispose()
+            with _ -> ()
+        | _ -> ()
+        ws <- None
+        currentState <- Disconnected
+        stateChanged.Trigger(currentState)
+
+    interface INetworkService with
+        member _.State = currentState
+        member _.StateChanged = stateChanged.Publish :> IObservable<_>
+        member _.MessageReceived = messageReceived.Publish :> IObservable<_>
+
+        member _.Send(_, data) =
+            match ws with
+            | Some s when s.State = WebSocketState.Open ->
+                try
+                    s.SendAsync(
+                        ArraySegment(data),
+                        WebSocketMessageType.Binary,
+                        true,
+                        cts.Token
+                    ) |> fun t -> t.Wait()
+                with _ -> ()
+            | _ -> ()
+
+        member _.Broadcast(data) = (this :> INetworkService).Send(1<peerId>, data)
+        member _.Connect(address) = this.Start(address)
+        member _.Disconnect() = this.Stop()

--- a/samples/PingPong/Client/Program.fs
+++ b/samples/PingPong/Client/Program.fs
@@ -1,116 +1,163 @@
 module PingPong.Client.Program
 
 open System
-open System.Numerics
 open Mibo.Elmish
 open Mibo.Elmish.Graphics2D
 open PingPong.Shared.Types
+open PingPong.Shared.Physics
 open PingPong.Shared.Serialization
+open PingPong.Client.Types
 open PingPong.Client.NetworkService
 open PingPong.Client.View
-
-// ── Model ──────────────────────────────────────────────────────────────────
-
-type Model = {
-  GameState: GameState
-  Connected: bool
-  PeerId: int<peerId>
-}
-
-// ── Messages ───────────────────────────────────────────────────────────────
-
-type Msg =
-  | ServerState of byte[]
-  | ConnectionChanged of ConnectionState
-  | LocalInput of float32
-  | Tick of GameTime
+open FSharp.UMX
 
 // ── Env ────────────────────────────────────────────────────────────────────
 
-type Env = { Network: INetworkService }
+type Env = { Network: IClientTransport }
 
 // ── Elmish Logic ───────────────────────────────────────────────────────────
 
-let init ctx =
-  struct ({
-            GameState = initGameState 800f 800f
-            Connected = false
-            PeerId = 0<peerId>
-          },
-          Cmd.none)
+let init ctx : struct (Model * Cmd<_>) =
+  {
+    LocalState = initGameState 800f 800f
+    ServerState = ValueNone
+    AssignedPaddle = ValueNone
+    Connected = false
+    PeerId = 0<peerId>
+  },
+  Cmd.none
 
-let update env msg model =
+let update env msg model : struct (Model * Cmd<_>) =
   match msg with
-  | ConnectionChanged state ->
+  | ConnectionChanged(state, peerId, side) ->
     match state with
-    | Connected peerId ->
-      struct ({
-                model with
-                    Connected = true
-                    PeerId = peerId
-              },
-              Cmd.none)
-    | _ -> struct ({ model with Connected = false }, Cmd.none)
+    | Connected ->
+      {
+        model with
+            Connected = true
+            PeerId = peerId
+            AssignedPaddle = side
+      },
+      Cmd.none
+    | _ -> { model with Connected = false }, Cmd.none
 
-  | ServerState bytes ->
-    let serverState = deserializeGameState bytes
-    struct ({ model with GameState = serverState }, Cmd.none)
+  | ServerState serverState ->
+    let local = model.LocalState
+
+    let syncedBall = serverState.Ball
+
+    let leftPaddle =
+      match model.AssignedPaddle with
+      | ValueSome Left -> local.LeftPaddle
+      | _ ->
+          {
+            local.LeftPaddle with
+                Y = lerp local.LeftPaddle.Y serverState.LeftPaddle.Y 0.3f
+          }
+
+    let rightPaddle =
+      match model.AssignedPaddle with
+      | ValueSome Right -> local.RightPaddle
+      | _ ->
+          {
+            local.RightPaddle with
+                Y = lerp local.RightPaddle.Y serverState.RightPaddle.Y 0.3f
+          }
+
+    let synced = {
+      local with
+          Ball = syncedBall
+          LeftPaddle = leftPaddle
+          RightPaddle = rightPaddle
+          Scores = serverState.Scores
+    }
+
+    {
+      model with
+          LocalState = synced
+          ServerState = ValueSome serverState
+    },
+    Cmd.none
 
   | LocalInput mouseY ->
-    if model.Connected then
-      let side = if model.PeerId = 1<peerId> then Left else Right
-      let bytes = serializeClientMsg(MovePaddle(side, mouseY))
+    match model.AssignedPaddle with
+    | ValueSome side ->
+      let clampedY = clampPaddle model.LocalState.Height mouseY
 
-      struct (model,
-              Cmd.ofEffect(
-                Effect<Msg>(fun _ ->
-                  env.Network.Send(model.PeerId, bytes))
-              ))
-    else
-      struct (model, Cmd.none)
+      let localState =
+        match side with
+        | Left -> {
+            model.LocalState with
+                LeftPaddle = {
+                  model.LocalState.LeftPaddle with
+                      Y = clampedY
+                }
+          }
+        | Right ->
+            {
+              model.LocalState with
+                  RightPaddle = {
+                    model.LocalState.RightPaddle with
+                        Y = clampedY
+                  }
+            }
 
-  | Tick _ -> struct (model, Cmd.none)
+      { model with LocalState = localState },
+      Network.send env.Network (MovePaddle(side, mouseY))
+    | ValueNone -> model, Cmd.none
 
 // ── Subscriptions ──────────────────────────────────────────────────────────
 
-let subscribe (net: INetworkService) ctx model =
-  let networkSub =
-    Sub.Active(
-      SubId.ofString "network",
-      fun dispatch ->
-        net.MessageReceived.Subscribe(fun (_, bytes) ->
-          dispatch(ServerState bytes))
-    )
-
+let subscribe
+  (transport: IClientTransport)
+  (getHandshake: unit -> struct (int<peerId> * PaddleSide voption))
+  ctx
+  model
+  =
   let stateSub =
     Sub.Active(
       SubId.ofString "network/state",
-      fun dispatch ->
-        // If already connected by the time subscription starts, dispatch now
-        match net.State with
-        | Connected _ as state -> dispatch(ConnectionChanged state)
-        | _ -> ()
-        net.StateChanged.Subscribe(fun state ->
-          dispatch(ConnectionChanged state))
+      Network.subscribeState transport (fun state ->
+        match state with
+        | Connected ->
+          let struct (peerId, side) = getHandshake()
+          ConnectionChanged(Connected, peerId, side)
+        | other -> ConnectionChanged(other, 0<peerId>, ValueNone))
     )
 
-  let inputSub =
-    Mibo.Input.Mouse.onMove (fun pos -> LocalInput pos.Y) ctx
+  let msgSub =
+    Sub.Active(
+      SubId.ofString "network/messages",
+      fun dispatch ->
+        transport.MessageReceived.Subscribe(fun bytes ->
+          deserializeGameState bytes |> ServerState |> dispatch)
+    )
 
-  Sub.batch [ networkSub; stateSub; inputSub ]
+  let inputSub = Mibo.Input.Mouse.onMove (fun pos -> LocalInput pos.Y) ctx
+
+  Sub.batch [ stateSub; msgSub; inputSub ]
 
 // ── Program ────────────────────────────────────────────────────────────────
 
 [<EntryPoint>]
 let main _args =
-  let net = new WebSocketClient() :> INetworkService
+  let transport, getHandshake =
+    createWebSocketClient(fun bytes ->
+      let peerId = BitConverter.ToInt32(bytes, 0) |> UMX.tag<peerId>
 
-  let env = { Network = net }
+      let side =
+        match bytes[4] with
+        | 0uy -> ValueSome Left
+        | 1uy -> ValueSome Right
+        | _ -> ValueNone
+
+      struct (peerId, side))
+
+  let env = { Network = transport }
 
   let program =
     Program.mkProgram init (update env)
-    |> Program.withSubscription(subscribe net)
-    |> Program.withTick Tick
+    |> Program.withSubscription(subscribe transport getHandshake)
     |> Program.withInput
     |> Program.withConfig(fun cfg -> {
       cfg with
@@ -120,14 +167,12 @@ let main _args =
           TargetFPS = 60
     })
     |> Program.withRenderer(fun () ->
-      Renderer2D.create(fun c m b -> view c m.GameState b))
+      Renderer2D.create(fun c m b -> view c m.LocalState b))
 
-  // Connect to server
-  net.Connect("ws://localhost:5000")
+  transport.Connect("ws://localhost:5000")
 
-  // Run game
   let game = new RaylibGame<Model, Msg>(program)
   game.Run()
 
-  net.Disconnect()
+  transport.Disconnect()
   0

--- a/samples/PingPong/Client/Program.fs
+++ b/samples/PingPong/Client/Program.fs
@@ -1,0 +1,133 @@
+module PingPong.Client.Program
+
+open System
+open System.Numerics
+open Mibo.Elmish
+open Mibo.Elmish.Graphics2D
+open PingPong.Shared.Types
+open PingPong.Shared.Serialization
+open PingPong.Client.NetworkService
+open PingPong.Client.View
+
+// ── Model ──────────────────────────────────────────────────────────────────
+
+type Model = {
+  GameState: GameState
+  Connected: bool
+  PeerId: int<peerId>
+}
+
+// ── Messages ───────────────────────────────────────────────────────────────
+
+type Msg =
+  | ServerState of byte[]
+  | ConnectionChanged of ConnectionState
+  | LocalInput of float32
+  | Tick of GameTime
+
+// ── Env ────────────────────────────────────────────────────────────────────
+
+type Env = { Network: INetworkService }
+
+// ── Elmish Logic ───────────────────────────────────────────────────────────
+
+let init ctx =
+  struct ({
+            GameState = initGameState 800f 800f
+            Connected = false
+            PeerId = 0<peerId>
+          },
+          Cmd.none)
+
+let update env msg model =
+  match msg with
+  | ConnectionChanged state ->
+    match state with
+    | Connected peerId ->
+      struct ({
+                model with
+                    Connected = true
+                    PeerId = peerId
+              },
+              Cmd.none)
+    | _ -> struct ({ model with Connected = false }, Cmd.none)
+
+  | ServerState bytes ->
+    let serverState = deserializeGameState bytes
+    struct ({ model with GameState = serverState }, Cmd.none)
+
+  | LocalInput mouseY ->
+    if model.Connected then
+      let side = if model.PeerId = 1<peerId> then Left else Right
+      let bytes = serializeClientMsg(MovePaddle(side, mouseY))
+
+      struct (model,
+              Cmd.ofEffect(
+                Effect<Msg>(fun _ ->
+                  env.Network.Send(model.PeerId, bytes))
+              ))
+    else
+      struct (model, Cmd.none)
+
+  | Tick _ -> struct (model, Cmd.none)
+
+// ── Subscriptions ──────────────────────────────────────────────────────────
+
+let subscribe (net: INetworkService) ctx model =
+  let networkSub =
+    Sub.Active(
+      SubId.ofString "network",
+      fun dispatch ->
+        net.MessageReceived.Subscribe(fun (_, bytes) ->
+          dispatch(ServerState bytes))
+    )
+
+  let stateSub =
+    Sub.Active(
+      SubId.ofString "network/state",
+      fun dispatch ->
+        // If already connected by the time subscription starts, dispatch now
+        match net.State with
+        | Connected _ as state -> dispatch(ConnectionChanged state)
+        | _ -> ()
+        net.StateChanged.Subscribe(fun state ->
+          dispatch(ConnectionChanged state))
+    )
+
+  let inputSub =
+    Mibo.Input.Mouse.onMove (fun pos -> LocalInput pos.Y) ctx
+
+  Sub.batch [ networkSub; stateSub; inputSub ]
+
+// ── Program ────────────────────────────────────────────────────────────────
+
+[<EntryPoint>]
+let main _args =
+  let net = new WebSocketClient() :> INetworkService
+
+  let env = { Network = net }
+
+  let program =
+    Program.mkProgram init (update env)
+    |> Program.withSubscription(subscribe net)
+    |> Program.withTick Tick
+    |> Program.withInput
+    |> Program.withConfig(fun cfg -> {
+      cfg with
+          Title = "Ping Pong - Client"
+          Width = 800
+          Height = 800
+          TargetFPS = 60
+    })
+    |> Program.withRenderer(fun () ->
+      Renderer2D.create(fun c m b -> view c m.GameState b))
+
+  // Connect to server
+  net.Connect("ws://localhost:5000")
+
+  // Run game
+  let game = new RaylibGame<Model, Msg>(program)
+  game.Run()
+
+  net.Disconnect()
+  0

--- a/samples/PingPong/Client/Types.fs
+++ b/samples/PingPong/Client/Types.fs
@@ -1,13 +1,34 @@
 module PingPong.Client.Types
 
+open System
 open PingPong.Shared.Types
-open Mibo.Elmish
 
+// ── Connection State (client-only) ─────────────────────────────────────────
+
+[<Struct>]
+type ConnectionState =
+  | Disconnected
+  | Connecting
+  | Connected
+  | Reconnecting
+
+// ── Client Transport (client-only) ─────────────────────────────────────────
+// Point-to-point pipe to a single server. No peer multiplexing.
+
+type IClientTransport =
+  abstract State: ConnectionState
+  abstract StateChanged: IObservable<ConnectionState>
+  abstract MessageReceived: IObservable<byte[]>
+  abstract Send: data: byte[] -> unit
+  abstract Connect: address: string -> unit
+  abstract Disconnect: unit -> unit
 
 // ── Model ──────────────────────────────────────────────────────────────────
 
 type Model = {
-  GameState: GameState
+  LocalState: GameState
+  ServerState: GameState voption
+  AssignedPaddle: PaddleSide voption
   Connected: bool
   PeerId: int<peerId>
 }
@@ -15,7 +36,9 @@ type Model = {
 // ── Messages ───────────────────────────────────────────────────────────────
 
 type Msg =
-  | ServerState of byte[]
-  | ConnectionChanged of ConnectionState
+  | ConnectionChanged of
+    state: ConnectionState *
+    peerId: int<peerId> *
+    side: PaddleSide voption
+  | ServerState of GameState
   | LocalInput of float32
-  | Tick of GameTime

--- a/samples/PingPong/Client/Types.fs
+++ b/samples/PingPong/Client/Types.fs
@@ -1,0 +1,21 @@
+module PingPong.Client.Types
+
+open PingPong.Shared.Types
+open Mibo.Elmish
+
+
+// ── Model ──────────────────────────────────────────────────────────────────
+
+type Model = {
+  GameState: GameState
+  Connected: bool
+  PeerId: int<peerId>
+}
+
+// ── Messages ───────────────────────────────────────────────────────────────
+
+type Msg =
+  | ServerState of byte[]
+  | ConnectionChanged of ConnectionState
+  | LocalInput of float32
+  | Tick of GameTime

--- a/samples/PingPong/Client/View.fs
+++ b/samples/PingPong/Client/View.fs
@@ -6,12 +6,6 @@ open Mibo.Elmish
 open Mibo.Elmish.Graphics2D
 open PingPong.Shared.Types
 
-// ── Constants ──────────────────────────────────────────────────────────────
-
-let paddleWidth = 10f
-let paddleHeight = 80f
-let ballRadius = 8f
-
 // ── View ───────────────────────────────────────────────────────────────────
 
 let view (_ctx: GameContext) (model: GameState) (buffer: RenderBuffer2D) =

--- a/samples/PingPong/Client/View.fs
+++ b/samples/PingPong/Client/View.fs
@@ -1,0 +1,50 @@
+module PingPong.Client.View
+
+open System.Numerics
+open Raylib_cs
+open Mibo.Elmish
+open Mibo.Elmish.Graphics2D
+open PingPong.Shared.Types
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+let paddleWidth = 10f
+let paddleHeight = 80f
+let ballRadius = 8f
+
+// ── View ───────────────────────────────────────────────────────────────────
+
+let view (_ctx: GameContext) (model: GameState) (buffer: RenderBuffer2D) =
+  // Draw paddles
+  Command2D.fillRect
+    (0<RenderLayer>, Color.White)
+    (Rectangle(
+      0f,
+      model.LeftPaddle.Y - paddleHeight / 2f,
+      paddleWidth,
+      paddleHeight
+    ))
+  |> buffer.Add
+
+  Command2D.fillRect
+    (0<RenderLayer>, Color.White)
+    (Rectangle(
+      model.Width - paddleWidth,
+      model.RightPaddle.Y - paddleHeight / 2f,
+      paddleWidth,
+      paddleHeight
+    ))
+  |> buffer.Add
+
+  // Draw ball
+  Command2D.fillCircle
+    (0<RenderLayer>, Color.White)
+    (Vector2(model.Ball.Position.X, model.Ball.Position.Y), ballRadius)
+  |> buffer.Add
+
+  // Draw center line
+  for y in 0.0f .. 20.0f .. model.Height do
+    Command2D.fillRect
+      (0<RenderLayer>, Color.Gray)
+      (Rectangle(model.Width / 2f - 1f, y, 2f, 10f))
+    |> buffer.Add

--- a/samples/PingPong/PingPong.sln
+++ b/samples/PingPong/PingPong.sln
@@ -1,0 +1,31 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shared", "Shared\Shared.fsproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Server", "Server\Server.fsproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Client", "Client\Client.fsproj", "{C3D4E5F6-A7B8-9012-CDEF-123456789012}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3D4E5F6-A7B8-9012-CDEF-123456789012}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/samples/PingPong/Server/GameLogic.fs
+++ b/samples/PingPong/Server/GameLogic.fs
@@ -1,9 +1,8 @@
 module PingPong.Server.GameLogic
 
-open System
-open System.Numerics
 open Mibo.Elmish
 open PingPong.Shared.Types
+open PingPong.Shared.Physics
 
 // ── Server Messages ────────────────────────────────────────────────────────
 
@@ -11,116 +10,32 @@ type ServerMsg =
   | FromClient of int<peerId> * ClientMsg
   | GameTick
 
-// ── Physics Constants ──────────────────────────────────────────────────────
-
-let paddleWidth = 10f
-let paddleHeight = 80f
-let ballRadius = 8f
-
-// ── Update Logic ───────────────────────────────────────────────────────────
-
-let updateBall
-  (ball: Ball)
-  (leftPaddle: Paddle)
-  (rightPaddle: Paddle)
-  (dt: float32)
-  : Ball =
-  let mutable pos = ball.Position + ball.Velocity * dt
-  let mutable vel = ball.Velocity
-
-  // Top/bottom walls
-  if pos.Y - ballRadius < 0f then
-    pos <- Vector2(pos.X, ballRadius)
-    vel <- Vector2(vel.X, -vel.Y)
-  elif pos.Y + ballRadius > 800f then
-    pos <- Vector2(pos.X, 800f - ballRadius)
-    vel <- Vector2(vel.X, -vel.Y)
-
-  // Left paddle collision
-  if vel.X < 0f then
-    let paddleRight = paddleWidth
-
-    if pos.X - ballRadius < paddleRight && pos.X + ballRadius > 0f then
-      if
-        pos.Y > leftPaddle.Y - paddleHeight / 2f
-        && pos.Y < leftPaddle.Y + paddleHeight / 2f
-      then
-        pos <- Vector2(paddleRight + ballRadius, pos.Y)
-        vel <- Vector2(-vel.X, vel.Y)
-
-  // Right paddle collision
-  if vel.X > 0f then
-    let paddleLeft = 800f - paddleWidth
-
-    if pos.X + ballRadius > paddleLeft && pos.X - ballRadius < 800f then
-      if
-        pos.Y > rightPaddle.Y - paddleHeight / 2f
-        && pos.Y < rightPaddle.Y + paddleHeight / 2f
-      then
-        pos <- Vector2(paddleLeft - ballRadius, pos.Y)
-        vel <- Vector2(-vel.X, vel.Y)
-
-  { Position = pos; Velocity = vel }
-
-let clampPaddle(y: float32) : float32 =
-  let halfHeight = paddleHeight / 2f
-  max halfHeight (min (800f - halfHeight) y)
-
-let step (model: GameState) (dt: float32) : GameState =
-  let newBall = updateBall model.Ball model.LeftPaddle model.RightPaddle dt
-
-  // Check for scoring
-  let mutable scores = model.Scores
-  let mutable newBall' = newBall
-  let rng = Random()
-
-  if newBall.Position.X < 0f then
-    scores <- { scores with Right = scores.Right + 1 }
-    let yDir = if rng.NextDouble() > 0.5 then 1.0f else -1.0f
-
-    newBall' <- {
-      Position = Vector2(model.Width / 2f, model.Height / 2f)
-      Velocity = Vector2(300f, 200f * yDir)
-    }
-  elif newBall.Position.X > model.Width then
-    scores <- { scores with Left = scores.Left + 1 }
-    let yDir = if rng.NextDouble() > 0.5 then 1.0f else -1.0f
-
-    newBall' <- {
-      Position = Vector2(model.Width / 2f, model.Height / 2f)
-      Velocity = Vector2(-300f, 200f * yDir)
-    }
-
-  {
-    model with
-        Ball = newBall'
-        Scores = scores
-  }
-
 // ── Elmish Update ──────────────────────────────────────────────────────────
 
-let init ctx =
+let private rng = System.Random()
+
+let init ctx : struct (_ * Cmd<_>) =
   struct (initGameState 800f 800f, Cmd.none)
 
-let update msg model =
+let update msg model : struct (_ * Cmd<_>) =
   match msg with
-  | GameTick -> struct (step model (1f / 60f), Cmd.none)
+  | GameTick -> step rng model (1f / 60f), Cmd.none
 
   | FromClient(_, clientMsg) ->
     match clientMsg with
     | MovePaddle(side, y) ->
-      let clampedY = clampPaddle y
+      let clampedY = clampPaddle model.Height y
 
       match side with
       | Left ->
-        struct ({
-                  model with
-                      LeftPaddle = { model.LeftPaddle with Y = clampedY }
-                },
-                Cmd.none)
+        {
+          model with
+              LeftPaddle = { model.LeftPaddle with Y = clampedY }
+        },
+        Cmd.none
       | Right ->
-        struct ({
-                  model with
-                      RightPaddle = { model.RightPaddle with Y = clampedY }
-                },
-                Cmd.none)
+        {
+          model with
+              RightPaddle = { model.RightPaddle with Y = clampedY }
+        },
+        Cmd.none

--- a/samples/PingPong/Server/GameLogic.fs
+++ b/samples/PingPong/Server/GameLogic.fs
@@ -1,0 +1,126 @@
+module PingPong.Server.GameLogic
+
+open System
+open System.Numerics
+open Mibo.Elmish
+open PingPong.Shared.Types
+
+// ── Server Messages ────────────────────────────────────────────────────────
+
+type ServerMsg =
+  | FromClient of int<peerId> * ClientMsg
+  | GameTick
+
+// ── Physics Constants ──────────────────────────────────────────────────────
+
+let paddleWidth = 10f
+let paddleHeight = 80f
+let ballRadius = 8f
+
+// ── Update Logic ───────────────────────────────────────────────────────────
+
+let updateBall
+  (ball: Ball)
+  (leftPaddle: Paddle)
+  (rightPaddle: Paddle)
+  (dt: float32)
+  : Ball =
+  let mutable pos = ball.Position + ball.Velocity * dt
+  let mutable vel = ball.Velocity
+
+  // Top/bottom walls
+  if pos.Y - ballRadius < 0f then
+    pos <- Vector2(pos.X, ballRadius)
+    vel <- Vector2(vel.X, -vel.Y)
+  elif pos.Y + ballRadius > 800f then
+    pos <- Vector2(pos.X, 800f - ballRadius)
+    vel <- Vector2(vel.X, -vel.Y)
+
+  // Left paddle collision
+  if vel.X < 0f then
+    let paddleRight = paddleWidth
+
+    if pos.X - ballRadius < paddleRight && pos.X + ballRadius > 0f then
+      if
+        pos.Y > leftPaddle.Y - paddleHeight / 2f
+        && pos.Y < leftPaddle.Y + paddleHeight / 2f
+      then
+        pos <- Vector2(paddleRight + ballRadius, pos.Y)
+        vel <- Vector2(-vel.X, vel.Y)
+
+  // Right paddle collision
+  if vel.X > 0f then
+    let paddleLeft = 800f - paddleWidth
+
+    if pos.X + ballRadius > paddleLeft && pos.X - ballRadius < 800f then
+      if
+        pos.Y > rightPaddle.Y - paddleHeight / 2f
+        && pos.Y < rightPaddle.Y + paddleHeight / 2f
+      then
+        pos <- Vector2(paddleLeft - ballRadius, pos.Y)
+        vel <- Vector2(-vel.X, vel.Y)
+
+  { Position = pos; Velocity = vel }
+
+let clampPaddle(y: float32) : float32 =
+  let halfHeight = paddleHeight / 2f
+  max halfHeight (min (800f - halfHeight) y)
+
+let step (model: GameState) (dt: float32) : GameState =
+  let newBall = updateBall model.Ball model.LeftPaddle model.RightPaddle dt
+
+  // Check for scoring
+  let mutable scores = model.Scores
+  let mutable newBall' = newBall
+  let rng = Random()
+
+  if newBall.Position.X < 0f then
+    scores <- { scores with Right = scores.Right + 1 }
+    let yDir = if rng.NextDouble() > 0.5 then 1.0f else -1.0f
+
+    newBall' <- {
+      Position = Vector2(model.Width / 2f, model.Height / 2f)
+      Velocity = Vector2(300f, 200f * yDir)
+    }
+  elif newBall.Position.X > model.Width then
+    scores <- { scores with Left = scores.Left + 1 }
+    let yDir = if rng.NextDouble() > 0.5 then 1.0f else -1.0f
+
+    newBall' <- {
+      Position = Vector2(model.Width / 2f, model.Height / 2f)
+      Velocity = Vector2(-300f, 200f * yDir)
+    }
+
+  {
+    model with
+        Ball = newBall'
+        Scores = scores
+  }
+
+// ── Elmish Update ──────────────────────────────────────────────────────────
+
+let init ctx =
+  struct (initGameState 800f 800f, Cmd.none)
+
+let update msg model =
+  match msg with
+  | GameTick -> struct (step model (1f / 60f), Cmd.none)
+
+  | FromClient(_, clientMsg) ->
+    match clientMsg with
+    | MovePaddle(side, y) ->
+      let clampedY = clampPaddle y
+
+      match side with
+      | Left ->
+        struct ({
+                  model with
+                      LeftPaddle = { model.LeftPaddle with Y = clampedY }
+                },
+                Cmd.none)
+      | Right ->
+        struct ({
+                  model with
+                      RightPaddle = { model.RightPaddle with Y = clampedY }
+                },
+                Cmd.none)

--- a/samples/PingPong/Server/NetworkService.fs
+++ b/samples/PingPong/Server/NetworkService.fs
@@ -44,7 +44,7 @@ let createWebSocketServer
   : IServerTransport =
 
   let connections = ConcurrentDictionary<int<peerId>, WebSocket>()
-  let mutable nextPeerId = 1<peerId>
+  let mutable nextPeerId = 0
   let cts = new CancellationTokenSource()
 
   let messageReceived = Event<int<peerId> * byte[]>()
@@ -111,19 +111,21 @@ let createWebSocketServer
   }
 
   let acceptWebSocket(ctx: HttpListenerContext) = async {
-    let! socket = ctx.AcceptWebSocketAsync(null) |> Async.AwaitTask
-    let ws = socket.WebSocket
-    let peer = nextPeerId
-    nextPeerId <- nextPeerId + UMX.tag 1
+    try
+      let! socket = ctx.AcceptWebSocketAsync(null) |> Async.AwaitTask
+      let ws = socket.WebSocket
+      let peer = Interlocked.Increment(&nextPeerId) |> UMX.tag<peerId>
 
-    // Send handshake BEFORE adding to connections so the Broadcast loop
-    // can't race ahead of the handshake with a GameState JSON blob.
-    match onPeerConnected peer with
-    | ValueSome handshake -> do! sendTo ws handshake
-    | ValueNone -> ()
+      // Send handshake BEFORE adding to connections so the Broadcast loop
+      // can't race ahead of the handshake with a GameState JSON blob.
+      match onPeerConnected peer with
+      | ValueSome handshake -> do! sendTo ws handshake
+      | ValueNone -> ()
 
-    connections[peer] <- ws
-    Async.Start(receiveLoop peer ws, cts.Token)
+      connections[peer] <- ws
+      Async.Start(receiveLoop peer ws, cts.Token)
+    with ex ->
+      Console.WriteLine $"acceptWebSocket error: {ex}"
   }
 
   let acceptConnections(listener: HttpListener) = async {
@@ -131,7 +133,7 @@ let createWebSocketServer
       let! ctx = listener.GetContextAsync() |> Async.AwaitTask
 
       if ctx.Request.IsWebSocketRequest then
-        do! acceptWebSocket ctx
+        Async.Start(acceptWebSocket ctx, cts.Token)
   }
 
   let listener = new HttpListener()

--- a/samples/PingPong/Server/NetworkService.fs
+++ b/samples/PingPong/Server/NetworkService.fs
@@ -1,0 +1,122 @@
+module PingPong.Server.NetworkService
+
+open System
+open System.Net
+open System.Net.WebSockets
+open System.Collections.Generic
+open System.Threading
+open PingPong.Shared.Types
+open FSharp.UMX
+
+// ── WebSocket Server Implementation ────────────────────────────────────────
+
+type WebSocketServer(port: int) as this =
+  let connections = Dictionary<int<peerId>, WebSocket>()
+  let mutable nextPeerId = 1<peerId>
+  let cts = new CancellationTokenSource()
+
+  let stateChanged = Event<ConnectionState>()
+  let messageReceived = Event<int<peerId> * byte[]>()
+
+  let receiveLoop (peer: int<peerId>) (ws: WebSocket) = async {
+    let buffer = Array.zeroCreate<byte> 4096
+
+    try
+      while ws.State = WebSocketState.Open && not cts.IsCancellationRequested do
+        let! result =
+          ws.ReceiveAsync(ArraySegment(buffer), cts.Token) |> Async.AwaitTask
+
+        if result.MessageType = WebSocketMessageType.Binary then
+          let data = buffer.[0 .. result.Count - 1]
+          messageReceived.Trigger(peer, data)
+    with _ ->
+      connections.Remove(peer) |> ignore
+      stateChanged.Trigger Disconnected
+  }
+
+  let acceptWebSocket(ctx: HttpListenerContext) = async {
+    let! socket = ctx.AcceptWebSocketAsync(null) |> Async.AwaitTask
+    let ws = socket.WebSocket
+    let peer = nextPeerId
+    nextPeerId <- nextPeerId + UMX.tag 1
+    connections.Add(peer, ws)
+    // Send the assigned peer ID back to the client as a single int
+    let peerBytes = System.BitConverter.GetBytes(int peer)
+    do! ws.SendAsync(
+          System.ArraySegment(peerBytes),
+          WebSocketMessageType.Binary,
+          true,
+          cts.Token
+        ) |> Async.AwaitTask |> Async.Ignore
+    stateChanged.Trigger(Connected peer)
+    Async.Start(receiveLoop peer ws, cts.Token)
+  }
+
+  let acceptConnections(listener: HttpListener) = async {
+    while not cts.IsCancellationRequested do
+      let! ctx = listener.GetContextAsync() |> Async.AwaitTask
+
+      if ctx.Request.IsWebSocketRequest then
+        do! acceptWebSocket ctx
+  }
+
+  let listener = new HttpListener()
+
+  member _.Start() =
+    listener.Prefixes.Add(sprintf "http://localhost:%d/" port)
+    listener.Start()
+    Async.Start(acceptConnections listener, cts.Token)
+
+  member _.Stop() =
+    cts.Cancel()
+    listener.Stop()
+
+    for KeyValue(_, ws) in connections do
+      try
+        ws.CloseAsync(
+          WebSocketCloseStatus.NormalClosure,
+          "",
+          CancellationToken.None
+        )
+        |> fun t -> t.Wait()
+
+        ws.Dispose()
+      with _ ->
+        ()
+
+  interface INetworkService with
+    member _.State = Connected 1<peerId>
+    member _.StateChanged = stateChanged.Publish :> IObservable<_>
+    member _.MessageReceived = messageReceived.Publish :> IObservable<_>
+
+    member _.Send(peer, data) =
+      match connections.TryGetValue(peer) with
+      | true, ws when ws.State = WebSocketState.Open ->
+        try
+          ws.SendAsync(
+            ArraySegment(data),
+            WebSocketMessageType.Binary,
+            true,
+            cts.Token
+          )
+          |> fun t -> t.Wait()
+        with _ ->
+          ()
+      | _ -> ()
+
+    member _.Broadcast(data) =
+      for KeyValue(_, ws) in connections do
+        if ws.State = WebSocketState.Open then
+          try
+            ws.SendAsync(
+              ArraySegment(data),
+              WebSocketMessageType.Binary,
+              true,
+              cts.Token
+            )
+            |> fun t -> t.Wait()
+          with _ ->
+            ()
+
+    member _.Connect(_) = ()
+    member _.Disconnect() = this.Stop()

--- a/samples/PingPong/Server/NetworkService.fs
+++ b/samples/PingPong/Server/NetworkService.fs
@@ -3,35 +3,111 @@ module PingPong.Server.NetworkService
 open System
 open System.Net
 open System.Net.WebSockets
-open System.Collections.Generic
+open System.Collections.Concurrent
 open System.Threading
+open FSharp.Control
 open PingPong.Shared.Types
 open FSharp.UMX
 
-// ── WebSocket Server Implementation ────────────────────────────────────────
+// ── Server Transport Interface (server-only) ───────────────────────────────
+// Multiplexer for many connected peers. Peer lifecycle is handled via
+// factory callbacks, not the interface.
 
-type WebSocketServer(port: int) as this =
-  let connections = Dictionary<int<peerId>, WebSocket>()
+type IServerTransport =
+  abstract MessageReceived: IObservable<int<peerId> * byte[]>
+  abstract Send: peer: int<peerId> * data: byte[] -> unit
+  abstract Broadcast: data: byte[] -> unit
+  abstract Disconnect: unit -> unit
+
+type private Command =
+  | SendOne of peer: int<peerId> * data: byte[]
+  | Broadcast of data: byte[]
+  | Shutdown
+
+/// <summary>
+/// Creates a WebSocket server hidden behind IServerTransport.
+/// All sends are serialized through a MailboxProcessor — WebSocket permits
+/// at most one outstanding SendAsync per instance.
+/// </summary>
+/// <param name="port">TCP port to listen on.</param>
+/// <param name="onPeerConnected">
+/// Called when a peer connects. Return optional handshake bytes to send back.
+/// </param>
+/// <param name="onPeerDisconnected">
+/// Called on both clean and abnormal disconnect. The peer has already been
+/// removed from the connection table when this fires.
+/// </param>
+let createWebSocketServer
+  (port: int)
+  (onPeerConnected: int<peerId> -> byte[] voption)
+  (onPeerDisconnected: int<peerId> -> unit)
+  : IServerTransport =
+
+  let connections = ConcurrentDictionary<int<peerId>, WebSocket>()
   let mutable nextPeerId = 1<peerId>
   let cts = new CancellationTokenSource()
 
-  let stateChanged = Event<ConnectionState>()
   let messageReceived = Event<int<peerId> * byte[]>()
+
+  let sendTo (ws: WebSocket) (data: byte[]) = async {
+    if ws.State = WebSocketState.Open then
+      try
+        do!
+          ws.SendAsync(
+            ArraySegment data,
+            WebSocketMessageType.Binary,
+            true,
+            cts.Token
+          )
+          |> Async.AwaitTask
+      with
+      | :? WebSocketException
+      | :? OperationCanceledException
+      | :? ObjectDisposedException -> ()
+  }
+
+  let agentBody(inbox: MailboxProcessor<Command>) =
+    let rec loop() = async {
+      let! cmd = inbox.Receive()
+
+      match cmd with
+      | SendOne(peer, data) ->
+        match connections.TryGetValue peer with
+        | true, ws -> do! sendTo ws data
+        | false, _ -> ()
+
+        return! loop()
+
+      | Broadcast data ->
+        for KeyValue(_, ws) in connections do
+          do! sendTo ws data
+
+        return! loop()
+
+      | Shutdown -> ()
+    }
+
+    loop()
+
+  let agent = MailboxProcessor.Start(agentBody, cancellationToken = cts.Token)
 
   let receiveLoop (peer: int<peerId>) (ws: WebSocket) = async {
     let buffer = Array.zeroCreate<byte> 4096
 
     try
-      while ws.State = WebSocketState.Open && not cts.IsCancellationRequested do
-        let! result =
-          ws.ReceiveAsync(ArraySegment(buffer), cts.Token) |> Async.AwaitTask
+      try
+        while ws.State = WebSocketState.Open && not cts.IsCancellationRequested do
+          let! result =
+            ws.ReceiveAsync(ArraySegment(buffer), cts.Token) |> Async.AwaitTask
 
-        if result.MessageType = WebSocketMessageType.Binary then
-          let data = buffer.[0 .. result.Count - 1]
-          messageReceived.Trigger(peer, data)
-    with _ ->
-      connections.Remove(peer) |> ignore
-      stateChanged.Trigger Disconnected
+          if result.MessageType = WebSocketMessageType.Binary then
+            messageReceived.Trigger(peer, buffer.[0 .. result.Count - 1])
+      with ex ->
+        Console.WriteLine $"receiveLoop error for peer {peer}: {ex}"
+    finally
+      let mutable _ws = Unchecked.defaultof<WebSocket>
+      connections.TryRemove(peer, &_ws) |> ignore
+      onPeerDisconnected peer
   }
 
   let acceptWebSocket(ctx: HttpListenerContext) = async {
@@ -39,16 +115,14 @@ type WebSocketServer(port: int) as this =
     let ws = socket.WebSocket
     let peer = nextPeerId
     nextPeerId <- nextPeerId + UMX.tag 1
-    connections.Add(peer, ws)
-    // Send the assigned peer ID back to the client as a single int
-    let peerBytes = System.BitConverter.GetBytes(int peer)
-    do! ws.SendAsync(
-          System.ArraySegment(peerBytes),
-          WebSocketMessageType.Binary,
-          true,
-          cts.Token
-        ) |> Async.AwaitTask |> Async.Ignore
-    stateChanged.Trigger(Connected peer)
+
+    // Send handshake BEFORE adding to connections so the Broadcast loop
+    // can't race ahead of the handshake with a GameState JSON blob.
+    match onPeerConnected peer with
+    | ValueSome handshake -> do! sendTo ws handshake
+    | ValueNone -> ()
+
+    connections[peer] <- ws
     Async.Start(receiveLoop peer ws, cts.Token)
   }
 
@@ -61,62 +135,34 @@ type WebSocketServer(port: int) as this =
   }
 
   let listener = new HttpListener()
+  listener.Prefixes.Add(sprintf "http://localhost:%d/" port)
+  listener.Start()
+  Async.Start(acceptConnections listener, cts.Token)
 
-  member _.Start() =
-    listener.Prefixes.Add(sprintf "http://localhost:%d/" port)
-    listener.Start()
-    Async.Start(acceptConnections listener, cts.Token)
-
-  member _.Stop() =
+  let stop() =
     cts.Cancel()
+    agent.Post Shutdown
     listener.Stop()
 
     for KeyValue(_, ws) in connections do
       try
-        ws.CloseAsync(
-          WebSocketCloseStatus.NormalClosure,
-          "",
-          CancellationToken.None
-        )
-        |> fun t -> t.Wait()
-
-        ws.Dispose()
-      with _ ->
-        ()
-
-  interface INetworkService with
-    member _.State = Connected 1<peerId>
-    member _.StateChanged = stateChanged.Publish :> IObservable<_>
-    member _.MessageReceived = messageReceived.Publish :> IObservable<_>
-
-    member _.Send(peer, data) =
-      match connections.TryGetValue(peer) with
-      | true, ws when ws.State = WebSocketState.Open ->
-        try
-          ws.SendAsync(
-            ArraySegment(data),
-            WebSocketMessageType.Binary,
-            true,
-            cts.Token
+        if ws.State = WebSocketState.Open then
+          ws.CloseAsync(
+            WebSocketCloseStatus.NormalClosure,
+            "",
+            CancellationToken.None
           )
           |> fun t -> t.Wait()
-        with _ ->
-          ()
-      | _ -> ()
 
-    member _.Broadcast(data) =
-      for KeyValue(_, ws) in connections do
-        if ws.State = WebSocketState.Open then
-          try
-            ws.SendAsync(
-              ArraySegment(data),
-              WebSocketMessageType.Binary,
-              true,
-              cts.Token
-            )
-            |> fun t -> t.Wait()
-          with _ ->
-            ()
+        ws.Dispose()
+      with
+      | :? WebSocketException
+      | :? OperationCanceledException
+      | :? ObjectDisposedException -> ()
 
-    member _.Connect(_) = ()
-    member _.Disconnect() = this.Stop()
+  { new IServerTransport with
+      member _.MessageReceived = upcast messageReceived.Publish
+      member _.Send(peer, data) = agent.Post(SendOne(peer, data))
+      member _.Broadcast(data) = agent.Post(Broadcast data)
+      member _.Disconnect() = stop()
+  }

--- a/samples/PingPong/Server/Program.fs
+++ b/samples/PingPong/Server/Program.fs
@@ -29,6 +29,7 @@ let main _args =
     )
 
   let paddles = ConcurrentDictionary<int<peerId>, PaddleSide voption>()
+  let paddleLock = obj()
 
   let assignPaddle() =
     let hasLeft = paddles.Values |> Seq.exists((=)(ValueSome Left))
@@ -42,8 +43,11 @@ let main _args =
     createWebSocketServer
       port
       (fun peerId ->
-        let side = assignPaddle()
-        paddles[peerId] <- side
+        let side =
+          lock paddleLock (fun () ->
+            let s = assignPaddle()
+            paddles[peerId] <- s
+            s)
 
         let sideByte =
           match side with
@@ -58,8 +62,10 @@ let main _args =
         printfn "Peer %d connected, assigned %A" (int peerId) side
         ValueSome data)
       (fun peerId ->
-        let mutable _side = ValueNone
-        paddles.TryRemove(peerId, &_side) |> ignore
+        lock paddleLock (fun () ->
+          let mutable _side = ValueNone
+          paddles.TryRemove(peerId, &_side) |> ignore)
+
         printfn "Peer %d disconnected" (int peerId))
 
   server.MessageReceived.Add(fun (peerId, bytes) ->

--- a/samples/PingPong/Server/Program.fs
+++ b/samples/PingPong/Server/Program.fs
@@ -1,6 +1,10 @@
 module PingPong.Server.Program
 
 open System
+open System.Collections.Concurrent
+open System.Threading
+open IcedTasks
+open FSharp.Control
 open Mibo.Elmish
 open PingPong.Shared.Types
 open PingPong.Shared.Serialization
@@ -11,47 +15,75 @@ open PingPong.Server.GameLogic
 
 [<EntryPoint>]
 let main _args =
-    let port = 5000
+  let port = 5000
 
-    let program =
-        HeadlessProgram.mkHeadless init update
-        |> HeadlessProgram.withFixedStep {
-            StepSeconds = 1f / 60f
-            MaxStepsPerFrame = 4
-            MaxFrameSeconds = ValueSome 0.25f
-            Map = fun _ -> GameTick
-        }
-
-    use runner = new HeadlessRunner<_,_>(program)
-    let server = new WebSocketServer(port)
-    server.Start()
-    let net = server :> INetworkService
-
-    // Subscribe to incoming messages
-    use _sub = net.MessageReceived.Subscribe(fun (peerId, bytes) ->
-        let msg = deserializeClientMsg bytes
-        runner.Dispatch(FromClient(peerId, msg))
+  use runner =
+    new HeadlessRunner<_, _>(
+      HeadlessProgram.mkHeadless init update
+      |> HeadlessProgram.withFixedStep {
+        StepSeconds = 1f / 60f
+        MaxStepsPerFrame = 4
+        MaxFrameSeconds = ValueSome 0.25f
+        Map = fun _ -> GameTick
+      }
     )
 
-    printfn "Server listening on port %d" port
-    printfn "Press Ctrl+C to stop"
+  let paddles = ConcurrentDictionary<int<peerId>, PaddleSide voption>()
 
-    // Main loop — pace to real time
-    let frameMs = 16.0
-    let sw = System.Diagnostics.Stopwatch.StartNew()
-    let mutable nextTick = 0.0
+  let assignPaddle() =
+    let hasLeft = paddles.Values |> Seq.exists((=)(ValueSome Left))
+    let hasRight = paddles.Values |> Seq.exists((=)(ValueSome Right))
 
-    while not runner.ShouldQuit do
-        let elapsed = sw.Elapsed.TotalMilliseconds
+    if not hasLeft then ValueSome Left
+    elif not hasRight then ValueSome Right
+    else ValueNone
 
-        if elapsed >= nextTick then
-          runner.Step(TimeSpan.FromMilliseconds(frameMs))
-          nextTick <- nextTick + frameMs
+  let server: IServerTransport =
+    createWebSocketServer
+      port
+      (fun peerId ->
+        let side = assignPaddle()
+        paddles[peerId] <- side
 
-          let bytes = serializeGameState runner.Model
-          net.Broadcast(bytes)
-        else
-          System.Threading.Thread.Sleep(1)
+        let sideByte =
+          match side with
+          | ValueSome Left -> 0uy
+          | ValueSome Right -> 1uy
+          | ValueNone -> 2uy
 
-    net.Disconnect()
-    0
+        let peerBytes = BitConverter.GetBytes(int peerId)
+        let data = Array.zeroCreate<byte> 5
+        Array.Copy(peerBytes, data, 4)
+        data[4] <- sideByte
+        printfn "Peer %d connected, assigned %A" (int peerId) side
+        ValueSome data)
+      (fun peerId ->
+        let mutable _side = ValueNone
+        paddles.TryRemove(peerId, &_side) |> ignore
+        printfn "Peer %d disconnected" (int peerId))
+
+  server.MessageReceived.Add(fun (peerId, bytes) ->
+    let msg = deserializeClientMsg bytes
+    runner.Dispatch(FromClient(peerId, msg)))
+
+  printfn "Server listening on port %d" port
+  printfn "Press Ctrl+C to stop"
+
+  use cts = new CancellationTokenSource()
+
+  Console.CancelKeyPress.Add(fun args ->
+    args.Cancel <- true
+    cts.Cancel())
+
+  try
+    asyncEx {
+      for _, gameState in
+        runner.RunAsync(TimeSpan.FromMilliseconds 16., cts.Token) do
+        serializeGameState gameState |> server.Broadcast
+    }
+    |> Async.RunSynchronously
+  with :? OperationCanceledException ->
+    ()
+
+  server.Disconnect()
+  0

--- a/samples/PingPong/Server/Program.fs
+++ b/samples/PingPong/Server/Program.fs
@@ -1,0 +1,57 @@
+module PingPong.Server.Program
+
+open System
+open Mibo.Elmish
+open PingPong.Shared.Types
+open PingPong.Shared.Serialization
+open PingPong.Server.NetworkService
+open PingPong.Server.GameLogic
+
+// ── Server Main Loop ───────────────────────────────────────────────────────
+
+[<EntryPoint>]
+let main _args =
+    let port = 5000
+
+    let program =
+        HeadlessProgram.mkHeadless init update
+        |> HeadlessProgram.withFixedStep {
+            StepSeconds = 1f / 60f
+            MaxStepsPerFrame = 4
+            MaxFrameSeconds = ValueSome 0.25f
+            Map = fun _ -> GameTick
+        }
+
+    use runner = new HeadlessRunner<_,_>(program)
+    let server = new WebSocketServer(port)
+    server.Start()
+    let net = server :> INetworkService
+
+    // Subscribe to incoming messages
+    use _sub = net.MessageReceived.Subscribe(fun (peerId, bytes) ->
+        let msg = deserializeClientMsg bytes
+        runner.Dispatch(FromClient(peerId, msg))
+    )
+
+    printfn "Server listening on port %d" port
+    printfn "Press Ctrl+C to stop"
+
+    // Main loop — pace to real time
+    let frameMs = 16.0
+    let sw = System.Diagnostics.Stopwatch.StartNew()
+    let mutable nextTick = 0.0
+
+    while not runner.ShouldQuit do
+        let elapsed = sw.Elapsed.TotalMilliseconds
+
+        if elapsed >= nextTick then
+          runner.Step(TimeSpan.FromMilliseconds(frameMs))
+          nextTick <- nextTick + frameMs
+
+          let bytes = serializeGameState runner.Model
+          net.Broadcast(bytes)
+        else
+          System.Threading.Thread.Sleep(1)
+
+    net.Disconnect()
+    0

--- a/samples/PingPong/Server/Server.fsproj
+++ b/samples/PingPong/Server/Server.fsproj
@@ -14,4 +14,7 @@
     <ProjectReference Include="..\Shared\Shared.fsproj" />
     <ProjectReference Include="..\..\..\src\Mibo.Raylib\Mibo.Raylib.fsproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="IcedTasks" Version="0.11.9" />
+  </ItemGroup>
 </Project>

--- a/samples/PingPong/Server/Server.fsproj
+++ b/samples/PingPong/Server/Server.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="NetworkService.fs" />
+    <Compile Include="GameLogic.fs" />
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Shared\Shared.fsproj" />
+    <ProjectReference Include="..\..\..\src\Mibo.Raylib\Mibo.Raylib.fsproj" />
+  </ItemGroup>
+</Project>

--- a/samples/PingPong/Shared/Physics.fs
+++ b/samples/PingPong/Shared/Physics.fs
@@ -1,0 +1,89 @@
+module PingPong.Shared.Physics
+
+open System
+open System.Numerics
+open PingPong.Shared.Types
+
+let updateBall
+  (width: float32)
+  (height: float32)
+  (ball: Ball)
+  (leftPaddle: Paddle)
+  (rightPaddle: Paddle)
+  (dt: float32)
+  : Ball =
+  let mutable pos = ball.Position + ball.Velocity * dt
+  let mutable vel = ball.Velocity
+
+  if pos.Y - ballRadius < 0f then
+    pos <- Vector2(pos.X, ballRadius)
+    vel <- Vector2(vel.X, -vel.Y)
+  elif pos.Y + ballRadius > height then
+    pos <- Vector2(pos.X, height - ballRadius)
+    vel <- Vector2(vel.X, -vel.Y)
+
+  if vel.X < 0f then
+    let paddleRight = paddleWidth
+
+    if pos.X - ballRadius < paddleRight && pos.X + ballRadius > 0f then
+      if
+        pos.Y > leftPaddle.Y - paddleHeight / 2f
+        && pos.Y < leftPaddle.Y + paddleHeight / 2f
+      then
+        pos <- Vector2(paddleRight + ballRadius, pos.Y)
+        vel <- Vector2(-vel.X, vel.Y)
+
+  if vel.X > 0f then
+    let paddleLeft = width - paddleWidth
+
+    if pos.X + ballRadius > paddleLeft && pos.X - ballRadius < width then
+      if
+        pos.Y > rightPaddle.Y - paddleHeight / 2f
+        && pos.Y < rightPaddle.Y + paddleHeight / 2f
+      then
+        pos <- Vector2(paddleLeft - ballRadius, pos.Y)
+        vel <- Vector2(-vel.X, vel.Y)
+
+  { Position = pos; Velocity = vel }
+
+let clampPaddle (height: float32) (y: float32) : float32 =
+  let halfHeight = paddleHeight / 2f
+  max halfHeight (min (height - halfHeight) y)
+
+let step (rng: Random) (model: GameState) (dt: float32) : GameState =
+  let newBall =
+    updateBall
+      model.Width
+      model.Height
+      model.Ball
+      model.LeftPaddle
+      model.RightPaddle
+      dt
+
+  let mutable scores = model.Scores
+  let mutable newBall' = newBall
+
+  if newBall.Position.X < 0f then
+    scores <- { scores with Right = scores.Right + 1 }
+    let yDir = if rng.NextDouble() > 0.5 then 1.0f else -1.0f
+
+    newBall' <- {
+      Position = Vector2(model.Width / 2f, model.Height / 2f)
+      Velocity = Vector2(300f, 200f * yDir)
+    }
+  elif newBall.Position.X > model.Width then
+    scores <- { scores with Left = scores.Left + 1 }
+    let yDir = if rng.NextDouble() > 0.5 then 1.0f else -1.0f
+
+    newBall' <- {
+      Position = Vector2(model.Width / 2f, model.Height / 2f)
+      Velocity = Vector2(-300f, 200f * yDir)
+    }
+
+  {
+    model with
+        Ball = newBall'
+        Scores = scores
+  }
+
+let lerp (a: float32) (b: float32) (t: float32) = a + (b - a) * t

--- a/samples/PingPong/Shared/Serialization.fs
+++ b/samples/PingPong/Shared/Serialization.fs
@@ -7,7 +7,7 @@ open PingPong.Shared.Types
 
 // ── Encoders ───────────────────────────────────────────────────────────────
 
-let encodeBall (ball: Ball) : JsonNode =
+let encodeBall(ball: Ball) : JsonNode =
   Json.object [
     "x", Encode.single ball.Position.X
     "y", Encode.single ball.Position.Y
@@ -15,24 +15,24 @@ let encodeBall (ball: Ball) : JsonNode =
     "vy", Encode.single ball.Velocity.Y
   ]
 
-let encodePaddleSide (side: PaddleSide) : JsonNode =
+let encodePaddleSide(side: PaddleSide) : JsonNode =
   match side with
   | Left -> Encode.string "Left"
   | Right -> Encode.string "Right"
 
-let encodePaddle (paddle: Paddle) : JsonNode =
+let encodePaddle(paddle: Paddle) : JsonNode =
   Json.object [
     "side", encodePaddleSide paddle.Side
     "y", Encode.single paddle.Y
   ]
 
-let encodeScores (scores: Scores) : JsonNode =
+let encodeScores(scores: Scores) : JsonNode =
   Json.object [
     "left", Encode.int scores.Left
     "right", Encode.int scores.Right
   ]
 
-let encodeGameState (state: GameState) : JsonNode =
+let encodeGameState(state: GameState) : JsonNode =
   Json.object [
     "ball", encodeBall state.Ball
     "leftPaddle", encodePaddle state.LeftPaddle
@@ -42,7 +42,7 @@ let encodeGameState (state: GameState) : JsonNode =
     "height", Encode.single state.Height
   ]
 
-let encodeClientMsg (msg: ClientMsg) : JsonNode =
+let encodeClientMsg(msg: ClientMsg) : JsonNode =
   match msg with
   | MovePaddle(side, y) ->
     Json.object [
@@ -53,36 +53,41 @@ let encodeClientMsg (msg: ClientMsg) : JsonNode =
 
 // ── Decoders ───────────────────────────────────────────────────────────────
 
-let decodeBall : Decoder<Ball> =
+let decodeBall: Decoder<Ball> =
   fun el -> decode {
     let! x = el |> Required.Property.get("x", Required.single)
     and! y = el |> Required.Property.get("y", Required.single)
     and! vx = el |> Required.Property.get("vx", Required.single)
     and! vy = el |> Required.Property.get("vy", Required.single)
-    return { Position = System.Numerics.Vector2(x, y); Velocity = System.Numerics.Vector2(vx, vy) }
+
+    return {
+      Position = System.Numerics.Vector2(x, y)
+      Velocity = System.Numerics.Vector2(vx, vy)
+    }
   }
 
-let decodePaddleSide : Decoder<PaddleSide> =
-  fun el -> match el.GetString() with
-            | "Left" -> Ok Left
-            | "Right" -> Ok Right
-            | other -> Error(DecodeError.ofError(el, $"Unknown paddle side: {other}"))
+let decodePaddleSide: Decoder<PaddleSide> =
+  fun el ->
+    match el.GetString() with
+    | "Left" -> Ok Left
+    | "Right" -> Ok Right
+    | other -> Error(DecodeError.ofError(el, $"Unknown paddle side: {other}"))
 
-let decodePaddle : Decoder<Paddle> =
+let decodePaddle: Decoder<Paddle> =
   fun el -> decode {
     let! side = el |> Required.Property.get("side", decodePaddleSide)
     and! y = el |> Required.Property.get("y", Required.single)
     return { Side = side; Y = y }
   }
 
-let decodeScores : Decoder<Scores> =
+let decodeScores: Decoder<Scores> =
   fun el -> decode {
     let! left = el |> Required.Property.get("left", Required.int)
     and! right = el |> Required.Property.get("right", Required.int)
     return { Left = left; Right = right }
   }
 
-let decodeGameState : Decoder<GameState> =
+let decodeGameState: Decoder<GameState> =
   fun el -> decode {
     let! ball = el |> Required.Property.get("ball", decodeBall)
     and! leftPaddle = el |> Required.Property.get("leftPaddle", decodePaddle)
@@ -90,18 +95,28 @@ let decodeGameState : Decoder<GameState> =
     and! scores = el |> Required.Property.get("scores", decodeScores)
     and! width = el |> Required.Property.get("width", Required.single)
     and! height = el |> Required.Property.get("height", Required.single)
-    return { Ball = ball; LeftPaddle = leftPaddle; RightPaddle = rightPaddle; Scores = scores; Width = width; Height = height }
+
+    return {
+      Ball = ball
+      LeftPaddle = leftPaddle
+      RightPaddle = rightPaddle
+      Scores = scores
+      Width = width
+      Height = height
+    }
   }
 
-let decodeClientMsg : Decoder<ClientMsg> =
+let decodeClientMsg: Decoder<ClientMsg> =
   fun el -> decode {
     let! msgType = el |> Required.Property.get("type", Required.string)
+
     match msgType with
     | "MovePaddle" ->
       let! side = el |> Required.Property.get("side", decodePaddleSide)
       and! y = el |> Required.Property.get("y", Required.single)
       return MovePaddle(side, y)
-    | other -> return! Error(DecodeError.ofError(el, $"Unknown message type: {other}"))
+    | other ->
+      return! Error(DecodeError.ofError(el, $"Unknown message type: {other}"))
   }
 
 // ── Options ────────────────────────────────────────────────────────────────
@@ -113,14 +128,14 @@ let jsonOptions =
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-let serializeGameState (state: GameState) : byte[] =
+let serializeGameState(state: GameState) : byte[] =
   JsonSerializer.SerializeToUtf8Bytes(state, jsonOptions)
 
-let deserializeGameState (bytes: byte[]) : GameState =
+let deserializeGameState(bytes: byte[]) : GameState =
   JsonSerializer.Deserialize<GameState>(bytes, jsonOptions)
 
-let serializeClientMsg (msg: ClientMsg) : byte[] =
+let serializeClientMsg(msg: ClientMsg) : byte[] =
   JsonSerializer.SerializeToUtf8Bytes(msg, jsonOptions)
 
-let deserializeClientMsg (bytes: byte[]) : ClientMsg =
+let deserializeClientMsg(bytes: byte[]) : ClientMsg =
   JsonSerializer.Deserialize<ClientMsg>(bytes, jsonOptions)

--- a/samples/PingPong/Shared/Serialization.fs
+++ b/samples/PingPong/Shared/Serialization.fs
@@ -1,0 +1,126 @@
+module PingPong.Shared.Serialization
+
+open System.Text.Json
+open System.Text.Json.Nodes
+open JDeck
+open PingPong.Shared.Types
+
+// ── Encoders ───────────────────────────────────────────────────────────────
+
+let encodeBall (ball: Ball) : JsonNode =
+  Json.object [
+    "x", Encode.single ball.Position.X
+    "y", Encode.single ball.Position.Y
+    "vx", Encode.single ball.Velocity.X
+    "vy", Encode.single ball.Velocity.Y
+  ]
+
+let encodePaddleSide (side: PaddleSide) : JsonNode =
+  match side with
+  | Left -> Encode.string "Left"
+  | Right -> Encode.string "Right"
+
+let encodePaddle (paddle: Paddle) : JsonNode =
+  Json.object [
+    "side", encodePaddleSide paddle.Side
+    "y", Encode.single paddle.Y
+  ]
+
+let encodeScores (scores: Scores) : JsonNode =
+  Json.object [
+    "left", Encode.int scores.Left
+    "right", Encode.int scores.Right
+  ]
+
+let encodeGameState (state: GameState) : JsonNode =
+  Json.object [
+    "ball", encodeBall state.Ball
+    "leftPaddle", encodePaddle state.LeftPaddle
+    "rightPaddle", encodePaddle state.RightPaddle
+    "scores", encodeScores state.Scores
+    "width", Encode.single state.Width
+    "height", Encode.single state.Height
+  ]
+
+let encodeClientMsg (msg: ClientMsg) : JsonNode =
+  match msg with
+  | MovePaddle(side, y) ->
+    Json.object [
+      "type", Encode.string "MovePaddle"
+      "side", encodePaddleSide side
+      "y", Encode.single y
+    ]
+
+// ── Decoders ───────────────────────────────────────────────────────────────
+
+let decodeBall : Decoder<Ball> =
+  fun el -> decode {
+    let! x = el |> Required.Property.get("x", Required.single)
+    and! y = el |> Required.Property.get("y", Required.single)
+    and! vx = el |> Required.Property.get("vx", Required.single)
+    and! vy = el |> Required.Property.get("vy", Required.single)
+    return { Position = System.Numerics.Vector2(x, y); Velocity = System.Numerics.Vector2(vx, vy) }
+  }
+
+let decodePaddleSide : Decoder<PaddleSide> =
+  fun el -> match el.GetString() with
+            | "Left" -> Ok Left
+            | "Right" -> Ok Right
+            | other -> Error(DecodeError.ofError(el, $"Unknown paddle side: {other}"))
+
+let decodePaddle : Decoder<Paddle> =
+  fun el -> decode {
+    let! side = el |> Required.Property.get("side", decodePaddleSide)
+    and! y = el |> Required.Property.get("y", Required.single)
+    return { Side = side; Y = y }
+  }
+
+let decodeScores : Decoder<Scores> =
+  fun el -> decode {
+    let! left = el |> Required.Property.get("left", Required.int)
+    and! right = el |> Required.Property.get("right", Required.int)
+    return { Left = left; Right = right }
+  }
+
+let decodeGameState : Decoder<GameState> =
+  fun el -> decode {
+    let! ball = el |> Required.Property.get("ball", decodeBall)
+    and! leftPaddle = el |> Required.Property.get("leftPaddle", decodePaddle)
+    and! rightPaddle = el |> Required.Property.get("rightPaddle", decodePaddle)
+    and! scores = el |> Required.Property.get("scores", decodeScores)
+    and! width = el |> Required.Property.get("width", Required.single)
+    and! height = el |> Required.Property.get("height", Required.single)
+    return { Ball = ball; LeftPaddle = leftPaddle; RightPaddle = rightPaddle; Scores = scores; Width = width; Height = height }
+  }
+
+let decodeClientMsg : Decoder<ClientMsg> =
+  fun el -> decode {
+    let! msgType = el |> Required.Property.get("type", Required.string)
+    match msgType with
+    | "MovePaddle" ->
+      let! side = el |> Required.Property.get("side", decodePaddleSide)
+      and! y = el |> Required.Property.get("y", Required.single)
+      return MovePaddle(side, y)
+    | other -> return! Error(DecodeError.ofError(el, $"Unknown message type: {other}"))
+  }
+
+// ── Options ────────────────────────────────────────────────────────────────
+
+let jsonOptions =
+  JsonSerializerOptions()
+  |> Codec.useCodec(encodeGameState, decodeGameState)
+  |> Codec.useCodec(encodeClientMsg, decodeClientMsg)
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+let serializeGameState (state: GameState) : byte[] =
+  JsonSerializer.SerializeToUtf8Bytes(state, jsonOptions)
+
+let deserializeGameState (bytes: byte[]) : GameState =
+  JsonSerializer.Deserialize<GameState>(bytes, jsonOptions)
+
+let serializeClientMsg (msg: ClientMsg) : byte[] =
+  JsonSerializer.SerializeToUtf8Bytes(msg, jsonOptions)
+
+let deserializeClientMsg (bytes: byte[]) : ClientMsg =
+  JsonSerializer.Deserialize<ClientMsg>(bytes, jsonOptions)

--- a/samples/PingPong/Shared/Shared.fsproj
+++ b/samples/PingPong/Shared/Shared.fsproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Types.fs" />
+    <Compile Include="Serialization.fs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="JDeck" Version="1.1.0" />
+  </ItemGroup>
+</Project>

--- a/samples/PingPong/Shared/Shared.fsproj
+++ b/samples/PingPong/Shared/Shared.fsproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Types.fs" />
+    <Compile Include="Physics.fs" />
     <Compile Include="Serialization.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/samples/PingPong/Shared/Types.fs
+++ b/samples/PingPong/Shared/Types.fs
@@ -8,32 +8,18 @@ open System
 [<Measure>]
 type peerId
 
-// ── Connection State ───────────────────────────────────────────────────────
-
-[<Struct>]
-type ConnectionState =
-  | Disconnected
-  | Connecting
-  | Connected of int<peerId>
-  | Reconnecting
-
-// ── Network Service Interface ──────────────────────────────────────────────
-
-type INetworkService =
-  abstract State: ConnectionState
-  abstract StateChanged: IObservable<ConnectionState>
-  abstract MessageReceived: IObservable<int<peerId> * byte[]>
-  abstract Send: peer: int<peerId> * data: byte[] -> unit
-  abstract Broadcast: data: byte[] -> unit
-  abstract Connect: address: string -> unit
-  abstract Disconnect: unit -> unit
-
 // ── Game Types ─────────────────────────────────────────────────────────────
 
 [<Struct>]
 type PaddleSide =
   | Left
   | Right
+
+// ── Physics Constants ──────────────────────────────────────────────────────
+
+let paddleWidth = 10f
+let paddleHeight = 80f
+let ballRadius = 8f
 
 type Ball = { Position: Vector2; Velocity: Vector2 }
 

--- a/samples/PingPong/Shared/Types.fs
+++ b/samples/PingPong/Shared/Types.fs
@@ -1,0 +1,69 @@
+module PingPong.Shared.Types
+
+open System.Numerics
+open System
+
+// ── Peer Identity ──────────────────────────────────────────────────────────
+
+[<Measure>]
+type peerId
+
+// ── Connection State ───────────────────────────────────────────────────────
+
+[<Struct>]
+type ConnectionState =
+  | Disconnected
+  | Connecting
+  | Connected of int<peerId>
+  | Reconnecting
+
+// ── Network Service Interface ──────────────────────────────────────────────
+
+type INetworkService =
+  abstract State: ConnectionState
+  abstract StateChanged: IObservable<ConnectionState>
+  abstract MessageReceived: IObservable<int<peerId> * byte[]>
+  abstract Send: peer: int<peerId> * data: byte[] -> unit
+  abstract Broadcast: data: byte[] -> unit
+  abstract Connect: address: string -> unit
+  abstract Disconnect: unit -> unit
+
+// ── Game Types ─────────────────────────────────────────────────────────────
+
+[<Struct>]
+type PaddleSide =
+  | Left
+  | Right
+
+type Ball = { Position: Vector2; Velocity: Vector2 }
+
+type Paddle = { Side: PaddleSide; Y: float32 }
+
+type Scores = { Left: int; Right: int }
+
+type GameState = {
+  Ball: Ball
+  LeftPaddle: Paddle
+  RightPaddle: Paddle
+  Scores: Scores
+  Width: float32
+  Height: float32
+}
+
+// ── Messages ───────────────────────────────────────────────────────────────
+
+type ClientMsg = MovePaddle of side: PaddleSide * y: float32
+
+// ── Initial State ──────────────────────────────────────────────────────────
+
+let initGameState (width: float32) (height: float32) = {
+  Ball = {
+    Position = Vector2(width / 2f, height / 2f)
+    Velocity = Vector2(200f, 100f)
+  }
+  LeftPaddle = { Side = Left; Y = height / 2f }
+  RightPaddle = { Side = Right; Y = height / 2f }
+  Scores = { Left = 0; Right = 0 }
+  Width = width
+  Height = height
+}

--- a/src/Mibo.Raylib/Elmish.Headless.fs
+++ b/src/Mibo.Raylib/Elmish.Headless.fs
@@ -70,11 +70,16 @@ module HeadlessProgram =
         Subscribe = subscribe
   }
 
+  /// <summary>Adds a per-frame tick message generated from the current <see cref="T:Mibo.Elmish.GameTime"/>.</summary>
+  /// <param name="map">Function that converts the current game time into a message dispatched each frame.</param>
   let withTick map program : HeadlessProgram<'Model, 'Msg> = {
     program with
         Tick = ValueSome map
   }
 
+  /// <summary>Enables a framework-managed fixed timestep that dispatches a message at a constant rate, independent of variable frame timing.</summary>
+  /// <param name="cfg">Fixed step configuration (step size, max steps per frame, max frame budget, message mapper).</param>
+  /// <exception cref="T:System.ArgumentException">Thrown when <c>StepSeconds</c> ≤ 0 or <c>MaxStepsPerFrame</c> ≤ 0.</exception>
   let withFixedStep cfg program : HeadlessProgram<'Model, 'Msg> =
     if cfg.StepSeconds <= 0.0f then
       invalidArg (nameof cfg.StepSeconds) "StepSeconds must be > 0"
@@ -87,6 +92,8 @@ module HeadlessProgram =
           FixedStep = ValueSome cfg
     }
 
+  /// <summary>Sets the dispatch mode controlling when messages become eligible for processing.</summary>
+  /// <param name="mode"><c>Immediate</c> processes in-frame; <c>FrameBounded</c> defers to the next step.</param>
   let withDispatchMode mode program : HeadlessProgram<'Model, 'Msg> = {
     program with
         DispatchMode = mode


### PR DESCRIPTION
# Headless Runtime Enhancements + PingPong Networking Sample

## Summary

Adds observer support and paced run loops to the headless runtime, ships a production-grade PingPong client-server sample demonstrating the headless server pattern, and fills in missing documentation.

## Headless Runtime (`Elmish.Headless.fs`)

- **IObserver support**: `HeadlessProgram.withObserver` + `HeadlessProgram.observe` — observers receive `(GameContext * 'Model * GameTime)` snapshots every frame after the update loop. `IDisposable` observers are disposed with the runner.
- **`Run(interval, ?ct)`**: synchronous `seq<GameTime * 'Model>` paced by spin-wait with `Thread.Sleep(1)`. For game servers that own the main thread.
- **`RunAsync(interval, ?ct)`**: `IAsyncEnumerable<GameTime * 'Model>` paced by `PeriodicTimer`. For efficient async server loops.
- **Breaking**: `HeadlessRunner.TotalTime` renamed to `GameTime` (returns `GameTime` struct with `TotalTime` + `ElapsedGameTime`).
- **XML docs**: Added `<summary>`/`<param>`/`<exception>` to `withTick`, `withFixedStep`, `withDispatchMode`.
- **47 headless tests** covering step return values, observer lifecycle, Run/RunAsync enumeration, cancellation, and ShouldQuit behavior.

## PingPong Networking Sample

A 2-player WebSocket Pong game demonstrating the headless server + raylib client pattern.

**Divergent transport interfaces** (no shared `INetworkService`):
- `IClientTransport` (client-only) — point-to-point pipe: `Send(byte[])`, `MessageReceived: IObservable<byte[]>`, connection state
- `IServerTransport` (server-only) — multiplexer: `Send(peer, data)`, `Broadcast(data)`, `MessageReceived: IObservable<int<peerId> * byte[]>`
- `Shared` project contains only game types (`peerId`, `PaddleSide`, `GameState`, physics, serialization)

**Robustness features:**
- Both sides use `MailboxProcessor` to serialize sends (WebSocket permits one outstanding `SendAsync` per instance)
- `try/finally` on receive loops — guaranteed cleanup on any exception
- `CloseOutputAsync` before `cts.Cancel()` — server detects clean disconnect
- Handshake consumed by transport before signaling `Connected` — eliminates race between early message delivery and Elmish subscription setup
- `ConcurrentDictionary` for thread-safe connection/paddle tracking
- Graceful shutdown via `Console.CancelKeyPress` + `CancellationToken`

## Documentation (`docs/headless.md`)

- Fixed stale `runner.TotalTime` → `runner.GameTime` references
- Added `withObserver` to the builder DSL table
- New **Observers** section with `observe` helper example
- New **Run and RunAsync** section with sync/async pacing examples and mix-warning
- Rewrote **Server Simulation** example to use observer-based broadcast + `Run`

## Test Plan

- [x] `dotnet build` — all projects compile (0 errors)
- [x] `dotnet test` — 888 tests pass (47 headless + 841 existing)
- [x] `dotnet fantomas .` — all files formatted
- [x] Manual: 2 clients connect, paddles move, disconnect frees paddles for reconnecting clients
