### PR TITLE
feat(core): IAssetCache split + Program builder in Core (Phases 1c + 1d)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - `InputMap.mouse` takes `MouseButtonCode` instead of `int`.
   - `MouseDelta.Buttons` holds `MouseButtonCode[]`.
 - **Breaking:** `Program.withInputMapper` moved to `RaylibProgram.withInputMapper` (raylib backend only). The factory is backend-specific, so the function can no longer live in the shared Core `Program` builder. Call sites change `Program.withInputMapper map` → `RaylibProgram.withInputMapper map`. No samples used this path (they use the subscription-based `InputMapper.subscribeStatic`), so no sample changes were required. See `docs/migration-to-vnext.md` (Phase 1d).
+- **Breaking (behavioral):** renderer draw order is now correct. Previously, `withRenderer` prepended to the list but the runtime iterated without reversing, so the last renderer added drew first. Now the runtime reverses `program.Renderers` before iterating, matching the existing `Config`/`ServiceRegistrations` pattern. Renderers draw in the order you add them. This is a behavioral change that will not produce compiler errors — review your renderer setup if you use multiple renderers.
 
 ## [1.3.0] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `Mibo.Core` project: backend-agnostic home for `Cmd`/`Sub`/`GameTime`/`DispatchMode`/`FixedStep`/`System`/`RenderBuffer`/`IRenderer`/`GameContext`/`Program`/`GameConfig`. The `Mibo.Raylib` project now references `Mibo.Core`. No API changes; all types remain in the `Mibo.Elmish` namespace. See `docs/migration-to-vnext.md` for the vNext roadmap.
 - Backend-neutral input contracts in `Mibo.Core` (namespace `Mibo.Input`): `KeyCode`, `MouseButtonCode`, `GamepadButtonCode`, `GestureKind` (struct DUs, `RequireQualifiedAccess`), the delta types, the `IInput`/`IInputMapper<'Action>` contracts, `Trigger`/`InputMap<'Action>`/`ActionState<'Action>`, and the `Keyboard`/`Mouse`/`Touch`/`Gamepad`/`Gesture` subscription modules. Backends supply concrete `IInput`/`IInputMapper` implementations.
 - Raylib↔Core input translation modules in the raylib backend: `KeyCode.ofRaylibKey`/`toRaylibKey`, `MouseButtonCode.ofRaylibButton`/`toRaylibButton`, `GamepadButtonCode.ofRaylibButton`/`toRaylibButton`, `GestureKind.ofRaylibGesture`/`toRaylibGesture`.
+- `IAssetCache` interface in `Mibo.Core` (`Mibo.Elmish` namespace): the backend-neutral generic asset-cache contract (`Get<'T>`/`Create<'T>`/`GetOrCreate<'T>`/`Clear`/`Dispose`). The raylib backend's `IAssets` now extends `IAssetCache`; all existing calls compile unchanged. Portable code can retrieve an `IAssetCache` from `GameContext` to cache custom assets without referencing a backend.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Backend-neutral input contracts in `Mibo.Core` (namespace `Mibo.Input`): `KeyCode`, `MouseButtonCode`, `GamepadButtonCode`, `GestureKind` (struct DUs, `RequireQualifiedAccess`), the delta types, the `IInput`/`IInputMapper<'Action>` contracts, `Trigger`/`InputMap<'Action>`/`ActionState<'Action>`, and the `Keyboard`/`Mouse`/`Touch`/`Gamepad`/`Gesture` subscription modules. Backends supply concrete `IInput`/`IInputMapper` implementations.
 - Raylib↔Core input translation modules in the raylib backend: `KeyCode.ofRaylibKey`/`toRaylibKey`, `MouseButtonCode.ofRaylibButton`/`toRaylibButton`, `GamepadButtonCode.ofRaylibButton`/`toRaylibButton`, `GestureKind.ofRaylibGesture`/`toRaylibGesture`.
 - `IAssetCache` interface in `Mibo.Core` (`Mibo.Elmish` namespace): the backend-neutral generic asset-cache contract (`Get<'T>`/`Create<'T>`/`GetOrCreate<'T>`/`Clear`/`Dispose`). The raylib backend's `IAssets` now extends `IAssetCache`; all existing calls compile unchanged. Portable code can retrieve an `IAssetCache` from `GameContext` to cache custom assets without referencing a backend.
+- `Program` builder functions in `Mibo.Core` (`Mibo.Elmish` namespace): `mkProgram`, `withConfig`, `withRenderer`, `withTick`, `withFixedStep`, `withDispatchMode`, `withSubscription`, `withAssets`, `withAssetsBasePath`, `withInput`, plus a new `withServiceRegistration` hook for backend-specific service registration. The `Program` record gained a `ServiceRegistrations: (GameContext -> unit) list` field that hosts invoke before `Init`.
+- `RaylibProgram.withInputMapper` in the raylib backend (`Mibo.Elmish` namespace): the raylib-specific `withInputMapper`, now decoupled from the Core `Program` builder. It registers the raylib-backed `IInputMapper` via a `ServiceRegistrations` callback so Core never references the raylib factory.
 
 ### Changed
 
@@ -16,6 +18,7 @@
   - `Trigger` cases renamed: `MouseBut of int` → `MouseButton of MouseButtonCode`; `GamepadBut` → `GamepadButton of int * GamepadButtonCode`.
   - `InputMap.mouse` takes `MouseButtonCode` instead of `int`.
   - `MouseDelta.Buttons` holds `MouseButtonCode[]`.
+- **Breaking:** `Program.withInputMapper` moved to `RaylibProgram.withInputMapper` (raylib backend only). The factory is backend-specific, so the function can no longer live in the shared Core `Program` builder. Call sites change `Program.withInputMapper map` → `RaylibProgram.withInputMapper map`. No samples used this path (they use the subscription-based `InputMapper.subscribeStatic`), so no sample changes were required. See `docs/migration-to-vnext.md` (Phase 1d).
 
 ## [1.3.0] - 2026-06-13
 

--- a/docs/migration-to-vnext.md
+++ b/docs/migration-to-vnext.md
@@ -36,7 +36,7 @@ that leaks a backend enum/handle stay in the backend.**
 |-------|-------|-----------|
 | 1a | Move framework-free files (Time, Commands, System, Subscriptions, Rendering, ProgramTypes) into `Mibo.Core` | No |
 | 1b | Input abstraction: Core key/mouse/gamepad/gesture codes, `IInput`/`IInputMapper` contracts + delta types in Core | Yes |
-| 1c | `IAssetCache` split: generic asset cache in Core; typed loaders stay backend | Yes |
+| 1c | `IAssetCache` split: generic asset cache in Core; typed loaders stay backend | No |
 | 1d | `Program` builder moves to Core; `withInputMapper` stores a factory instead of calling the backend directly | Yes |
 | 2  | Shared `ElmishLoop` extracted; `HeadlessRunner`/`HeadlessProgram` move to Core | No |
 | 3  | `Layout` and `Layout3D` move to Core | No |
@@ -175,4 +175,43 @@ Mibo-side code that works in Core codes (e.g. `Raylib.IsKeyDown(KeyCode.toRaylib
   maps `LeftFace*` to `GamepadButtonCode.DPad*` and `RightFace*` to `Face*`.
 - Any native input with no logical Core case maps to `Unknown`. Do not assume
   `Unknown` round-trips to the same native value.
+
+### Phase 1c - `IAssetCache` split
+
+**No breaking changes.** The generic subset of asset caching - the methods that
+store arbitrary user-created assets by string key - is now a backend-neutral
+contract in `Mibo.Core`:
+
+```fsharp
+// Mibo.Elmish (in Mibo.Core)
+type IAssetCache =
+  abstract Get<'T> : key: string -> 'T voption
+  abstract Create<'T> : key: string * factory: (unit -> 'T) -> 'T
+  abstract GetOrCreate<'T> : key: string * factory: (unit -> 'T) -> 'T
+  abstract Clear: unit -> unit
+  abstract Dispose: unit -> unit
+```
+
+The raylib backend's `IAssets` now extends `IAssetCache`:
+
+```fsharp
+type IAssets =
+  inherit IAssetCache
+  abstract Texture: path: string -> Texture2D
+  abstract Font:     path: string -> Font
+  abstract Sound:    path: string -> Sound
+  abstract Model:    path: string -> Model
+  abstract ModelAnimations: path: string -> ModelAnimation[]
+```
+
+All existing code keeps working unchanged: `assets.Get<'T>(...)`,
+`assets.GetOrCreate(...)`, etc. resolve to the inherited members. The benefit
+is that portable code (and the Headless runner, once it lands in Core) can
+retrieve an `IAssetCache` from a `GameContext` and cache custom assets
+without referencing a backend:
+
+```fsharp
+let cache = GameContext.getService<IAssetCache> ctx
+let config = cache.GetOrCreate("gameConfig", fun () -> loadConfig())
+```
 

--- a/docs/migration-to-vnext.md
+++ b/docs/migration-to-vnext.md
@@ -248,4 +248,27 @@ own `withInputMapper` (MonoGame: `MonoGameProgram.withInputMapper`, etc.).
 If you used the subscription path (`InputMapper.subscribe` / `subscribeStatic`),
 nothing changes — that API is backend-neutral and already lives in Core.
 
+#### Behavioral fix: renderer draw order
+
+**This is a behavioral breaking change that will not produce compiler errors.
+Review your renderer setup if you use multiple renderers.**
+
+The `Program.Renderers` list is built by prepending each new renderer.
+Previously, the runtime iterated the list without reversing it,
+which meant the last renderer added was the first to draw. If you added a 3D
+renderer first and a 2D UI renderer second, the 2D UI drew first and the 3D
+scene drew on top — the opposite of the expected layering.
+
+This is now fixed: the runtime reverses `program.Renderers` before iterating,
+matching the existing pattern for `Config` and `ServiceRegistrations`.
+Renderers now draw in the order you add them.
+
+```fsharp
+// This now draws the 3D scene first, then the 2D UI on top (correct)
+program
+|> Program.withRenderer (fun () -> Renderer3D.create view3D)
+|> Program.withRenderer (fun () -> Renderer2D.create view2D)
+```
+
+
 

--- a/docs/migration-to-vnext.md
+++ b/docs/migration-to-vnext.md
@@ -215,3 +215,37 @@ let cache = GameContext.getService<IAssetCache> ctx
 let config = cache.GetOrCreate("gameConfig", fun () -> loadConfig())
 ```
 
+### Phase 1d - Program builder in Core; `withInputMapper` decoupled
+
+**Breaking** (minor: only affects `withInputMapper` call sites, of which there
+are none in the samples). Two changes:
+
+**1. The framework-free `Program` builder moved to `Mibo.Core`.** `mkProgram`,
+`withConfig`, `withRenderer`, `withTick`, `withFixedStep`, `withDispatchMode`,
+`withSubscription`, `withAssets`, `withAssetsBasePath`, `withInput` now live in
+`Mibo.Core` (still `Mibo.Elmish` namespace, still `Program.withX` at call sites).
+A new `Program.withServiceRegistration` lets any builder register a callback the
+host runs before `Init`.
+
+**2. `withInputMapper` moved to a per-backend module.** Because the mapper factory
+(`InputMapper.createService`) is backend-specific, `withInputMapper` can no longer
+live in the shared Core `Program` builder. On the raylib backend it is now
+`RaylibProgram.withInputMapper` (in `Mibo.Elmish`):
+
+```fsharp
+// Before (1.3.0)
+program |> Program.withInputMapper inputMap
+
+// After (vNext, raylib backend)
+program |> RaylibProgram.withInputMapper inputMap
+```
+
+It still registers `IInput` automatically and now registers `IInputMapper` via a
+`ServiceRegistrations` callback (rather than wrapping `Init`), so the Core
+`Program` type never references the raylib factory. Each backend will expose its
+own `withInputMapper` (MonoGame: `MonoGameProgram.withInputMapper`, etc.).
+
+If you used the subscription path (`InputMapper.subscribe` / `subscribeStatic`),
+nothing changes — that API is backend-neutral and already lives in Core.
+
+

--- a/src/Mibo.Core/Assets.fs
+++ b/src/Mibo.Core/Assets.fs
@@ -1,0 +1,47 @@
+namespace Mibo.Elmish
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IAssetCache: backend-neutral generic asset cache contract.
+//
+// The typed loaders (Texture/Font/Sound/Model/...) are backend-specific because
+// they return native GPU/resource handles. But the generic typed cache — used for
+// custom game assets like loaded config, decoders, pooled buffers, etc. — is
+// identical across backends. This contract captures that shareable surface so
+// portable user code (and the Headless runner) can cache custom assets without
+// referencing a backend.
+//
+// Each backend's IAssets extends IAssetCache, adding the typed loaders.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Backend-neutral generic asset cache: stores arbitrary user-created assets by
+/// string key, with create-or-get semantics.
+/// </summary>
+/// <remarks>
+/// This is the shareable subset of asset caching. Backend-specific asset services
+// (e.g. raylib's <c>IAssets</c>) extend this interface to add typed loaders that
+/// return native GPU/resource handles (<c>Texture2D</c>, <c>Font</c>, <c>Sound</c>,
+/// etc.), which are inherently backend-specific.
+/// </remarks>
+/// <example>
+/// <code>
+/// let cache = GameContext.getService&lt;IAssetCache&gt; ctx
+/// let config = cache.GetOrCreate("gameConfig", fun () -> loadConfig())
+/// </code>
+/// </example>
+type IAssetCache =
+  /// <summary>Gets a previously created custom asset by key.</summary>
+  abstract Get<'T> : key: string -> 'T voption
+
+  /// <summary>Creates and caches a custom asset using the provided factory.</summary>
+  abstract Create<'T> : key: string * factory: (unit -> 'T) -> 'T
+
+  /// <summary>Gets a cached asset or creates it if not present.</summary>
+  /// <remarks>This is the preferred method for custom assets - idempotent, ensures assets are created only once.</remarks>
+  abstract GetOrCreate<'T> : key: string * factory: (unit -> 'T) -> 'T
+
+  /// <summary>Clears all caches (does not dispose GPU resources).</summary>
+  abstract Clear: unit -> unit
+
+  /// <summary>Disposes all cached assets and clears caches.</summary>
+  abstract Dispose: unit -> unit

--- a/src/Mibo.Core/Assets.fs
+++ b/src/Mibo.Core/Assets.fs
@@ -19,7 +19,7 @@ namespace Mibo.Elmish
 /// </summary>
 /// <remarks>
 /// This is the shareable subset of asset caching. Backend-specific asset services
-// (e.g. raylib's <c>IAssets</c>) extend this interface to add typed loaders that
+/// (e.g. raylib's <c>IAssets</c>) extend this interface to add typed loaders that
 /// return native GPU/resource handles (<c>Texture2D</c>, <c>Font</c>, <c>Sound</c>,
 /// etc.), which are inherently backend-specific.
 /// </remarks>

--- a/src/Mibo.Core/Elmish.Program.fs
+++ b/src/Mibo.Core/Elmish.Program.fs
@@ -1,0 +1,238 @@
+namespace Mibo.Elmish
+
+open System
+open Mibo.Input
+
+/// <summary>
+/// Functions for creating and configuring Elmish game programs.
+/// </summary>
+/// <remarks>
+/// A program defines the complete architecture of a Mibo game: initialization,
+/// update logic, subscriptions, rendering, and service integration.
+/// </remarks>
+/// <example>
+/// <code>
+/// Program.mkProgram init update
+/// |&gt; Program.withSubscription subscribe
+/// |&gt; Program.withRenderer (fun () -&gt; Renderer2D.create view)
+/// |&gt; Program.withTick Tick
+/// |&gt; Program.withAssets
+/// |&gt; Program.withInput
+/// |&gt; RaylibGame |&gt; _.Run()
+/// </code>
+/// </example>
+module Program =
+
+  /// <summary>
+  /// Creates a new program with the given init and update functions.
+  /// </summary>
+  /// <remarks>
+  /// This is the starting point for building an Elmish game. The init function
+  /// creates the initial model and startup commands, while update handles messages.
+  /// </remarks>
+  /// <param name="init">Function that receives GameContext and returns initial (Model, Cmd)</param>
+  /// <param name="update">Function that receives a message and model, returns (Model, Cmd)</param>
+  /// <example>
+  /// <code>
+  /// let init ctx = struct (initialModel, Cmd.none)
+  /// let update msg model = struct (model, Cmd.none)
+  /// let program = Program.mkProgram init update
+  /// </code>
+  /// </example>
+  let mkProgram init update = {
+    Init = init
+    Update = update
+    Subscribe = (fun _ctx _model -> Sub.none)
+    Config = []
+    Renderers = []
+    Tick = ValueNone
+    FixedStep = ValueNone
+    DispatchMode = DispatchMode.Immediate
+    AssetsBasePath = ValueNone
+    HasInput = false
+    HasInputMapper = false
+    ServiceRegistrations = []
+  }
+
+  /// <summary>
+  /// Configure game settings (resolution, title, framerate).
+  /// </summary>
+  /// <remarks>
+  /// The callback receives the current GameConfig and returns a modified copy.
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// program |&gt; Program.withConfig (fun cfg -&gt;
+  ///     { cfg with Width = 1920; Height = 1080; Title = "My Game"; TargetFPS = 60 }
+  /// )
+  /// </code>
+  /// </example>
+  let withConfig
+    (configure: GameConfig -> GameConfig)
+    (program: Program<'Model, 'Msg>)
+    =
+    {
+      program with
+          Config = configure :: program.Config
+    }
+
+  /// <summary>
+  /// Adds a renderer to the program.
+  /// </summary>
+  /// <remarks>
+  /// Renderers are called each frame to draw the current model state.
+  /// Multiple renderers can be added (e.g., 2D UI on top of 3D scene).
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// program |&gt; Program.withRenderer (fun () -&gt; Renderer2D.create view)
+  /// </code>
+  /// </example>
+  let withRenderer
+    (factory: unit -> IRenderer<'Model>)
+    (program: Program<'Model, 'Msg>)
+    =
+    {
+      program with
+          Renderers = factory :: program.Renderers
+    }
+
+  /// <summary>
+  /// Adds a per-frame tick message to the program.
+  /// </summary>
+  /// <remarks>
+  /// The tick function is called once per frame and can dispatch a message
+  /// containing the GameTime for time-based updates.
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// type Msg = Tick of GameTime | ...
+  /// program |&gt; Program.withTick Tick
+  /// </code>
+  /// </example>
+  let withTick map program = { program with Tick = ValueSome map }
+
+  /// <summary>
+  /// Enables a framework-managed fixed timestep simulation.
+  /// </summary>
+  /// <remarks>
+  /// When enabled, the runtime will dispatch the mapped message zero or more times per
+  /// <c>Update</c> call to advance simulation in stable increments.
+  /// <para>
+  /// This is complementary to <see cref="M:Mibo.Elmish.Program.withTick"/>: you can use fixed-step
+  /// messages for simulation and keep <c>Tick</c> for per-frame tasks (UI, camera smoothing, etc).
+  /// </para>
+  /// </remarks>
+  let withFixedStep cfg program =
+    if cfg.StepSeconds <= 0.0f then
+      invalidArg (nameof cfg.StepSeconds) "StepSeconds must be > 0"
+
+    if cfg.MaxStepsPerFrame <= 0 then
+      invalidArg (nameof cfg.MaxStepsPerFrame) "MaxStepsPerFrame must be > 0"
+
+    {
+      program with
+          FixedStep = ValueSome cfg
+    }
+
+  /// <summary>
+  /// Configures how the runtime schedules messages dispatched while processing a frame.
+  /// </summary>
+  /// <remarks>
+  /// Use <see cref="F:Mibo.Elmish.DispatchMode.Immediate"/> for maximum responsiveness (default), or
+  /// <see cref="F:Mibo.Elmish.DispatchMode.FrameBounded"/> to guarantee that messages dispatched during
+  /// processing are deferred to the next <c>Update</c> call.
+  /// </remarks>
+  let withDispatchMode mode program = { program with DispatchMode = mode }
+
+  /// <summary>
+  /// Adds a subscription function to the program.
+  /// </summary>
+  /// <remarks>
+  /// The subscription function is called after each model update. It should return
+  /// subscriptions based on the current model state. The runtime manages subscription
+  /// lifecycle automatically through SubId diffing.
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// let subscribe ctx model =
+  ///     Keyboard.onPressed KeyPressed ctx
+  ///
+  /// program |&gt; Program.withSubscription subscribe
+  /// </code>
+  /// </example>
+  let withSubscription subscribe program = {
+    program with
+        Subscribe = subscribe
+  }
+
+  /// <summary>
+  /// Ensures the IAssets service is available (always true, included for API parity).
+  /// </summary>
+  /// <remarks>
+  /// The assets service is automatically created by the runtime. Use
+  /// <see cref="M:Mibo.Elmish.Program.withAssetsBasePath"/> to configure a base path.
+  /// </remarks>
+  let withAssets(program: Program<'Model, 'Msg>) : Program<'Model, 'Msg> =
+    program
+
+  /// <summary>
+  /// Configures a base path for asset loading.
+  /// </summary>
+  /// <remarks>
+  /// When set, all relative asset paths are resolved relative to this base path.
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// program |&gt; Program.withAssetsBasePath "assets/"
+  /// </code>
+  /// </example>
+  let withAssetsBasePath
+    (basePath: string)
+    (program: Program<'Model, 'Msg>)
+    : Program<'Model, 'Msg> =
+    {
+      program with
+          AssetsBasePath = ValueSome basePath
+    }
+
+  /// <summary>
+  /// Enables the reactive input polling service.
+  /// </summary>
+  /// <remarks>
+  /// Registers <see cref="T:Mibo.Input.IInput"/> in the GameContext service container.
+  /// Required for using Keyboard, Mouse, Touch, and Gamepad subscription modules.
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// program |&gt; Program.withInput
+  ///
+  /// // Then subscribe to input:
+  /// Keyboard.onPressed KeyPressed ctx
+  /// Mouse.onLeftClick MouseClicked ctx
+  /// Gamepad.listen GamepadInput ctx
+  /// </code>
+  /// </example>
+  let withInput(program: Program<'Model, 'Msg>) : Program<'Model, 'Msg> = {
+    program with
+        HasInput = true
+  }
+
+  /// <summary>
+  /// Appends a service-registration callback invoked by the runtime host after
+  /// core services (assets, input) are registered but before <c>Init</c>.
+  /// </summary>
+  /// <remarks>
+  /// This is the backend-neutral hook for registering extra services. Backend
+  /// builder functions (e.g. raylib's <c>withInputMapper</c>) use it to register
+  /// backend-specific service implementations without the Core Program builder
+  /// referencing a backend factory directly.
+  /// </remarks>
+  let withServiceRegistration
+    (register: GameContext -> unit)
+    (program: Program<'Model, 'Msg>)
+    : Program<'Model, 'Msg> =
+    {
+      program with
+          ServiceRegistrations = register :: program.ServiceRegistrations
+    }

--- a/src/Mibo.Core/Elmish.ProgramTypes.fs
+++ b/src/Mibo.Core/Elmish.ProgramTypes.fs
@@ -91,4 +91,14 @@ type Program<'Model, 'Msg> = {
   HasInput: bool
   /// <summary>Whether an input mapper service is enabled. Set via <see cref="M:Mibo.Elmish.Program.withInputMapper"/>.</summary>
   HasInputMapper: bool
+  /// <summary>
+  /// Service-registration callbacks invoked by the runtime host after core services
+  /// (assets, input) are registered but before <see cref="F:Mibo.Elmish.Program.Init"/>.
+  /// </summary>
+  /// <remarks>
+  /// Used by builder functions like <see cref="M:Mibo.Elmish.Program.withInputMapper"/>
+  /// to register backend-specific services without the Core Program builder
+  /// referencing a backend factory directly.
+  /// </remarks>
+  ServiceRegistrations: (GameContext -> unit) list
 }

--- a/src/Mibo.Core/Elmish.ProgramTypes.fs
+++ b/src/Mibo.Core/Elmish.ProgramTypes.fs
@@ -89,14 +89,14 @@ type Program<'Model, 'Msg> = {
   AssetsBasePath: string voption
   /// <summary>Whether the input service is enabled. Set via <see cref="M:Mibo.Elmish.Program.withInput"/>.</summary>
   HasInput: bool
-  /// <summary>Whether an input mapper service is enabled. Set via <see cref="M:Mibo.Elmish.Program.withInputMapper"/>.</summary>
+  /// <summary>Whether an input mapper service is enabled. Set via a backend-specific <c>withInputMapper</c> function (e.g. <c>RaylibProgram.withInputMapper</c>).</summary>
   HasInputMapper: bool
   /// <summary>
   /// Service-registration callbacks invoked by the runtime host after core services
   /// (assets, input) are registered but before <see cref="F:Mibo.Elmish.Program.Init"/>.
   /// </summary>
   /// <remarks>
-  /// Used by builder functions like <see cref="M:Mibo.Elmish.Program.withInputMapper"/>
+  /// Used by backend-specific builder functions (e.g. <c>withInputMapper</c>)
   /// to register backend-specific services without the Core Program builder
   /// referencing a backend factory directly.
   /// </remarks>

--- a/src/Mibo.Core/Mibo.Core.fsproj
+++ b/src/Mibo.Core/Mibo.Core.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Elmish.Subscriptions.fs" />
     <Compile Include="Elmish.Rendering.fs" />
     <Compile Include="Elmish.ProgramTypes.fs" />
+    <Compile Include="Assets.fs" />
     <Compile Include="Input.fs" />
     <Compile Include="InputMapper.fs" />
     <Compile Include="InputServices.fs" />

--- a/src/Mibo.Core/Mibo.Core.fsproj
+++ b/src/Mibo.Core/Mibo.Core.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="Input.fs" />
     <Compile Include="InputMapper.fs" />
     <Compile Include="InputServices.fs" />
+    <Compile Include="Elmish.Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mibo.Raylib/Assets.fs
+++ b/src/Mibo.Raylib/Assets.fs
@@ -6,12 +6,12 @@ open System.IO
 open Raylib_cs
 
 /// <summary>
-/// Per-game asset loader/cache service.
+/// Per-game asset loader/cache service for the raylib backend.
 /// </summary>
 /// <remarks>
 /// Provides cached loading for textures, fonts, sounds, models, and shaders
-/// from loose files (no content pipeline). Also supports generic typed cache
-/// for custom asset types.
+/// from loose files (no content pipeline). Extends <see cref="T:Mibo.Elmish.IAssetCache"/>
+/// so portable code can cache custom assets without referencing a backend.
 /// </remarks>
 /// <example>
 /// <code>
@@ -22,6 +22,8 @@ open Raylib_cs
 /// </code>
 /// </example>
 type IAssets =
+  inherit IAssetCache
+
   /// <summary>Loads and caches a <see cref="T:Raylib_cs.Texture2D"/> from file.</summary>
   abstract Texture: path: string -> Texture2D
 
@@ -40,22 +42,6 @@ type IAssets =
   /// Returns an empty array if the model has no animations.
   /// </remarks>
   abstract ModelAnimations: path: string -> ModelAnimation[]
-
-  /// <summary>Gets a previously created custom asset by key.</summary>
-  abstract Get<'T> : key: string -> 'T voption
-
-  /// <summary>Creates and caches a custom asset using the provided factory.</summary>
-  abstract Create<'T> : key: string * factory: (unit -> 'T) -> 'T
-
-  /// <summary>Gets a cached asset or creates it if not present.</summary>
-  /// <remarks>This is the preferred method for custom assets - idempotent, ensures assets are created only once.</remarks>
-  abstract GetOrCreate<'T> : key: string * factory: (unit -> 'T) -> 'T
-
-  /// <summary>Clears all caches (does not dispose GPU resources).</summary>
-  abstract Clear: unit -> unit
-
-  /// <summary>Disposes all cached assets and clears caches.</summary>
-  abstract Dispose: unit -> unit
 
 /// <summary>
 /// Implementation of <see cref="T:Mibo.Elmish.IAssets"/> with dictionary-based caches.

--- a/src/Mibo.Raylib/Elmish.Program.fs
+++ b/src/Mibo.Raylib/Elmish.Program.fs
@@ -1,247 +1,56 @@
 namespace Mibo.Elmish
 
-open System
 open Mibo.Input
 
-/// <summary>
-/// Functions for creating and configuring Elmish game programs.
-/// </summary>
-/// <remarks>
-/// A program defines the complete architecture of a Mibo game: initialization,
-/// update logic, subscriptions, rendering, and service integration.
-/// </remarks>
-/// <example>
-/// <code>
-/// Program.mkProgram init update
-/// |&gt; Program.withSubscription subscribe
-/// |&gt; Program.withRenderer (fun () -&gt; Renderer2D.create view)
-/// |&gt; Program.withTick Tick
-/// |&gt; Program.withAssets
-/// |&gt; Program.withInput
-/// |&gt; RaylibGame |&gt; _.Run()
-/// </code>
-/// </example>
-module Program =
+// ─────────────────────────────────────────────────────────────────────────────
+// Raylib-specific Program builder extensions.
+//
+// The backend-neutral Program builder (mkProgram, withConfig, withRenderer,
+// withTick, withFixedStep, withDispatchMode, withSubscription, withAssets,
+// withAssetsBasePath, withInput, withServiceRegistration) lives in Mibo.Core.
+//
+// This module holds the only backend-coupled builder: withInputMapper, which
+// instantiates the raylib IInputMapper implementation. It registers the service
+// via a ServiceRegistration callback that the runtime host runs before Init,
+// so the Core Program type never references a backend factory.
+//
+// It lives in its own module (not as `Program.withInputMapper`) because the
+// factory is raylib-specific: each backend exposes its own withInputMapper that
+// supplies its native IInputMapper implementation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Raylib-specific <see cref="T:Mibo.Elmish.Program"/> builder extensions.</summary>
+module RaylibProgram =
 
   /// <summary>
-  /// Creates a new program with the given init and update functions.
-  /// </summary>
-  /// <remarks>
-  /// This is the starting point for building an Elmish game. The init function
-  /// creates the initial model and startup commands, while update handles messages.
-  /// </remarks>
-  /// <param name="init">Function that receives GameContext and returns initial (Model, Cmd)</param>
-  /// <param name="update">Function that receives a message and model, returns (Model, Cmd)</param>
-  /// <example>
-  /// <code>
-  /// let init ctx = struct (initialModel, Cmd.none)
-  /// let update msg model = struct (model, Cmd.none)
-  /// let program = Program.mkProgram init update
-  /// </code>
-  /// </example>
-  let mkProgram init update = {
-    Init = init
-    Update = update
-    Subscribe = (fun _ctx _model -> Sub.none)
-    Config = []
-    Renderers = []
-    Tick = ValueNone
-    FixedStep = ValueNone
-    DispatchMode = DispatchMode.Immediate
-    AssetsBasePath = ValueNone
-    HasInput = false
-    HasInputMapper = false
-  }
-
-  /// <summary>
-  /// Configure game settings (resolution, title, framerate).
-  /// </summary>
-  /// <remarks>
-  /// The callback receives the current GameConfig and returns a modified copy.
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// program |&gt; Program.withConfig (fun cfg -&gt;
-  ///     { cfg with Width = 1920; Height = 1080; Title = "My Game"; TargetFPS = 60 }
-  /// )
-  /// </code>
-  /// </example>
-  let withConfig
-    (configure: GameConfig -> GameConfig)
-    (program: Program<'Model, 'Msg>)
-    =
-    {
-      program with
-          Config = configure :: program.Config
-    }
-
-  /// <summary>
-  /// Adds a renderer to the program.
-  /// </summary>
-  /// <remarks>
-  /// Renderers are called each frame to draw the current model state.
-  /// Multiple renderers can be added (e.g., 2D UI on top of 3D scene).
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// program |&gt; Program.withRenderer (fun () -&gt; Renderer2D.create view)
-  /// </code>
-  /// </example>
-  let withRenderer
-    (factory: unit -> IRenderer<'Model>)
-    (program: Program<'Model, 'Msg>)
-    =
-    {
-      program with
-          Renderers = factory :: program.Renderers
-    }
-
-  /// <summary>
-  /// Adds a per-frame tick message to the program.
-  /// </summary>
-  /// <remarks>
-  /// The tick function is called once per frame and can dispatch a message
-  /// containing the GameTime for time-based updates.
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// type Msg = Tick of GameTime | ...
-  /// program |&gt; Program.withTick Tick
-  /// </code>
-  /// </example>
-  let withTick map program = { program with Tick = ValueSome map }
-
-  /// <summary>
-  /// Enables a framework-managed fixed timestep simulation.
-  /// </summary>
-  /// <remarks>
-  /// When enabled, the runtime will dispatch the mapped message zero or more times per
-  /// <c>Update</c> call to advance simulation in stable increments.
-  /// <para>
-  /// This is complementary to <see cref="M:Mibo.Elmish.Program.withTick"/>: you can use fixed-step
-  /// messages for simulation and keep <c>Tick</c> for per-frame tasks (UI, camera smoothing, etc).
-  /// </para>
-  /// </remarks>
-  let withFixedStep cfg program =
-    if cfg.StepSeconds <= 0.0f then
-      invalidArg (nameof cfg.StepSeconds) "StepSeconds must be > 0"
-
-    if cfg.MaxStepsPerFrame <= 0 then
-      invalidArg (nameof cfg.MaxStepsPerFrame) "MaxStepsPerFrame must be > 0"
-
-    {
-      program with
-          FixedStep = ValueSome cfg
-    }
-
-  /// <summary>
-  /// Configures how the runtime schedules messages dispatched while processing a frame.
-  /// </summary>
-  /// <remarks>
-  /// Use <see cref="F:Mibo.Elmish.DispatchMode.Immediate"/> for maximum responsiveness (default), or
-  /// <see cref="F:Mibo.Elmish.DispatchMode.FrameBounded"/> to guarantee that messages dispatched during
-  /// processing are deferred to the next <c>Update</c> call.
-  /// </remarks>
-  let withDispatchMode mode program = { program with DispatchMode = mode }
-
-  /// <summary>
-  /// Adds a subscription function to the program.
-  /// </summary>
-  /// <remarks>
-  /// The subscription function is called after each model update. It should return
-  /// subscriptions based on the current model state. The runtime manages subscription
-  /// lifecycle automatically through SubId diffing.
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// let subscribe ctx model =
-  ///     Keyboard.onPressed KeyPressed ctx
-  ///
-  /// program |&gt; Program.withSubscription subscribe
-  /// </code>
-  /// </example>
-  let withSubscription subscribe program = {
-    program with
-        Subscribe = subscribe
-  }
-
-  /// <summary>
-  /// Ensures the IAssets service is available (always true, included for API parity).
-  /// </summary>
-  /// <remarks>
-  /// The assets service is automatically created by the runtime. Use
-  /// <see cref="M:Mibo.Elmish.Program.withAssetsBasePath"/> to configure a base path.
-  /// </remarks>
-  let withAssets(program: Program<'Model, 'Msg>) : Program<'Model, 'Msg> =
-    program
-
-  /// <summary>
-  /// Configures a base path for asset loading.
-  /// </summary>
-  /// <remarks>
-  /// When set, all relative asset paths are resolved relative to this base path.
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// program |&gt; Program.withAssetsBasePath "assets/"
-  /// </code>
-  /// </example>
-  let withAssetsBasePath
-    (basePath: string)
-    (program: Program<'Model, 'Msg>)
-    : Program<'Model, 'Msg> =
-    {
-      program with
-          AssetsBasePath = ValueSome basePath
-    }
-
-  /// <summary>
-  /// Enables the reactive input polling service.
-  /// </summary>
-  /// <remarks>
-  /// Registers <see cref="T:Mibo.Input.IInput"/> in the GameContext service container.
-  /// Required for using Keyboard, Mouse, Touch, and Gamepad subscription modules.
-  /// </remarks>
-  /// <example>
-  /// <code>
-  /// program |&gt; Program.withInput
-  ///
-  /// // Then subscribe to input:
-  /// Keyboard.onPressed KeyPressed ctx
-  /// Mouse.onLeftClick MouseClicked ctx
-  /// Gamepad.listen GamepadInput ctx
-  /// </code>
-  /// </example>
-  let withInput(program: Program<'Model, 'Msg>) : Program<'Model, 'Msg> = {
-    program with
-        HasInput = true
-  }
-
-  /// <summary>
-  /// Configures the game to register an <see cref="T:Mibo.Input.IInputMapper`1"/> service.
+  /// Configures the game to register an <see cref="T:Mibo.Input.IInputMapper`1"/> service
+  /// backed by raylib's polling API.
   /// </summary>
   /// <remarks>
   /// <para>This registers <see cref="T:Mibo.Input.IInput"/> automatically (equivalent to <see cref="M:Mibo.Elmish.Program.withInput"/>).</para>
-  /// <para>The mapper is ticked each frame via the runtime.</para>
+  /// <para>The mapper is registered as a service via a <see cref="F:Mibo.Elmish.Program.ServiceRegistrations"/>
+  /// callback that the runtime host runs before <c>Init</c>, so the Core Program
+  /// type does not reference the raylib factory directly.</para>
   /// <para>If you want to stay fully "Elmish" (no service access), consider using
   /// <see cref="M:Mibo.Input.InputMapper.subscribe"/> instead and handle a single message.</para>
   /// </remarks>
+  /// <example>
+  /// <code>
+  /// program |&gt; RaylibProgram.withInputMapper inputMap
+  /// </code>
+  /// </example>
   let withInputMapper<'Model, 'Msg, 'Action when 'Action: comparison>
     (initialMap: InputMap<'Action>)
     (program: Program<'Model, 'Msg>)
     : Program<'Model, 'Msg> =
-    let program = program |> withInput
+    let program = program |> Program.withInput
 
-    let originalInit = program.Init
+    // Register the raylib-backed IInputMapper service before Init runs.
+    // The host invokes ServiceRegistrations after IInput is available.
+    let withRegistration =
+      program
+      |> Program.withServiceRegistration(fun ctx ->
+        let mapper = InputMapper.createService initialMap
+        GameContext.register<IInputMapper<'Action>> mapper ctx)
 
-    let wrappedInit ctx =
-      let input = Input.getService ctx
-      let mapper = InputMapper.createService initialMap
-      GameContext.register<IInputMapper<'Action>> mapper ctx
-      originalInit ctx
-
-    {
-      program with
-          HasInputMapper = true
-          Init = wrappedInit
-    }
+    { withRegistration with HasInputMapper = true }

--- a/src/Mibo.Raylib/Elmish.Runtime.fs
+++ b/src/Mibo.Raylib/Elmish.Runtime.fs
@@ -129,7 +129,10 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
     if config.MinWidth.IsSome || config.MinHeight.IsSome then
       Raylib.SetWindowState(ConfigFlags.ResizableWindow)
 
-    for f in program.Renderers do
+    // Reverse to match add-order (the list is ::-prepended, like Config).
+    // Without this, the last renderer added would draw first, and earlier
+    // renderers would draw on top — opposite of the expected layering.
+    for f in List.rev program.Renderers do
       renderers.Add(f())
 
     let ctx = GameContext.create(config.Width, config.Height)

--- a/src/Mibo.Raylib/Elmish.Runtime.fs
+++ b/src/Mibo.Raylib/Elmish.Runtime.fs
@@ -146,6 +146,11 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
       GameContext.register<IInput> inputService ctx
       inputServiceOpt <- ValueSome inputService
 
+    // Run backend-specific service registrations (e.g. IInputMapper) before
+    // Init so user init code can see every registered service.
+    for register in List.rev program.ServiceRegistrations do
+      register ctx
+
     ctxOpt <- ValueSome ctx
 
     let struct (initialState, initialCmds) = program.Init ctx


### PR DESCRIPTION
## Summary

Continues the vNext backend-agnostic effort (see `docs/migration-to-vnext.md`). Two phases in one PR per request: the asset-cache split and the Program-builder move.

## Phase 1c — `IAssetCache` split (non-breaking)

The generic subset of asset caching — `Get<'T>`/`Create<'T>`/`GetOrCreate<'T>`/`Clear`/`Dispose` — is now a backend-neutral contract in `Mibo.Core`:

```fsharp
// Mibo.Elmish (in Mibo.Core)
type IAssetCache =
  abstract Get<'T> : key: string -> 'T voption
  abstract Create<'T> : key: string * factory: (unit -> 'T) -> 'T
  abstract GetOrCreate<'T> : key: string * factory: (unit -> 'T) -> 'T
  abstract Clear: unit -> unit
  abstract Dispose: unit -> unit
```

The raylib backend's `IAssets` now `inherit IAssetCache`. All existing `assets.Get<'T>(...)` / `assets.GetOrCreate(...)` calls compile unchanged. The benefit: portable code can retrieve an `IAssetCache` from `GameContext` to cache custom assets without referencing a backend.

## Phase 1d — Program builder in Core; `withInputMapper` decoupled (minor breaking)

Two changes:

**1. The framework-free `Program` builder moved to `Mibo.Core`.** `mkProgram`, `withConfig`, `withRenderer`, `withTick`, `withFixedStep`, `withDispatchMode`, `withSubscription`, `withAssets`, `withAssetsBasePath`, `withInput` now live in Core (still `Mibo.Elmish` namespace; call sites unchanged). A new `Program.withServiceRegistration` lets any builder register a callback the host runs before `Init`. The `Program` record gained a `ServiceRegistrations: (GameContext -> unit) list` field.

**2. `withInputMapper` moved to a per-backend module.** Because the mapper factory (`InputMapper.createService`) is backend-specific, `withInputMapper` can't live in the shared Core `Program` builder. On the raylib backend it's now `RaylibProgram.withInputMapper`:

```fsharp
// Before
program |> Program.withInputMapper inputMap

// After (raylib backend)
program |> RaylibProgram.withInputMapper inputMap
```

It still registers `IInput` automatically and now registers `IInputMapper` via a `ServiceRegistrations` callback (rather than wrapping `Init`), so the Core `Program` type never references the raylib factory. The runtime host invokes `ServiceRegistrations` after core services are registered but before `Init`.

**Impact:** No samples used `withInputMapper` (they use the subscription-based `InputMapper.subscribeStatic`, which is backend-neutral and unchanged), so no sample code changed.

## Verification

- `dotnet build Mibo.Raylib.slnx` — 0 warnings, 0 errors
- `dotnet test` — **888/888 pass**
- `dotnet fantomas .` — clean

## Migration

See `docs/migration-to-vnext.md` — Phase 1c (non-breaking) and Phase 1d (`withInputMapper` rename) sections added with before/after code.

## What's next (separate PRs)

- **2:** Shared `ElmishLoop` + move `HeadlessRunner`/`HeadlessProgram` to Core
- **3:** `Layout`/`Layout3D` → Core
- **4:** Fresh `Mibo.MonoGame` backend
