### PR TITLE
feat(core): extract shared ElmishLoop; move Headless to Core (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - `IAssetCache` interface in `Mibo.Core` (`Mibo.Elmish` namespace): the backend-neutral generic asset-cache contract (`Get<'T>`/`Create<'T>`/`GetOrCreate<'T>`/`Clear`/`Dispose`). The raylib backend's `IAssets` now extends `IAssetCache`; all existing calls compile unchanged. Portable code can retrieve an `IAssetCache` from `GameContext` to cache custom assets without referencing a backend.
 - `Program` builder functions in `Mibo.Core` (`Mibo.Elmish` namespace): `mkProgram`, `withConfig`, `withRenderer`, `withTick`, `withFixedStep`, `withDispatchMode`, `withSubscription`, `withAssets`, `withAssetsBasePath`, `withInput`, plus a new `withServiceRegistration` hook for backend-specific service registration. The `Program` record gained a `ServiceRegistrations: (GameContext -> unit) list` field that hosts invoke before `Init`.
 - `RaylibProgram.withInputMapper` in the raylib backend (`Mibo.Elmish` namespace): the raylib-specific `withInputMapper`, now decoupled from the Core `Program` builder. It registers the raylib-backed `IInputMapper` via a `ServiceRegistrations` callback so Core never references the raylib factory.
+- `ElmishLoop<'Model,'Msg>` and `LoopCore<'Model,'Msg>` in `Mibo.Core` (`Mibo.Elmish` namespace): the shared message-processing loop extracted from the duplicated code in `RaylibGame` and `HeadlessRunner`. Both hosts now delegate to `ElmishLoop`; `Program` and `HeadlessProgram` project to `LoopCore` via `ElmishLoop.coreOfProgram` / `HeadlessProgram.toLoopCore`.
+- `HeadlessProgram`, `HeadlessRunner`, and the `HeadlessProgram` builder module moved from the raylib backend to `Mibo.Core` (pure F#, no backend dependencies). All existing user code keeps working unchanged — types stay in the `Mibo.Elmish` namespace.
 
 ### Changed
 

--- a/docs/migration-to-vnext.md
+++ b/docs/migration-to-vnext.md
@@ -270,5 +270,26 @@ program
 |> Program.withRenderer (fun () -> Renderer2D.create view2D)
 ```
 
+### Phase 2 - Shared ElmishLoop; HeadlessRunner/HeadlessProgram in Core
+
+**No breaking changes.** The message-processing core that was duplicated between
+`RaylibGame` and `HeadlessRunner` (the dispatch queue, `execCmd`, `updateSubs`,
+deferred-effect draining, `FixedStep` accumulation, tick dispatch, and the
+message pump) is now a shared `ElmishLoop<'Model,'Msg>` type in `Mibo.Core`.
+
+A `LoopCore<'Model,'Msg>` struct record captures the six fields that define
+message-processing behavior (Init/Update/Subscribe/Tick/FixedStep/DispatchMode).
+`Program` and `HeadlessProgram` each project to `LoopCore` without changing shape.
+
+`HeadlessProgram`, `HeadlessRunner`, and the `HeadlessProgram` builder module
+(`mkHeadless`, `withSubscribe`, `withTick`, `withFixedStep`, `withDispatchMode`,
+`withObserver`, `observe`) have moved from the raylib backend to `Mibo.Core`.
+They are pure F# with zero backend dependencies, so this is a pure relocation.
+
+All existing user code (`HeadlessProgram.mkHeadless`, `HeadlessRunner`, etc.)
+keeps working unchanged — the types stay in the `Mibo.Elmish` namespace.
+The `PingPong` server sample, which relies on `HeadlessRunner`, continues to work.
+
+
 
 

--- a/src/Mibo.Core/Elmish.Headless.fs
+++ b/src/Mibo.Core/Elmish.Headless.fs
@@ -31,9 +31,7 @@ type HeadlessProgram<'Model, 'Msg> = {
   Observers: (unit -> IObserver<struct (GameContext * 'Model * GameTime)>) list
 }
 
-/// <summary>
-/// Functions for creating and configuring headless Elmish programs.
-/// </summary>
+/// <summary>Extension functions for projecting a <see cref="T:Mibo.Elmish.HeadlessProgram`2"/> onto a <see cref="T:Mibo.Elmish.LoopCore`2"/>.</summary>
 module HeadlessProgram =
 
   /// <summary>
@@ -45,6 +43,19 @@ module HeadlessProgram =
         member _.OnNext value = onNext value
         member _.OnError _ = ()
         member _.OnCompleted() = ()
+    }
+
+  /// <summary>Projects a <see cref="T:Mibo.Elmish.HeadlessProgram`2"/> to a <see cref="T:Mibo.Elmish.LoopCore`2"/>.</summary>
+  let toLoopCore
+    (program: HeadlessProgram<'Model, 'Msg>)
+    : LoopCore<'Model, 'Msg> =
+    {
+      Init = program.Init
+      Update = program.Update
+      Subscribe = program.Subscribe
+      Tick = program.Tick
+      FixedStep = program.FixedStep
+      DispatchMode = program.DispatchMode
     }
 
   /// <summary>
@@ -112,114 +123,49 @@ module HeadlessProgram =
 /// Controls execution of a headless Elmish program with explicit frame stepping.
 /// </summary>
 /// <remarks>
-/// The runner manages virtual time, message dispatching, command execution,
-/// and subscription lifecycle. Call <see cref="Step"/> or <see cref="StepN"/>
-/// to advance the simulation.
+/// The runner delegates message processing to a shared <see cref="T:Mibo.Elmish.ElmishLoop`2"/>
+/// and adds observer notification + virtual time management on top. Call <see cref="Step"/>
+/// or <see cref="StepN"/> to advance the simulation.
 /// </remarks>
 type HeadlessRunner<'Model, 'Msg>
   (program: HeadlessProgram<'Model, 'Msg>, ?width: int, ?height: int) =
 
-  let msgQueue = DispatchQueue<'Msg> program.DispatchMode
-  let mutable state: 'Model = Unchecked.defaultof<'Model>
-  let mutable ctxOpt: GameContext voption = ValueNone
-  let activeSubs = Dictionary<SubId, IDisposable>()
-  let subIdsInUse = HashSet<SubId>()
-  let subIdsToRemove = ResizeArray<SubId>(32)
-  let subBuffer = ResizeArray<struct (SubId * Subscribe<'Msg>)>()
-  let subStack = ResizeArray<Sub<'Msg>>()
-  let deferredEffs = ResizeArray<Effect<'Msg>>(64)
-  let deferredEffsRun = ResizeArray<Effect<'Msg>>(64)
-  let mutable fixedAccSeconds = 0.0f
+  let loop = ElmishLoop.create(HeadlessProgram.toLoopCore program)
+
+  let observers =
+    ResizeArray<IObserver<struct (GameContext * 'Model * GameTime)>>()
 
   let mutable gameTime = {
     TotalTime = TimeSpan.Zero
     ElapsedGameTime = TimeSpan.Zero
   }
 
-
-  let mutable shouldQuit = false
-
-  let observers =
-    ResizeArray<IObserver<struct (GameContext * 'Model * GameTime)>>()
-
   let w = defaultArg width 800
   let h = defaultArg height 600
 
-  let dispatch(msg: 'Msg) = msgQueue.Dispatch(msg)
-
-  let execCmd(cmd: Cmd<'Msg>) =
-    match cmd with
-    | Empty -> ()
-    | Quit -> shouldQuit <- true
-    | Single eff -> eff.Invoke dispatch
-    | Batch effs ->
-      for i = 0 to effs.Length - 1 do
-        effs[i].Invoke dispatch
-    | DeferNextFrame effs -> deferredEffs.AddRange effs
-    | NowAndDeferNextFrame(now, next) ->
-      for i = 0 to now.Length - 1 do
-        now[i].Invoke dispatch
-
-      deferredEffs.AddRange next
-
-  let updateSubs(ctx: GameContext) =
-    subBuffer.Clear()
-    subStack.Clear()
-    subStack.Add(program.Subscribe ctx state)
-    Sub.flatten subStack subBuffer
-
-    subIdsInUse.Clear()
-    subIdsToRemove.Clear()
-
-    for id, subscribeFn in subBuffer do
-      subIdsInUse.Add id |> ignore
-
-      if not(activeSubs.ContainsKey id) then
-        try
-          activeSubs.Add(id, subscribeFn dispatch)
-        with ex ->
-          Console.WriteLine $"Error starting sub {SubId.value id}: {ex}"
-
-    for KeyValue(key, _disp) in activeSubs do
-      if not(subIdsInUse.Contains key) then
-        subIdsToRemove.Add key
-
-    for i = 0 to subIdsToRemove.Count - 1 do
-      let key = subIdsToRemove[i]
-
-      match activeSubs.TryGetValue key with
-      | true, disp ->
-        disp.Dispose()
-        activeSubs.Remove key |> ignore
-      | _ -> ()
-
   do
     let ctx = GameContext.create(w, h)
-    ctxOpt <- ValueSome ctx
-    let struct (initialState, initialCmds) = program.Init ctx
-    state <- initialState
-    execCmd initialCmds
-    updateSubs ctx
+    loop.Init(ctx)
 
     for factory in program.Observers do
       observers.Add(factory())
 
   /// <summary>Whether the runner has received a Quit signal.</summary>
-  member _.ShouldQuit = shouldQuit
+  member _.ShouldQuit = loop.ShouldQuit
 
   /// <summary>The current model state.</summary>
-  member _.Model = state
+  member _.Model = loop.Model
 
   /// <summary>Total elapsed virtual time.</summary>
   member _.GameTime = gameTime
 
   /// <summary>Dispatch a message to the runner.</summary>
-  member _.Dispatch(msg: 'Msg) = dispatch msg
+  member _.Dispatch(msg: 'Msg) = loop.Dispatch(msg)
 
   /// <summary>Dispatch multiple messages at once.</summary>
   member _.DispatchMany(msgs: 'Msg seq) =
     for msg in msgs do
-      dispatch msg
+      loop.Dispatch(msg)
 
   /// <summary>Advance the simulation by one frame with the given delta time.</summary>
   /// <param name="elapsed">Frame delta (e.g. TimeSpan.FromMilliseconds(16) for 60fps). Negative values are clamped to zero.</param>
@@ -229,7 +175,7 @@ type HeadlessRunner<'Model, 'Msg>
   /// — they all advance the simulation and using them together will produce simulation corruption.
   /// </remarks>
   member _.Step(elapsed: TimeSpan) =
-    if shouldQuit then
+    if loop.ShouldQuit then
       ()
     else
 
@@ -238,59 +184,14 @@ type HeadlessRunner<'Model, 'Msg>
       gameTime <- {
         TotalTime = gameTime.TotalTime + elapsed
         ElapsedGameTime = elapsed
-
       }
 
-      if deferredEffs.Count <> 0 then
-        deferredEffsRun.Clear()
-        deferredEffsRun.AddRange(deferredEffs)
-        deferredEffs.Clear()
+      loop.TickFrame(elapsed, gameTime) |> ignore
 
-        for i = 0 to deferredEffsRun.Count - 1 do
-          deferredEffsRun[i].Invoke(dispatch)
-
-      match program.FixedStep with
-      | ValueNone -> ()
-      | ValueSome cfg ->
-        let maxFrame = cfg.MaxFrameSeconds |> ValueOption.defaultValue 0.25f
-        let deltaSeconds = float32 elapsed.TotalSeconds
-
-        let struct (acc2, steps, _dropped) =
-          FixedStep.compute
-            cfg.StepSeconds
-            cfg.MaxStepsPerFrame
-            maxFrame
-            fixedAccSeconds
-            deltaSeconds
-
-        fixedAccSeconds <- acc2
-
-        for _i = 1 to steps do
-          dispatch(cfg.Map cfg.StepSeconds)
-
-      program.Tick |> ValueOption.iter(fun map -> dispatch(map gameTime))
-
-      let mutable stateChanged = false
-      let mutable msg = Unchecked.defaultof<'Msg>
-      msgQueue.StartBatch()
-
-      while msgQueue.TryDequeue(&msg) do
-        let struct (newState, cmds) = program.Update msg state
-        state <- newState
-        execCmd cmds
-        stateChanged <- true
-
-      msgQueue.EndBatch()
-
-      if stateChanged then
-        match ctxOpt with
-        | ValueSome ctx -> updateSubs ctx
-        | ValueNone -> ()
-
-      match ctxOpt with
+      match loop.Context with
       | ValueSome ctx ->
         for i = 0 to observers.Count - 1 do
-          observers[i].OnNext(ctx, state, gameTime)
+          observers[i].OnNext(ctx, loop.Model, gameTime)
       | ValueNone -> ()
 
   /// <summary>Advance the simulation by N frames.</summary>
@@ -422,10 +323,7 @@ type HeadlessRunner<'Model, 'Msg>
 
   /// <summary>Dispose active subscriptions, observers, and clean up resources.</summary>
   member _.Dispose() =
-    for KeyValue(_key, disp) in activeSubs do
-      disp.Dispose()
-
-    activeSubs.Clear()
+    loop.DisposeSubs()
 
     for i = 0 to observers.Count - 1 do
       match observers[i] with

--- a/src/Mibo.Core/Elmish.Headless.fs
+++ b/src/Mibo.Core/Elmish.Headless.fs
@@ -147,7 +147,10 @@ type HeadlessRunner<'Model, 'Msg>
     let ctx = GameContext.create(w, h)
     loop.Init(ctx)
 
-    for factory in program.Observers do
+    // Observers are stored by prepending (see withObserver), so reverse to
+    // initialize and notify in registration order — matching Renderers,
+    // Config, and ServiceRegistrations.
+    for factory in List.rev program.Observers do
       observers.Add(factory())
 
   /// <summary>Whether the runner has received a Quit signal.</summary>

--- a/src/Mibo.Core/Elmish.Loop.fs
+++ b/src/Mibo.Core/Elmish.Loop.fs
@@ -1,0 +1,262 @@
+namespace Mibo.Elmish
+
+open System
+open System.Collections.Concurrent
+open System.Collections.Generic
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The shared Elmish message-processing loop.
+//
+// Both RaylibGame (the windowed host) and HeadlessRunner (the headless host)
+// run the exact same message-processing core: a DispatchQueue, execCmd,
+// updateSubs, deferred-effect draining, FixedStep accumulation, tick dispatch,
+// and the StartBatch/TryDequeue/EndBatch message pump. This type captures that
+// shared core so the two hosts become thin I/O shells around it.
+//
+// A host constructs an ElmishLoop from a LoopCore (the six fields that define
+// message-processing behavior) and then:
+//   1. calls Init(ctx) once after registering backend services
+//   2. calls TickFrame(dt, gameTime) each frame
+//   3. reads Model / ShouldQuit / GameTime as needed
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Internal message queue supporting optional frame-bounded dispatch.
+/// </summary>
+/// <remarks>
+/// Extracted from the runtime so both the windowed and headless hosts share it.
+/// Kept internal — hosts interact with it through <see cref="T:Mibo.Elmish.ElmishLoop`2"/>.
+/// </remarks>
+type internal DispatchQueue<'Msg>(mode: DispatchMode) =
+  let gate = obj()
+  let mutable isProcessing = false
+  let mutable current = ConcurrentQueue<'Msg>()
+  let mutable next = ConcurrentQueue<'Msg>()
+
+  member _.Mode = mode
+
+  member _.Dispatch(msg: 'Msg) =
+    match mode with
+    | Immediate -> current.Enqueue(msg)
+    | FrameBounded ->
+      lock gate (fun () ->
+        if isProcessing then
+          next.Enqueue(msg)
+        else
+          current.Enqueue(msg))
+
+  member _.StartBatch() =
+    match mode with
+    | Immediate -> ()
+    | FrameBounded -> lock gate (fun () -> isProcessing <- true)
+
+  member _.EndBatch() =
+    match mode with
+    | Immediate -> ()
+    | FrameBounded ->
+      lock gate (fun () ->
+        isProcessing <- false
+        let tmp = current
+        current <- next
+        next <- tmp)
+
+  member _.TryDequeue(msg: byref<'Msg>) = current.TryDequeue(&msg)
+
+/// <summary>
+/// The six fields that define message-processing behavior, shared by
+/// <see cref="T:Mibo.Elmish.Program`2"/> and <see cref="T:Mibo.Elmish.HeadlessProgram`2"/>.
+/// </summary>
+/// <remarks>
+/// Each host projects its program type to a <c>LoopCore</c> via a trivial accessor,
+/// so neither <c>Program</c> nor <c>HeadlessProgram</c> changes shape.
+/// </remarks>
+[<Struct>]
+type LoopCore<'Model, 'Msg> = {
+  Init: GameContext -> struct ('Model * Cmd<'Msg>)
+  Update: 'Msg -> 'Model -> struct ('Model * Cmd<'Msg>)
+  Subscribe: GameContext -> 'Model -> Sub<'Msg>
+  Tick: (GameTime -> 'Msg) voption
+  FixedStep: FixedStepConfig<'Msg> voption
+  DispatchMode: DispatchMode
+}
+
+/// <summary>
+/// The shared message-processing loop used by every Mibo host
+/// (<c>RaylibGame</c>, <c>HeadlessRunner</c>, future backends).
+/// </summary>
+/// <remarks>
+/// Owns all mutable loop state: the dispatch queue, current model, active
+/// subscriptions, deferred-effect buffers, and the fixed-step accumulator.
+/// Hosts call <see cref="M:Mibo.Elmish.ElmishLoop`2.Init"/> once after registering
+/// backend services, then <see cref="M:Mibo.Elmish.ElmishLoop`2.TickFrame"/> each frame.
+/// </remarks>
+type ElmishLoop<'Model, 'Msg> internal (core: LoopCore<'Model, 'Msg>) =
+
+  let msgQueue = DispatchQueue<'Msg>(core.DispatchMode)
+  let mutable state: 'Model = Unchecked.defaultof<'Model>
+  let mutable ctxOpt: GameContext voption = ValueNone
+  let activeSubs = Dictionary<SubId, IDisposable>()
+  let subIdsInUse = HashSet<SubId>()
+  let subIdsToRemove = ResizeArray<SubId>(32)
+  let subBuffer = ResizeArray<struct (SubId * Subscribe<'Msg>)>()
+  let subStack = ResizeArray<Sub<'Msg>>()
+  let deferredEffs = ResizeArray<Effect<'Msg>>(64)
+  let deferredEffsRun = ResizeArray<Effect<'Msg>>(64)
+  let mutable fixedAccSeconds = 0.0f
+  let mutable shouldQuit = false
+
+  let dispatch(msg: 'Msg) = msgQueue.Dispatch(msg)
+
+  let execCmd(cmd: Cmd<'Msg>) =
+    match cmd with
+    | Empty -> ()
+    | Quit -> shouldQuit <- true
+    | Single eff -> eff.Invoke(dispatch)
+    | Batch effs ->
+      for i = 0 to effs.Length - 1 do
+        effs[i].Invoke(dispatch)
+    | DeferNextFrame effs -> deferredEffs.AddRange(effs)
+    | NowAndDeferNextFrame(now, next) ->
+      for i = 0 to now.Length - 1 do
+        now[i].Invoke(dispatch)
+
+      deferredEffs.AddRange(next)
+
+  let updateSubs(ctx: GameContext) =
+    subBuffer.Clear()
+    subStack.Clear()
+    subStack.Add(core.Subscribe ctx state)
+    Sub.flatten subStack subBuffer
+
+    subIdsInUse.Clear()
+    subIdsToRemove.Clear()
+
+    for id, subscribeFn in subBuffer do
+      subIdsInUse.Add(id) |> ignore
+
+      if not(activeSubs.ContainsKey(id)) then
+        try
+          activeSubs.Add(id, subscribeFn dispatch)
+        with ex ->
+          Console.WriteLine($"Error starting sub {SubId.value id}: {ex}")
+
+    for KeyValue(key, _disp) in activeSubs do
+      if not(subIdsInUse.Contains(key)) then
+        subIdsToRemove.Add(key)
+
+    for i = 0 to subIdsToRemove.Count - 1 do
+      let key = subIdsToRemove[i]
+
+      match activeSubs.TryGetValue(key) with
+      | true, disp ->
+        disp.Dispose()
+        activeSubs.Remove(key) |> ignore
+      | _ -> ()
+
+  /// <summary>Whether the loop has received a <c>Cmd.Quit</c> signal.</summary>
+  member _.ShouldQuit = shouldQuit
+
+  /// <summary>The current model state.</summary>
+  member _.Model = state
+
+  /// <summary>The <see cref="T:Mibo.Elmish.GameContext"/> passed to <see cref="M:Mibo.Elmish.ElmishLoop`2.Init"/>, if initialized.</summary>
+  member _.Context = ctxOpt
+
+  /// <summary>The registered active subscriptions (for host-side disposal).</summary>
+  member internal _.ActiveSubs = activeSubs
+
+  /// <summary>Dispatch a message into the loop's queue.</summary>
+  member _.Dispatch(msg: 'Msg) = dispatch msg
+
+  /// <summary>
+  /// Initialize the loop: store the context, call the program's <c>Init</c>,
+  /// execute startup commands, and start initial subscriptions.
+  /// </summary>
+  /// <remarks>Call exactly once, after the host has registered backend services.</remarks>
+  member _.Init(ctx: GameContext) =
+    ctxOpt <- ValueSome ctx
+    let struct (initialState, initialCmds) = core.Init ctx
+    state <- initialState
+    execCmd initialCmds
+    updateSubs ctx
+
+  /// <summary>
+  /// Advance the simulation by one frame: drain deferred effects, run fixed-step,
+  /// dispatch the tick message, process all queued messages, and update
+  /// subscriptions if the model changed.
+  /// </summary>
+  /// <param name="elapsed">Frame delta (e.g. <c>TimeSpan.FromMilliseconds(16)</c> for 60fps).</param>
+  /// <param name="gameTime">The current game time, supplied by the host.</param>
+  /// <returns><c>true</c> if the model changed this frame; <c>false</c> otherwise.</returns>
+  member _.TickFrame(elapsed: TimeSpan, gameTime: GameTime) : bool =
+    let deltaSeconds = float32 elapsed.TotalSeconds
+
+    if deferredEffs.Count <> 0 then
+      deferredEffsRun.Clear()
+      deferredEffsRun.AddRange(deferredEffs)
+      deferredEffs.Clear()
+
+      for i = 0 to deferredEffsRun.Count - 1 do
+        deferredEffsRun[i].Invoke(dispatch)
+
+    match core.FixedStep with
+    | ValueNone -> ()
+    | ValueSome cfg ->
+      let maxFrame = cfg.MaxFrameSeconds |> ValueOption.defaultValue 0.25f
+
+      let struct (acc2, steps, _dropped) =
+        FixedStep.compute
+          cfg.StepSeconds
+          cfg.MaxStepsPerFrame
+          maxFrame
+          fixedAccSeconds
+          deltaSeconds
+
+      fixedAccSeconds <- acc2
+
+      for _i = 1 to steps do
+        dispatch(cfg.Map cfg.StepSeconds)
+
+    core.Tick |> ValueOption.iter(fun map -> dispatch(map gameTime))
+
+    let mutable stateChanged = false
+    let mutable msg = Unchecked.defaultof<'Msg>
+    msgQueue.StartBatch()
+
+    while msgQueue.TryDequeue(&msg) do
+      let struct (newState, cmds) = core.Update msg state
+      state <- newState
+      execCmd cmds
+      stateChanged <- true
+
+    msgQueue.EndBatch()
+
+    if stateChanged then
+      ctxOpt |> ValueOption.iter(updateSubs)
+
+    stateChanged
+
+  /// <summary>
+  /// Dispose all active subscriptions. Hosts should call this on shutdown.
+  /// </summary>
+  member _.DisposeSubs() =
+    for KeyValue(_key, disp) in activeSubs do
+      disp.Dispose()
+
+    activeSubs.Clear()
+
+/// Functions for constructing and working with <see cref="T:Mibo.Elmish.ElmishLoop`2"/>.
+module ElmishLoop =
+
+  /// <summary>Creates an <see cref="T:Mibo.Elmish.ElmishLoop`2"/> from a <see cref="T:Mibo.Elmish.LoopCore`2"/>.</summary>
+  let create(core: LoopCore<'Model, 'Msg>) = ElmishLoop<'Model, 'Msg>(core)
+
+  /// <summary>Projects a <see cref="T:Mibo.Elmish.Program`2"/> to a <see cref="T:Mibo.Elmish.LoopCore`2"/>.</summary>
+  let coreOfProgram(program: Program<'Model, 'Msg>) : LoopCore<'Model, 'Msg> = {
+    Init = program.Init
+    Update = program.Update
+    Subscribe = program.Subscribe
+    Tick = program.Tick
+    FixedStep = program.FixedStep
+    DispatchMode = program.DispatchMode
+  }

--- a/src/Mibo.Core/Mibo.Core.fsproj
+++ b/src/Mibo.Core/Mibo.Core.fsproj
@@ -19,6 +19,8 @@
     <Compile Include="InputMapper.fs" />
     <Compile Include="InputServices.fs" />
     <Compile Include="Elmish.Program.fs" />
+    <Compile Include="Elmish.Loop.fs" />
+    <Compile Include="Elmish.Headless.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mibo.Raylib.Tests/HeadlessTests.fs
+++ b/src/Mibo.Raylib.Tests/HeadlessTests.fs
@@ -730,6 +730,33 @@ let headlessObserver =
         snapshotsB[1]
         "Second snapshot should be identical"
 
+    testCase "Observers are notified in registration order"
+    <| fun _ ->
+      // withObserver prepends, so the runner must reverse the list before
+      // iterating or observers fire in reverse-registration order.
+      let order = ResizeArray<int>()
+
+      use runner =
+        new HeadlessRunner<_, _>(
+          HeadlessProgram.mkHeadless init update
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, _: TestModel, _) ->
+              order.Add(1)))
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, _: TestModel, _) ->
+              order.Add(2)))
+          |> HeadlessProgram.withObserver(fun () ->
+            HeadlessProgram.observe(fun struct (_, _: TestModel, _) ->
+              order.Add(3)))
+        )
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal order.Count 3 "All three observers should fire once"
+      Expect.equal order[0] 1 "First-registered observer fires first"
+      Expect.equal order[1] 2 "Second-registered observer fires second"
+      Expect.equal order[2] 3 "Third-registered observer fires third"
+
     testCase "Observer fires after ShouldQuit with frozen model"
     <| fun _ ->
       let snapshots = ResizeArray<int>()

--- a/src/Mibo.Raylib/Elmish.Runtime.fs
+++ b/src/Mibo.Raylib/Elmish.Runtime.fs
@@ -1,110 +1,18 @@
 namespace Mibo.Elmish
 
 open System
-open System.Collections.Concurrent
 open System.Collections.Generic
 open Raylib_cs
 open Mibo.Input
 
-type internal DispatchQueue<'Msg>(mode: DispatchMode) =
-  let gate = obj()
-  let mutable isProcessing = false
-  let mutable current = ConcurrentQueue<'Msg>()
-  let mutable next = ConcurrentQueue<'Msg>()
-
-  member _.Mode = mode
-
-  member _.Dispatch(msg: 'Msg) =
-    match mode with
-    | Immediate -> current.Enqueue(msg)
-    | FrameBounded ->
-      lock gate (fun () ->
-        if isProcessing then
-          next.Enqueue(msg)
-        else
-          current.Enqueue(msg))
-
-  member _.StartBatch() =
-    match mode with
-    | Immediate -> ()
-    | FrameBounded -> lock gate (fun () -> isProcessing <- true)
-
-  member _.EndBatch() =
-    match mode with
-    | Immediate -> ()
-    | FrameBounded ->
-      lock gate (fun () ->
-        isProcessing <- false
-        let tmp = current
-        current <- next
-        next <- tmp)
-
-  member _.TryDequeue(msg: byref<'Msg>) = current.TryDequeue(&msg)
-
+/// <summary>
+/// The raylib-backed game host. Owns the window/audio lifecycle and delegates
+/// message processing to a shared <see cref="T:Mibo.Elmish.ElmishLoop`2"/>.
+/// </summary>
 type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
-  let msgQueue = DispatchQueue<'Msg>(program.DispatchMode)
-  let mutable state: 'Model = Unchecked.defaultof<'Model>
-  let mutable ctxOpt: GameContext voption = ValueNone
-  let activeSubs = Dictionary<SubId, IDisposable>()
-  let subIdsInUse = HashSet<SubId>()
-  let subIdsToRemove = ResizeArray<SubId>(32)
+  let loop = ElmishLoop.create(ElmishLoop.coreOfProgram program)
   let renderers = ResizeArray<IRenderer<'Model>>()
-  let subBuffer = ResizeArray<struct (SubId * Subscribe<'Msg>)>()
-  let subStack = ResizeArray<Sub<'Msg>>()
-  let deferredEffs = ResizeArray<Effect<'Msg>>(64)
-  let deferredEffsRun = ResizeArray<Effect<'Msg>>(64)
-  let mutable fixedAccSeconds = 0.0f
-
-  let mutable shouldQuit = false
   let mutable inputServiceOpt: IInput voption = ValueNone
-
-  let dispatch(msg: 'Msg) = msgQueue.Dispatch(msg)
-
-  let execCmd(cmd: Cmd<'Msg>) =
-    match cmd with
-    | Empty -> ()
-    | Quit -> shouldQuit <- true
-    | Single eff -> eff.Invoke(dispatch)
-    | Batch effs ->
-      for i = 0 to effs.Length - 1 do
-        effs[i].Invoke(dispatch)
-    | DeferNextFrame effs -> deferredEffs.AddRange(effs)
-    | NowAndDeferNextFrame(now, next) ->
-      for i = 0 to now.Length - 1 do
-        now[i].Invoke(dispatch)
-
-      deferredEffs.AddRange(next)
-
-  let updateSubs(ctx: GameContext) =
-    subBuffer.Clear()
-    subStack.Clear()
-    subStack.Add(program.Subscribe ctx state)
-    Sub.flatten subStack subBuffer
-
-    subIdsInUse.Clear()
-    subIdsToRemove.Clear()
-
-    for id, subscribeFn in subBuffer do
-      subIdsInUse.Add(id) |> ignore
-
-      if not(activeSubs.ContainsKey(id)) then
-        try
-          activeSubs.Add(id, subscribeFn dispatch)
-        with ex ->
-          Console.WriteLine($"Error starting sub {SubId.value id}: {ex}")
-
-    for KeyValue(key, _disp) in activeSubs do
-      if not(subIdsInUse.Contains(key)) then
-        subIdsToRemove.Add(key)
-
-    for i = 0 to subIdsToRemove.Count - 1 do
-      let key = subIdsToRemove[i]
-
-      match activeSubs.TryGetValue(key) with
-      | true, disp ->
-        disp.Dispose()
-        activeSubs.Remove(key) |> ignore
-      | _ -> ()
 
   member _.Run() =
     let config =
@@ -154,14 +62,10 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
     for register in List.rev program.ServiceRegistrations do
       register ctx
 
-    ctxOpt <- ValueSome ctx
+    // Initialize the shared loop (calls program.Init, execCmd, updateSubs).
+    loop.Init(ctx)
 
-    let struct (initialState, initialCmds) = program.Init ctx
-    state <- initialState
-    execCmd initialCmds
-    updateSubs ctx
-
-    while not(shouldQuit || RaylibHelpers.windowShouldClose()) do
+    while not(loop.ShouldQuit || RaylibHelpers.windowShouldClose()) do
       let dt = Raylib.GetFrameTime()
       let elapsed = TimeSpan.FromSeconds(float dt)
 
@@ -177,54 +81,15 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
       if Raylib.IsWindowResized().AsBool() then
         ctx.UpdateDimensions(Raylib.GetScreenWidth(), Raylib.GetScreenHeight())
 
-      if deferredEffs.Count <> 0 then
-        deferredEffsRun.Clear()
-        deferredEffsRun.AddRange(deferredEffs)
-        deferredEffs.Clear()
-
-        for i = 0 to deferredEffsRun.Count - 1 do
-          deferredEffsRun[i].Invoke(dispatch)
-
-      match program.FixedStep with
-      | ValueNone -> ()
-      | ValueSome cfg ->
-        let maxFrame = cfg.MaxFrameSeconds |> ValueOption.defaultValue 0.25f
-
-        let struct (acc2, steps, _dropped) =
-          FixedStep.compute
-            cfg.StepSeconds
-            cfg.MaxStepsPerFrame
-            maxFrame
-            fixedAccSeconds
-            dt
-
-        fixedAccSeconds <- acc2
-
-        for _i = 1 to steps do
-          dispatch(cfg.Map cfg.StepSeconds)
-
-      program.Tick |> ValueOption.iter(fun map -> dispatch(map gameTime))
-
-      let mutable stateChanged = false
-      let mutable msg = Unchecked.defaultof<'Msg>
-      msgQueue.StartBatch()
-
-      while msgQueue.TryDequeue(&msg) do
-        let struct (newState, cmds) = program.Update msg state
-        state <- newState
-        execCmd cmds
-        stateChanged <- true
-
-      msgQueue.EndBatch()
-
-      if stateChanged then
-        updateSubs ctx
+      // Advance the shared message-processing loop (deferred drain + FixedStep
+      // + tick + message pump + subscription diffing).
+      loop.TickFrame(elapsed, gameTime) |> ignore
 
       Raylib.BeginDrawing()
       Raylib.ClearBackground(Color.Black)
 
       for i = 0 to renderers.Count - 1 do
-        renderers[i].Draw(ctx, state, gameTime)
+        renderers[i].Draw(ctx, loop.Model, gameTime)
 
       Raylib.EndDrawing()
 
@@ -233,6 +98,7 @@ type RaylibGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) =
       | :? IDisposable as d -> d.Dispose()
       | _ -> ()
 
+    loop.DisposeSubs()
     (GameContext.getService<IAssets> ctx).Dispose()
     Raylib.CloseAudioDevice()
     Raylib.CloseWindow()

--- a/src/Mibo.Raylib/Mibo.Raylib.fsproj
+++ b/src/Mibo.Raylib/Mibo.Raylib.fsproj
@@ -26,7 +26,6 @@
     <Compile Include="Assets.fs" />
     <Compile Include="Elmish.Program.fs" />
     <Compile Include="Elmish.Runtime.fs" />
-    <Compile Include="Elmish.Headless.fs" />
     <Compile Include="DefaultShaders.fs" />
     <Compile Include="Graphics2D/Lighting/LightTypes.fs" />
     <Compile Include="Graphics2D/Lighting/LitShader.fs" />


### PR DESCRIPTION
## Summary

Extracts the shared message-processing loop from the duplicated code in `RaylibGame` and `HeadlessRunner`, and moves the Headless types to Core. Non-breaking: all types stay in the `Mibo.Elmish` namespace, all existing user code works unchanged.

## What changed

### New: `ElmishLoop<'Model,'Msg>` in `Mibo.Core`

The message-processing core that was **character-for-character duplicated** between `RaylibGame` and `HeadlessRunner` — `DispatchQueue<'Msg>`, `execCmd`, `updateSubs`, deferred-effect draining, `FixedStep` accumulation, tick dispatch, and the `StartBatch`/`TryDequeue`/`EndBatch` message pump — is now a single `ElmishLoop<'Model,'Msg>` type in Core.

A `LoopCore<'Model,'Msg>` struct record captures the six fields that define message-processing behavior (`Init`/`Update`/`Subscribe`/`Tick`/`FixedStep`/`DispatchMode`). `Program` and `HeadlessProgram` each project to `LoopCore` via `ElmishLoop.coreOfProgram` / `HeadlessProgram.toLoopCore` without changing shape.

**Host responsibilities (the ~10% that stays backend-specific):**
- Backend init (window/audio/assets/input registration)
- Time source (`Raylib.GetFrameTime()` vs virtual `GameTime`)
- Pre-frame poll (input + resize)
- Post-frame I/O (render pass vs observer notification)
- Quit detection + cleanup

### Moved: `HeadlessProgram`, `HeadlessRunner`, builder module → Core

`HeadlessProgram`, `HeadlessRunner`, and the `HeadlessProgram` builder module (`mkHeadless`, `withSubscribe`, `withTick`, `withFixedStep`, `withDispatchMode`, `withObserver`, `observe`) move from the raylib backend to `Mibo.Core`. They are pure F# with zero backend dependencies.

### Rewritten: `RaylibGame.Run()`

Now a thin shell: window/audio/assets/input init → `loop.Init(ctx)` → `while not(loop.ShouldQuit || windowShouldClose())` → input poll + resize → `loop.TickFrame(dt, gameTime)` → render pass → cleanup. The `DispatchQueue`, `execCmd`, `updateSubs`, and the entire frame-step block are gone from the raylib backend.

### Rewritten: `HeadlessRunner`

Delegates to `ElmishLoop.TickFrame` and keeps only its headless-specific concerns: virtual time management, observer notification, and the `Run`/`RunAsync` pacing sequences.

## Why this matters

- **Eliminates duplication today.** `execCmd`/`updateSubs`/the pump were duplicated between `RaylibGame` and `HeadlessRunner` — a known maintenance hazard.
- **Headless is now backend-portable.** The PingPong server sample (which relies on `HeadlessRunner`) will work identically on any future backend for free, since `HeadlessRunner` is in Core.
- **Foundation for Phase 4 (MonoGame).** The MonoGame `ElmishGame` host will be a thin shell around the same `ElmishLoop`, just like `RaylibGame`.

## Verification

- `dotnet build Mibo.Raylib.slnx` — 0 warnings, 0 errors
- `dotnet test` — **888/888 pass**, including all 47 headless tests (proving the behavioral contract is preserved through the refactor)
- `dotnet fantomas .` — clean

## Migration

**No breaking changes.** See `docs/migration-to-vnext.md` (Phase 2 section). All types stay in the `Mibo.Elmish` namespace; `HeadlessProgram.mkHeadless`, `HeadlessRunner`, etc. keep working unchanged.
