### PR TITLE
feat(monogame): fresh Mibo.MonoGame backend against Core contracts (Phase 4)

### DIFF
--- a/Mibo.Raylib.slnx
+++ b/Mibo.Raylib.slnx
@@ -6,6 +6,7 @@
   </Folder>
   <Folder Name="/src/">
     <Project Path="src/Mibo.Core/Mibo.Core.fsproj" />
+    <Project Path="src/Mibo.MonoGame/Mibo.MonoGame.fsproj" />
     <Project Path="src/Mibo.Raylib/Mibo.Raylib.fsproj" />
     <Project Path="src/Mibo.Raylib.Tests/Mibo.Raylib.Tests.fsproj" />
     <Project Path="src/Templates/Mibo.Raylib.Templates.csproj" />

--- a/PLAN.md
+++ b/PLAN.md
@@ -40,7 +40,7 @@ backend enum/handle stays in the backend.
 | 1d | `Program` builder moves to Core; `withInputMapper` decoupled from the backend | Yes | ✅ Done (`#21`) |
 | 2  | Shared `ElmishLoop` extracted; `HeadlessRunner`/`HeadlessProgram` move to Core | No | ✅ Done (`#22`) |
 | 3  | `Layout` and `Layout3D` move to Core | No | ✅ Done (`#23`) |
-| 4  | Fresh `Mibo.MonoGame` backend | n/a (new project) | ⬜ Pending |
+| 4  | Fresh `Mibo.MonoGame` backend | n/a (new project) | 🔨 In progress (`feature/monogame-backend`) |
 | 5  | Parity verification (optional) | n/a | ⬜ Pending |
 
 ---
@@ -127,6 +127,47 @@ Phase 4 also targets `net8.0`, matching the upstream Mibo repo.)
 ## Phase 4 — Fresh `Mibo.MonoGame` backend
 
 **Breaking:** n/a — new project.
+
+### Status (in progress — `feature/monogame-backend`)
+
+Implemented and compiling (whole solution builds with 0 errors):
+- `MiboGame : Game` host — drives `ElmishLoop` from `Update`/`Draw`, applies
+  `GameConfig`, registers MonoGame handles + `IAssets` + `IInput` + service
+  registrations, reflects window resize into `GameContext` dimensions.
+- `MonoGameGameContext` — registers `GraphicsDevice`/`ContentManager`/`Game` into
+  the Core service registry (decision 5); typed `getGraphicsDevice`/
+  `getContentManager`/`getGame` accessors.
+- `Input.fs` — `KeyCode.ofMonoGameKey`/`toMonoGameKey`,
+  `GamepadButtonCode.ofMonoGameButton`/`toMonoGameButton`, whole-state pollers
+  (keyboard/mouse/touch/gamepad), `Input.create`. Matches the raylib 80/20
+  surface (decision 3).
+- `InputMapper.fs` — `buildActions` (shared logic) + `subscribe`/
+  `subscribeStatic` + `createService`, mirroring raylib.
+- `Assets.fs` — `IAssets` over `ContentManager` (typed loaders cached in
+  dictionaries), extending Core `IAssetCache`.
+- `Program.fs` — `MonoGameProgram.withInputMapper`.
+
+Parity notes surfaced during implementation:
+- **MonoGame gives whole-state snapshots** (`KeyboardState`/`MouseState`/
+  `GamePadState`), unlike raylib's per-query functions. Pollers diff against
+  the previous frame's state via `byref`/array fields.
+- **D-pad lives on `GamePadState.DPad`, not `GamePadButtons`** — a real API
+  difference from what the `Buttons` enum suggests.
+- **Triggers exposed digitally at a 0.5 threshold** (analog via `GamepadAnalog`).
+- **No `RightSuper` mapping** — MonoGame has only `LeftWindows`.
+- **No separate numpad Enter** — MonoGame shares `Keys.Enter`.
+- **Gestures are a known 80/20 gap** — MonoGame has no built-in high-level
+  gesture detection matching raylib's; the `GestureDelta` stream stays empty
+  until a recognizer is layered on.
+- **`IInputMapper` service path is registered but not ticked** — this matches
+  the raylib backend exactly (raylib also registers but never calls `Update()`;
+  the working path is the subscription `InputMapper.subscribeStatic`). Not a
+  regression; consistent with raylib.
+
+Remaining before merge: runtime smoke test (a `MiboGame` that boots, processes
+one tick, and exits cleanly without a window in CI is non-trivial — MonoGame
+needs a real `GraphicsDevice`). The library compiles and is API-complete; a
+manual boot test on a desktop is the verification step.
 
 ### Upstream reference: `E:\Mibo` (the original MonoGame Mibo)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -196,6 +196,27 @@ callbacks. Porting the Mibo types would reintroduce the coupling Phases 1–3 re
 if the MonoGame backend wants JSON asset decoding, add `JDeck` to that backend
 only — not to Core.
 
+### Reference guidance for steps 4–7 (the MonoGame-specific implementations)
+
+The original `E:\Mibo` is the **reference for *what MonoGame surface to cover***,
+not portable code. For steps 4–7, duplicate the patterns from `E:\Mibo\src\Mibo`
+*as long as they are backend-specific and do not break Core code*:
+
+- **Step 4 (IInput):** mirror `E:\Mibo\src\Mibo\Input.fs`'s polling shape
+  (`Keyboard.GetState`/`Mouse.GetState`/`GamePad.GetState`/`TouchPanel.GetState`)
+  and the set of `Keys`/`Buttons` it maps. Translate onto Core's
+  `KeyCode`/`MouseButtonCode`/`GamepadButtonCode`/delta structs — do **not**
+  reuse the MonoGame-typed delta records.
+- **Step 5 (IInputMapper):** the pure `InputMap`/`ActionState` core is already in
+  `Mibo.Core`; only the per-frame ticking impl is backend-specific.
+- **Step 6 (IAssets):** mirror `E:\Mibo\src\Mibo\Assets.fs`'s `ContentManager.Load`
+  caching pattern and the typed loaders it exposes
+  (`Texture2D`/`SpriteFont`/`SoundEffect`/`Model`/`Effect`). Implement against
+  Core's `IAssetCache` + a MonoGame `IAssets` that extends it.
+- **Step 7 (withInputMapper):** mirror `RaylibProgram.withInputMapper`'s
+  `ServiceRegistrations` shape; the upstream `E:\Mibo` version wraps `Init`
+  instead, which is the older pattern — follow the raylib one.
+
 ### What the new backend must provide
 
 | Core contract | MonoGame implementation |
@@ -273,6 +294,17 @@ only — not to Core.
 
    This resolves the "sharing mechanism" question: it's the established
    inheritance pattern, not a new interface/base-record debate.
+
+   **Refinement (resolved during Phase 4 scaffolding):** `LoopCore.Init` is
+   typed to the Core `GameContext` class (not an interface), and that class has
+   no backend-handle slot and an `internal` constructor. Rather than widen the
+   Core type (out of Phase 4's "new backend only" scope) or introduce a wrapper,
+   the MonoGame backend follows the **raylib pattern exactly**: the host
+   registers `GraphicsDevice`, `ContentManager`, and `Game` into the Core
+   `GameContext` service registry, and user code retrieves them via
+   `GameContext.getService<GraphicsDevice>() ctx` (just as raylib registers and
+   retrieves `IInput`/`IAssets`). Zero Core changes; `InternalsVisibleTo`
+   already grants `Mibo.MonoGame` access to the internal `register`.
 
 ### Steps (high level — flesh out when Phase 4 starts)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -5,7 +5,7 @@
 > user-facing breaking-changes live in [`docs/migration-to-vnext.md`](docs/migration-to-vnext.md);
 > this document is the engineering record.
 >
-> **Branch:** `vnext`. **Status:** Phases 1a–1d and 2 are merged.
+> **Branch:** `vnext`. **Status:** Phases 1a–1d, 2, and 3 are merged.
 >
 > **Workflow:** `vnext` is the integration branch. Each phase is developed on a
 > feature branch cut from `vnext` and merged back via a PR to `vnext`
@@ -39,7 +39,7 @@ backend enum/handle stays in the backend.
 | 1c | `IAssetCache` split: generic asset cache in Core; typed loaders stay backend | No | ✅ Done (`#21`) |
 | 1d | `Program` builder moves to Core; `withInputMapper` decoupled from the backend | Yes | ✅ Done (`#21`) |
 | 2  | Shared `ElmishLoop` extracted; `HeadlessRunner`/`HeadlessProgram` move to Core | No | ✅ Done (`#22`) |
-| 3  | `Layout` and `Layout3D` move to Core | No | ⬜ Pending |
+| 3  | `Layout` and `Layout3D` move to Core | No | ✅ Done (`#23`) |
 | 4  | Fresh `Mibo.MonoGame` backend | n/a (new project) | ⬜ Pending |
 | 5  | Parity verification (optional) | n/a | ⬜ Pending |
 

--- a/src/Mibo.MonoGame/Assets.fs
+++ b/src/Mibo.MonoGame/Assets.fs
@@ -1,0 +1,167 @@
+namespace Mibo.Elmish
+
+open System
+open System.Collections.Generic
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Audio
+open Microsoft.Xna.Framework.Content
+open Microsoft.Xna.Framework.Graphics
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MonoGame asset service.
+//
+// Mirrors the raylib backend's IAssets/AssetsService shape: typed loaders
+// (Texture2D/SpriteFont/SoundEffect/Model/Effect) cached in dictionaries,
+// extending the Core IAssetCache so portable code can cache custom assets
+// without referencing a backend.
+//
+// The difference from raylib: MonoGame loads XNB-compiled assets via
+// ContentManager.Load<'T> (no loose-file loading). The GraphicsDevice and
+// ContentManager are retrieved from the GameContext service registry, where
+// MiboGame registers them at startup (see MonoGameGameContext.register).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Per-game asset loader/cache service for the MonoGame backend.
+/// </summary>
+/// <remarks>
+/// Provides cached loading for textures, fonts, sounds, models, and effects via
+/// the MonoGame content pipeline. Extends <see cref="T:Mibo.Elmish.IAssetCache"/>
+/// so portable code can cache custom assets without referencing a backend.
+/// </remarks>
+/// <example>
+/// <code>
+/// let assets = GameContext.getService&lt;IAssets&gt; ctx
+/// let tex = assets.Texture "sprites/player"
+/// let font = assets.Font "fonts/main"
+/// let config = assets.GetOrCreate "gameConfig" (fun () -> loadConfig())
+/// </code>
+/// </example>
+type IAssets =
+  inherit IAssetCache
+
+  /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Graphics.Texture2D"/> from the content pipeline.</summary>
+  abstract Texture: path: string -> Texture2D
+
+  /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Graphics.SpriteFont"/> from the content pipeline.</summary>
+  abstract Font: path: string -> SpriteFont
+
+  /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Audio.SoundEffect"/> from the content pipeline.</summary>
+  abstract Sound: path: string -> SoundEffect
+
+  /// <summary>Loads and caches a 3D <see cref="T:Microsoft.Xna.Framework.Graphics.Model"/> from the content pipeline.</summary>
+  abstract Model: path: string -> Model
+
+  /// <summary>Loads and caches an <see cref="T:Microsoft.Xna.Framework.Graphics.Effect"/> from the content pipeline.</summary>
+  abstract Effect: path: string -> Effect
+
+/// <summary>
+/// Implementation of <see cref="T:Mibo.Elmish.IAssets"/> backed by a MonoGame
+/// <c>ContentManager</c>, with dictionary-based caches per asset type.
+/// </summary>
+/// <param name="content">The MonoGame content manager used to load XNB assets.</param>
+type AssetsService(content: ContentManager) =
+
+  let typedCache = Dictionary<string, obj>()
+
+  let textures = Dictionary<string, Texture2D>()
+  let fonts = Dictionary<string, SpriteFont>()
+  let sounds = Dictionary<string, SoundEffect>()
+  let models = Dictionary<string, Model>()
+  let effects = Dictionary<string, Effect>()
+
+  /// <summary>The <c>ContentManager</c> this service loads from.</summary>
+  member _.Content = content
+
+  interface IAssets with
+    member _.Texture(path) =
+      match textures.TryGetValue(path) with
+      | true, tex -> tex
+      | _ ->
+        let tex = content.Load<Texture2D>(path)
+        textures.Add(path, tex)
+        tex
+
+    member _.Font(path) =
+      match fonts.TryGetValue(path) with
+      | true, font -> font
+      | _ ->
+        let font = content.Load<SpriteFont>(path)
+        fonts.Add(path, font)
+        font
+
+    member _.Sound(path) =
+      match sounds.TryGetValue(path) with
+      | true, sound -> sound
+      | _ ->
+        let sound = content.Load<SoundEffect>(path)
+        sounds.Add(path, sound)
+        sound
+
+    member _.Model(path) =
+      match models.TryGetValue(path) with
+      | true, m -> m
+      | _ ->
+        let m = content.Load<Model>(path)
+        models.Add(path, m)
+        m
+
+    member _.Effect(path) =
+      match effects.TryGetValue(path) with
+      | true, e -> e
+      | _ ->
+        let e = content.Load<Effect>(path)
+        effects.Add(path, e)
+        e
+
+    member _.Get<'T>(key: string) : 'T voption =
+      match typedCache.TryGetValue(key) with
+      | true, (:? 'T as v) -> ValueSome v
+      | _ -> ValueNone
+
+    member _.Create<'T>(key: string, factory: unit -> 'T) : 'T =
+      let value = factory()
+      typedCache[key] <- box value
+      value
+
+    member _.GetOrCreate<'T>(key: string, factory: unit -> 'T) : 'T =
+      match typedCache.TryGetValue(key) with
+      | true, (:? 'T as v) -> v
+      | _ ->
+        let value = factory()
+        typedCache[key] <- box value
+        value
+
+    member _.Clear() =
+      typedCache.Clear()
+      textures.Clear()
+      fonts.Clear()
+      sounds.Clear()
+      models.Clear()
+      effects.Clear()
+
+    member _.Dispose() =
+      // ContentManager owns the XNB assets; individual Texture2D/Effect/etc.
+      // instances are NOT disposed here because ContentManager.Unload handles
+      // them. Disposing typed user assets would be unsafe if they hold
+      // references into content-loaded resources. Clear caches only.
+      typedCache.Clear()
+      textures.Clear()
+      fonts.Clear()
+      sounds.Clear()
+      models.Clear()
+      effects.Clear()
+
+/// Factory for <see cref="T:Mibo.Elmish.IAssets"/> implementations.
+module AssetsService =
+  /// <summary>Creates an asset service over the given <c>ContentManager</c>.</summary>
+  let create(content: ContentManager) : IAssets =
+    new AssetsService(content) :> IAssets
+
+  /// <summary>
+  /// Creates an asset service from a <see cref="T:Mibo.Elmish.GameContext"/>,
+  /// resolving the registered <c>ContentManager</c> (registered by the host).
+  /// </summary>
+  let createFromContext(ctx: GameContext) : IAssets =
+    let content = MonoGameGameContext.getContentManager ctx
+    create content

--- a/src/Mibo.MonoGame/Assets.fs
+++ b/src/Mibo.MonoGame/Assets.fs
@@ -141,10 +141,14 @@ type AssetsService(content: ContentManager) =
       effects.Clear()
 
     member _.Dispose() =
-      // ContentManager owns the XNB assets; individual Texture2D/Effect/etc.
-      // instances are NOT disposed here because ContentManager.Unload handles
-      // them. Disposing typed user assets would be unsafe if they hold
-      // references into content-loaded resources. Clear caches only.
+      // Dispose user-created IDisposable assets. ContentManager owns the
+      // XNB-loaded textures/fonts/etc., so the typed-loader caches below are
+      // left for ContentManager.Unload — only the generic typedCache is ours.
+      for kvp in typedCache do
+        match kvp.Value with
+        | :? IDisposable as d -> d.Dispose()
+        | _ -> ()
+
       typedCache.Clear()
       textures.Clear()
       fonts.Clear()

--- a/src/Mibo.MonoGame/GameContext.fs
+++ b/src/Mibo.MonoGame/GameContext.fs
@@ -1,0 +1,72 @@
+namespace Mibo.Elmish
+
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Content
+open Microsoft.Xna.Framework.Graphics
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MonoGame handle access via the Core GameContext service registry.
+//
+// The Core `GameContext` is backend-neutral (window dims + a typed service
+// registry) and has no slot for backend-specific handles. Rather than widen the
+// Core type, the MonoGame backend follows the same pattern the raylib backend
+// uses for `IInput`/`IAssets`: the host registers the long-lived MonoGame
+// handles (`GraphicsDevice`, `ContentManager`, `Game`) into the Core registry,
+// and user `init`/`update`/`subscribe` code retrieves them via the typed
+// `getService` accessors below.
+//
+// `MiboGame` (the host) calls `MonoGameGameContext.register game this` once,
+// after the `GraphicsDevice` exists and before `ElmishLoop.Init`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// Typed accessors for the MonoGame handles registered in a Core
+/// <see cref="T:Mibo.Elmish.GameContext"/>.
+/// </summary>
+/// <remarks>
+/// The MonoGame host registers <c>GraphicsDevice</c>, <c>ContentManager</c>, and
+/// <c>Game</c> into the Core service registry (mirroring how the raylib backend
+/// registers <c>IInput</c>/<c>IAssets</c>). These accessors retrieve them with
+/// the same <c>getService</c>/<c>tryGetService</c> semantics as other services.
+/// </remarks>
+module MonoGameGameContext =
+
+  /// <summary>
+  /// Registers the host game's <c>GraphicsDevice</c>, <c>ContentManager</c>, and
+  /// the <c>Game</c> itself into the <see cref="T:Mibo.Elmish.GameContext"/>.
+  /// </summary>
+  /// <remarks>
+  /// Called once by <c>MiboGame</c> after the <c>GraphicsDevice</c> is created
+  /// and before <see cref="M:Mibo.Elmish.ElmishLoop`2.Init"/>, so user
+  /// <c>init</c> code can resolve every MonoGame handle.
+  /// </remarks>
+  let register (game: Game) (ctx: GameContext) =
+    GameContext.register<GraphicsDevice> game.GraphicsDevice ctx
+    GameContext.register<ContentManager> game.Content ctx
+    GameContext.register<Game> game ctx
+
+  /// <summary>Gets the registered <c>GraphicsDevice</c>.</summary>
+  /// <exception cref="T:System.Exception">Thrown if not registered (the host must call <c>register</c> first).</exception>
+  let getGraphicsDevice(ctx: GameContext) : GraphicsDevice =
+    GameContext.getService<GraphicsDevice> ctx
+
+  /// <summary>Gets the registered <c>ContentManager</c>.</summary>
+  /// <exception cref="T:System.Exception">Thrown if not registered (the host must call <c>register</c> first).</exception>
+  let getContentManager(ctx: GameContext) : ContentManager =
+    GameContext.getService<ContentManager> ctx
+
+  /// <summary>Gets the registered <c>Game</c> instance.</summary>
+  /// <exception cref="T:System.Exception">Thrown if not registered (the host must call <c>register</c> first).</exception>
+  let getGame(ctx: GameContext) : Game = GameContext.getService<Game> ctx
+
+  /// <summary>Returns the registered <c>GraphicsDevice</c>, or <c>ValueNone</c>.</summary>
+  let tryGetGraphicsDevice(ctx: GameContext) : GraphicsDevice voption =
+    GameContext.tryGetService<GraphicsDevice> ctx
+
+  /// <summary>Returns the registered <c>ContentManager</c>, or <c>ValueNone</c>.</summary>
+  let tryGetContentManager(ctx: GameContext) : ContentManager voption =
+    GameContext.tryGetService<ContentManager> ctx
+
+  /// <summary>Returns the registered <c>Game</c> instance, or <c>ValueNone</c>.</summary>
+  let tryGetGame(ctx: GameContext) : Game voption =
+    GameContext.tryGetService<Game> ctx

--- a/src/Mibo.MonoGame/Input.fs
+++ b/src/Mibo.MonoGame/Input.fs
@@ -1,0 +1,631 @@
+namespace Mibo.Input
+
+open System
+open System.Numerics
+open Microsoft.Xna.Framework.Input
+open Microsoft.Xna.Framework.Input.Touch
+open Mibo.Elmish
+
+// NOTE: we deliberately do NOT `open Microsoft.Xna.Framework` (the root
+// namespace). It defines Microsoft.Xna.Framework.Vector2, which would shadow
+// System.Numerics.Vector2 used by the Core delta types. Only the lone
+// `Microsoft.Xna.Framework.Game` parameter type (in Input.create) is
+// fully-qualified below. The MG input types we need all live in the .Input /
+// .Input.Touch sub-namespaces opened above.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MonoGame ↔ Core input translation.
+//
+// This is the ONLY place in the MonoGame backend where Microsoft.Xna.Framework
+// .Keys / Buttons / MouseState / GamePadState touch the Core-neutral code types.
+// Everything else in the backend works in Core codes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Functions for translating between MonoGame's <c>Keys</c> and Mibo's backend-neutral <see cref="T:Mibo.Input.KeyCode"/>.</summary>
+module KeyCode =
+
+  /// <summary>Maps a MonoGame <c>Keys</c> to the backend-neutral <see cref="T:Mibo.Input.KeyCode"/>.
+  /// Returns <see cref="F:Mibo.Input.KeyCode.Unknown"/> for any key with no logical equivalent.</summary>
+  let ofMonoGameKey(k: Keys) : KeyCode =
+    match k with
+    // Letters
+    | Keys.A -> KeyCode.A
+    | Keys.B -> KeyCode.B
+    | Keys.C -> KeyCode.C
+    | Keys.D -> KeyCode.D
+    | Keys.E -> KeyCode.E
+    | Keys.F -> KeyCode.F
+    | Keys.G -> KeyCode.G
+    | Keys.H -> KeyCode.H
+    | Keys.I -> KeyCode.I
+    | Keys.J -> KeyCode.J
+    | Keys.K -> KeyCode.K
+    | Keys.L -> KeyCode.L
+    | Keys.M -> KeyCode.M
+    | Keys.N -> KeyCode.N
+    | Keys.O -> KeyCode.O
+    | Keys.P -> KeyCode.P
+    | Keys.Q -> KeyCode.Q
+    | Keys.R -> KeyCode.R
+    | Keys.S -> KeyCode.S
+    | Keys.T -> KeyCode.T
+    | Keys.U -> KeyCode.U
+    | Keys.V -> KeyCode.V
+    | Keys.W -> KeyCode.W
+    | Keys.X -> KeyCode.X
+    | Keys.Y -> KeyCode.Y
+    | Keys.Z -> KeyCode.Z
+    // Digits (top row)
+    | Keys.D0 -> KeyCode.D0
+    | Keys.D1 -> KeyCode.D1
+    | Keys.D2 -> KeyCode.D2
+    | Keys.D3 -> KeyCode.D3
+    | Keys.D4 -> KeyCode.D4
+    | Keys.D5 -> KeyCode.D5
+    | Keys.D6 -> KeyCode.D6
+    | Keys.D7 -> KeyCode.D7
+    | Keys.D8 -> KeyCode.D8
+    | Keys.D9 -> KeyCode.D9
+    // Function keys
+    | Keys.F1 -> KeyCode.F1
+    | Keys.F2 -> KeyCode.F2
+    | Keys.F3 -> KeyCode.F3
+    | Keys.F4 -> KeyCode.F4
+    | Keys.F5 -> KeyCode.F5
+    | Keys.F6 -> KeyCode.F6
+    | Keys.F7 -> KeyCode.F7
+    | Keys.F8 -> KeyCode.F8
+    | Keys.F9 -> KeyCode.F9
+    | Keys.F10 -> KeyCode.F10
+    | Keys.F11 -> KeyCode.F11
+    | Keys.F12 -> KeyCode.F12
+    // Arrow / navigation cluster
+    | Keys.Up -> KeyCode.Up
+    | Keys.Down -> KeyCode.Down
+    | Keys.Left -> KeyCode.Left
+    | Keys.Right -> KeyCode.Right
+    | Keys.PageUp -> KeyCode.PageUp
+    | Keys.PageDown -> KeyCode.PageDown
+    | Keys.Home -> KeyCode.Home
+    | Keys.End -> KeyCode.End
+    | Keys.Insert -> KeyCode.Insert
+    | Keys.Delete -> KeyCode.Delete
+    // Editing / control
+    | Keys.Space -> KeyCode.Space
+    | Keys.Enter -> KeyCode.Enter
+    | Keys.Escape -> KeyCode.Escape
+    | Keys.Tab -> KeyCode.Tab
+    | Keys.Back -> KeyCode.Backspace
+    | Keys.CapsLock -> KeyCode.CapsLock
+    // Modifiers
+    | Keys.LeftShift -> KeyCode.LeftShift
+    | Keys.RightShift -> KeyCode.RightShift
+    | Keys.LeftControl -> KeyCode.LeftControl
+    | Keys.RightControl -> KeyCode.RightControl
+    | Keys.LeftAlt -> KeyCode.LeftAlt
+    | Keys.RightAlt -> KeyCode.RightAlt
+    // MonoGame surfaces a single platform "Windows key" — map to LeftSuper.
+    // RightSuper has no MG equivalent on most platforms → falls to Unknown below.
+    | Keys.LeftWindows -> KeyCode.LeftSuper
+    // Punctuation / symbol keys (US layout)
+    | Keys.OemTilde -> KeyCode.Grave
+    | Keys.OemMinus -> KeyCode.Minus
+    | Keys.OemPlus -> KeyCode.Equal
+    | Keys.OemOpenBrackets -> KeyCode.LeftBracket
+    | Keys.OemCloseBrackets -> KeyCode.RightBracket
+    | Keys.OemBackslash -> KeyCode.Backslash
+    | Keys.OemSemicolon -> KeyCode.Semicolon
+    | Keys.OemQuotes -> KeyCode.Apostrophe
+    | Keys.OemComma -> KeyCode.Comma
+    | Keys.OemPeriod -> KeyCode.Period
+    | Keys.OemQuestion -> KeyCode.Slash
+    // Keypad
+    | Keys.NumPad0 -> KeyCode.Kp0
+    | Keys.NumPad1 -> KeyCode.Kp1
+    | Keys.NumPad2 -> KeyCode.Kp2
+    | Keys.NumPad3 -> KeyCode.Kp3
+    | Keys.NumPad4 -> KeyCode.Kp4
+    | Keys.NumPad5 -> KeyCode.Kp5
+    | Keys.NumPad6 -> KeyCode.Kp6
+    | Keys.NumPad7 -> KeyCode.Kp7
+    | Keys.NumPad8 -> KeyCode.Kp8
+    | Keys.NumPad9 -> KeyCode.Kp9
+    | Keys.Decimal -> KeyCode.KpDecimal
+    | Keys.Divide -> KeyCode.KpDivide
+    | Keys.Multiply -> KeyCode.KpMultiply
+    | Keys.Subtract -> KeyCode.KpSubtract
+    | Keys.Add -> KeyCode.KpAdd
+    // NOTE: MonoGame has no separate numpad Enter (it shares Keys.Enter with the
+    // main Enter key), so KeyCode.KpEnter is never produced by this backend.
+    // Media / system
+    | Keys.PrintScreen -> KeyCode.PrintScreen
+    | Keys.Scroll -> KeyCode.ScrollLock
+    | Keys.Pause -> KeyCode.Pause
+    // Locks / indicators
+    | Keys.NumLock -> KeyCode.NumLock
+    | _ -> KeyCode.Unknown
+
+  /// <summary>Maps a backend-neutral <see cref="T:Mibo.Input.KeyCode"/> back to a MonoGame <c>Keys</c>.
+  /// Returns <c>Keys.None</c> for <see cref="F:Mibo.Input.KeyCode.Unknown"/> and for codes with no MG equivalent.</summary>
+  let toMonoGameKey(k: KeyCode) : Keys =
+    match k with
+    // Letters
+    | KeyCode.A -> Keys.A
+    | KeyCode.B -> Keys.B
+    | KeyCode.C -> Keys.C
+    | KeyCode.D -> Keys.D
+    | KeyCode.E -> Keys.E
+    | KeyCode.F -> Keys.F
+    | KeyCode.G -> Keys.G
+    | KeyCode.H -> Keys.H
+    | KeyCode.I -> Keys.I
+    | KeyCode.J -> Keys.J
+    | KeyCode.K -> Keys.K
+    | KeyCode.L -> Keys.L
+    | KeyCode.M -> Keys.M
+    | KeyCode.N -> Keys.N
+    | KeyCode.O -> Keys.O
+    | KeyCode.P -> Keys.P
+    | KeyCode.Q -> Keys.Q
+    | KeyCode.R -> Keys.R
+    | KeyCode.S -> Keys.S
+    | KeyCode.T -> Keys.T
+    | KeyCode.U -> Keys.U
+    | KeyCode.V -> Keys.V
+    | KeyCode.W -> Keys.W
+    | KeyCode.X -> Keys.X
+    | KeyCode.Y -> Keys.Y
+    | KeyCode.Z -> Keys.Z
+    // Digits (top row)
+    | KeyCode.D0 -> Keys.D0
+    | KeyCode.D1 -> Keys.D1
+    | KeyCode.D2 -> Keys.D2
+    | KeyCode.D3 -> Keys.D3
+    | KeyCode.D4 -> Keys.D4
+    | KeyCode.D5 -> Keys.D5
+    | KeyCode.D6 -> Keys.D6
+    | KeyCode.D7 -> Keys.D7
+    | KeyCode.D8 -> Keys.D8
+    | KeyCode.D9 -> Keys.D9
+    // Function keys
+    | KeyCode.F1 -> Keys.F1
+    | KeyCode.F2 -> Keys.F2
+    | KeyCode.F3 -> Keys.F3
+    | KeyCode.F4 -> Keys.F4
+    | KeyCode.F5 -> Keys.F5
+    | KeyCode.F6 -> Keys.F6
+    | KeyCode.F7 -> Keys.F7
+    | KeyCode.F8 -> Keys.F8
+    | KeyCode.F9 -> Keys.F9
+    | KeyCode.F10 -> Keys.F10
+    | KeyCode.F11 -> Keys.F11
+    | KeyCode.F12 -> Keys.F12
+    // Arrow / navigation cluster
+    | KeyCode.Up -> Keys.Up
+    | KeyCode.Down -> Keys.Down
+    | KeyCode.Left -> Keys.Left
+    | KeyCode.Right -> Keys.Right
+    | KeyCode.PageUp -> Keys.PageUp
+    | KeyCode.PageDown -> Keys.PageDown
+    | KeyCode.Home -> Keys.Home
+    | KeyCode.End -> Keys.End
+    | KeyCode.Insert -> Keys.Insert
+    | KeyCode.Delete -> Keys.Delete
+    // Editing / control
+    | KeyCode.Space -> Keys.Space
+    | KeyCode.Enter -> Keys.Enter
+    | KeyCode.Escape -> Keys.Escape
+    | KeyCode.Tab -> Keys.Tab
+    | KeyCode.Backspace -> Keys.Back
+    | KeyCode.CapsLock -> Keys.CapsLock
+    // Modifiers
+    | KeyCode.LeftShift -> Keys.LeftShift
+    | KeyCode.RightShift -> Keys.RightShift
+    | KeyCode.LeftControl -> Keys.LeftControl
+    | KeyCode.RightControl -> Keys.RightControl
+    | KeyCode.LeftAlt -> Keys.LeftAlt
+    | KeyCode.RightAlt -> Keys.RightAlt
+    | KeyCode.LeftSuper -> Keys.LeftWindows
+    | KeyCode.RightSuper -> Keys.None
+    // Punctuation / symbol keys (US layout)
+    | KeyCode.Grave -> Keys.OemTilde
+    | KeyCode.Minus -> Keys.OemMinus
+    | KeyCode.Equal -> Keys.OemPlus
+    | KeyCode.LeftBracket -> Keys.OemOpenBrackets
+    | KeyCode.RightBracket -> Keys.OemCloseBrackets
+    | KeyCode.Backslash -> Keys.OemBackslash
+    | KeyCode.Semicolon -> Keys.OemSemicolon
+    | KeyCode.Apostrophe -> Keys.OemQuotes
+    | KeyCode.Comma -> Keys.OemComma
+    | KeyCode.Period -> Keys.OemPeriod
+    | KeyCode.Slash -> Keys.OemQuestion
+    // Keypad
+    | KeyCode.Kp0 -> Keys.NumPad0
+    | KeyCode.Kp1 -> Keys.NumPad1
+    | KeyCode.Kp2 -> Keys.NumPad2
+    | KeyCode.Kp3 -> Keys.NumPad3
+    | KeyCode.Kp4 -> Keys.NumPad4
+    | KeyCode.Kp5 -> Keys.NumPad5
+    | KeyCode.Kp6 -> Keys.NumPad6
+    | KeyCode.Kp7 -> Keys.NumPad7
+    | KeyCode.Kp8 -> Keys.NumPad8
+    | KeyCode.Kp9 -> Keys.NumPad9
+    | KeyCode.KpDecimal -> Keys.Decimal
+    | KeyCode.KpDivide -> Keys.Divide
+    | KeyCode.KpMultiply -> Keys.Multiply
+    | KeyCode.KpSubtract -> Keys.Subtract
+    | KeyCode.KpAdd -> Keys.Add
+    | KeyCode.KpEnter -> Keys.Enter
+    | KeyCode.KpEqual -> Keys.None
+    // Media / system
+    | KeyCode.PrintScreen -> Keys.PrintScreen
+    | KeyCode.ScrollLock -> Keys.Scroll
+    | KeyCode.Pause -> Keys.Pause
+    | KeyCode.Menu -> Keys.None
+    // Locks / indicators
+    | KeyCode.NumLock -> Keys.NumLock
+    | KeyCode.Unknown -> Keys.None
+
+/// <summary>Functions for translating between MonoGame's <c>Buttons</c> and Mibo's backend-neutral <see cref="T:Mibo.Input.GamepadButtonCode"/>.</summary>
+module GamepadButtonCode =
+
+  /// <summary>Maps a MonoGame <c>Buttons</c> to the backend-neutral <see cref="T:Mibo.Input.GamepadButtonCode"/>.
+  /// Returns <see cref="F:Mibo.Input.GamepadButtonCode.Unknown"/> for any button with no logical equivalent.</summary>
+  /// <remarks>
+  /// MonoGame's <c>Buttons</c> uses an Xbox layout: <c>A</c>/<c>B</c>/<c>X</c>/<c>Y</c> for face buttons,
+  /// <c>LeftShoulder</c>/<c>RightShoulder</c> for bumpers, <c>LeftTrigger</c>/<c>RightTrigger</c> for triggers.
+  /// We map to the abstract <c>FaceUp</c>/<c>FaceRight</c>/<c>FaceDown</c>/<c>FaceLeft</c> (Xbox: Y/B/A/X).
+  /// </remarks>
+  let ofMonoGameButton(b: Buttons) : GamepadButtonCode =
+    match b with
+    // Face buttons (Xbox layout → Face{Up,Right,Down,Left} = Y,B,A,X)
+    | Buttons.Y -> GamepadButtonCode.FaceUp
+    | Buttons.B -> GamepadButtonCode.FaceRight
+    | Buttons.A -> GamepadButtonCode.FaceDown
+    | Buttons.X -> GamepadButtonCode.FaceLeft
+    // Shoulder / bumper
+    | Buttons.LeftShoulder -> GamepadButtonCode.LeftShoulder
+    | Buttons.RightShoulder -> GamepadButtonCode.RightShoulder
+    // Triggers (digital press; analog values come through GamepadAnalog)
+    | Buttons.LeftTrigger -> GamepadButtonCode.LeftTrigger
+    | Buttons.RightTrigger -> GamepadButtonCode.RightTrigger
+    // Stick clicks
+    | Buttons.LeftStick -> GamepadButtonCode.LeftStick
+    | Buttons.RightStick -> GamepadButtonCode.RightStick
+    // Select / Start / Home
+    | Buttons.Back -> GamepadButtonCode.Select
+    | Buttons.Start -> GamepadButtonCode.Start
+    | Buttons.BigButton -> GamepadButtonCode.Home
+    // D-pad (the Buttons enum carries these, but the GamePadButtons snapshot
+    // does NOT — D-pad deltas come from GamePadState.DPad in the poller below).
+    | Buttons.DPadUp -> GamepadButtonCode.DPadUp
+    | Buttons.DPadRight -> GamepadButtonCode.DPadRight
+    | Buttons.DPadDown -> GamepadButtonCode.DPadDown
+    | Buttons.DPadLeft -> GamepadButtonCode.DPadLeft
+    | _ -> GamepadButtonCode.Unknown
+
+  /// <summary>Maps a backend-neutral <see cref="T:Mibo.Input.GamepadButtonCode"/> back to a MonoGame <c>Buttons</c>.
+  /// Returns <c>Buttons.None</c> for <see cref="F:Mibo.Input.GamepadButtonCode.Unknown"/>.</summary>
+  let toMonoGameButton(b: GamepadButtonCode) : Buttons =
+    match b with
+    | GamepadButtonCode.FaceUp -> Buttons.Y
+    | GamepadButtonCode.FaceRight -> Buttons.B
+    | GamepadButtonCode.FaceDown -> Buttons.A
+    | GamepadButtonCode.FaceLeft -> Buttons.X
+    | GamepadButtonCode.LeftShoulder -> Buttons.LeftShoulder
+    | GamepadButtonCode.RightShoulder -> Buttons.RightShoulder
+    | GamepadButtonCode.LeftTrigger -> Buttons.LeftTrigger
+    | GamepadButtonCode.RightTrigger -> Buttons.RightTrigger
+    | GamepadButtonCode.LeftStick -> Buttons.LeftStick
+    | GamepadButtonCode.RightStick -> Buttons.RightStick
+    | GamepadButtonCode.Select -> Buttons.Back
+    | GamepadButtonCode.Start -> Buttons.Start
+    | GamepadButtonCode.Home -> Buttons.BigButton
+    | GamepadButtonCode.DPadUp -> Buttons.DPadUp
+    | GamepadButtonCode.DPadRight -> Buttons.DPadRight
+    | GamepadButtonCode.DPadDown -> Buttons.DPadDown
+    | GamepadButtonCode.DPadLeft -> Buttons.DPadLeft
+    | GamepadButtonCode.Unknown -> Buttons.None
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Input polling (MonoGame). Emits Core-neutral delta values.
+//
+// MonoGame gives whole-state snapshots (KeyboardState/MouseState/GamePadState),
+// so each poller keeps the previous frame's state and diffs.
+// Mirrors the shape of the raylib InputPolling module.
+// ─────────────────────────────────────────────────────────────────────────────
+
+module private InputPolling =
+
+  // Only iterate over keys that are likely to produce a meaningful KeyCode.
+  let allKeys = Enum.GetValues(typeof<Keys>) :?> Keys[]
+
+  let pollKeyboard
+    (prevKeyboard: byref<KeyboardState>)
+    (pressedBuf: ResizeArray<KeyCode>)
+    (releasedBuf: ResizeArray<KeyCode>)
+    (trigger: KeyboardDelta -> unit)
+    =
+    let curr = Keyboard.GetState()
+    pressedBuf.Clear()
+    releasedBuf.Clear()
+
+    for k in allKeys do
+      if k <> Keys.None then
+        let wasDown = prevKeyboard.IsKeyDown(k)
+        let isDown = curr.IsKeyDown(k)
+
+        if isDown && not wasDown then
+          let code = KeyCode.ofMonoGameKey k
+
+          if code <> KeyCode.Unknown then
+            pressedBuf.Add(code)
+        elif wasDown && not isDown then
+          let code = KeyCode.ofMonoGameKey k
+
+          if code <> KeyCode.Unknown then
+            releasedBuf.Add(code)
+
+    if pressedBuf.Count > 0 || releasedBuf.Count > 0 then
+      trigger {
+        Pressed = pressedBuf.ToArray()
+        Released = releasedBuf.ToArray()
+      }
+
+    prevKeyboard <- curr
+
+  let pollMouse (prevMouse: byref<MouseState>) (trigger: MouseDelta -> unit) =
+    let curr = Mouse.GetState()
+
+    let posChanged = curr.X <> prevMouse.X || curr.Y <> prevMouse.Y
+    let scrollDelta = curr.ScrollWheelValue - prevMouse.ScrollWheelValue
+
+    let scrollDeltaH =
+      curr.HorizontalScrollWheelValue - prevMouse.HorizontalScrollWheelValue
+
+    let pressed = ResizeArray<MouseButtonCode>(2)
+    let released = ResizeArray<MouseButtonCode>(2)
+
+    let inline deltaBtn
+      (currBtn: ButtonState)
+      (prevBtn: ButtonState)
+      (code: MouseButtonCode)
+      =
+      if currBtn = ButtonState.Pressed && prevBtn = ButtonState.Released then
+        pressed.Add code
+      elif currBtn = ButtonState.Released && prevBtn = ButtonState.Pressed then
+        released.Add code
+
+    deltaBtn curr.LeftButton prevMouse.LeftButton MouseButtonCode.Left
+    deltaBtn curr.RightButton prevMouse.RightButton MouseButtonCode.Right
+    deltaBtn curr.MiddleButton prevMouse.MiddleButton MouseButtonCode.Middle
+
+    let hasButtonChange = pressed.Count > 0 || released.Count > 0
+
+    if
+      posChanged || scrollDelta <> 0 || scrollDeltaH <> 0 || hasButtonChange
+    then
+      trigger {
+        Position = Vector2(float32 curr.X, float32 curr.Y)
+        PositionDelta =
+          Vector2(float32(curr.X - prevMouse.X), float32(curr.Y - prevMouse.Y))
+        Buttons = {
+          Pressed = pressed.ToArray()
+          Released = released.ToArray()
+        }
+        ScrollDelta = float32 scrollDelta
+        ScrollDeltaV = Vector2(float32 scrollDeltaH, 0.0f)
+      }
+
+    prevMouse <- curr
+
+  let pollTouch(trigger: TouchDelta -> unit) =
+    // MonoGame's TouchPanel exposes raw touch points. High-level gesture
+    // detection (Tap/Hold/Swipe/Pinch) is not built in the way raylib provides;
+    // the GestureKind stream stays empty (see Input.create). Raw touch points
+    // are surfaced here when present.
+    let touches = TouchPanel.GetState()
+
+    if touches.Count > 0 then
+      let points = Array.zeroCreate<TouchPoint> touches.Count
+
+      for i = 0 to touches.Count - 1 do
+        let t = touches[i]
+
+        let state =
+          match t.State with
+          | TouchLocationState.Pressed -> TouchState.Pressed
+          | TouchLocationState.Moved -> TouchState.Moved
+          | TouchLocationState.Released
+          | TouchLocationState.Invalid
+          | _ -> TouchState.Released
+
+        points[i] <- {
+          Id = t.Id
+          Position = Vector2(t.Position.X, t.Position.Y)
+          State = state
+        }
+
+      trigger { Touches = points }
+
+  let pollGamepad
+    (prevGamepad: GamePadState[])
+    (prevConnected: bool[])
+    (triggerDelta: GamepadDelta -> unit)
+    (triggerConnection: GamepadConnection -> unit)
+    =
+    for i = 0 to 3 do
+      let state = GamePad.GetState(i)
+      let isConnected = state.IsConnected
+
+      if prevConnected[i] <> isConnected then
+        triggerConnection {
+          PlayerIndex = i
+          IsConnected = isConnected
+        }
+
+      prevConnected[i] <- isConnected
+
+      // On the first connected frame (or after a reconnect), prev is
+      // default(GamePadState) which reads as all-released, so a frame of
+      // currently-held buttons emits spurious "pressed" events — acceptable
+      // and matches the raylib backend's first-frame behavior.
+      if isConnected then
+        let prev = prevGamepad[i]
+        let pressed = ResizeArray<GamepadButtonCode>(8)
+        let released = ResizeArray<GamepadButtonCode>(8)
+
+        let inline delta
+          (currBtn: ButtonState)
+          (prevBtn: ButtonState)
+          (code: GamepadButtonCode)
+          =
+          if
+            currBtn = ButtonState.Pressed && prevBtn = ButtonState.Released
+          then
+            pressed.Add code
+          elif
+            currBtn = ButtonState.Released && prevBtn = ButtonState.Pressed
+          then
+            released.Add code
+
+        // Face / shoulder / stick / start-select-home live on GamePadButtons.
+        delta state.Buttons.A prev.Buttons.A GamepadButtonCode.FaceDown
+        delta state.Buttons.B prev.Buttons.B GamepadButtonCode.FaceRight
+        delta state.Buttons.X prev.Buttons.X GamepadButtonCode.FaceLeft
+        delta state.Buttons.Y prev.Buttons.Y GamepadButtonCode.FaceUp
+
+        delta
+          state.Buttons.LeftShoulder
+          prev.Buttons.LeftShoulder
+          GamepadButtonCode.LeftShoulder
+
+        delta
+          state.Buttons.RightShoulder
+          prev.Buttons.RightShoulder
+          GamepadButtonCode.RightShoulder
+
+        delta
+          state.Buttons.LeftStick
+          prev.Buttons.LeftStick
+          GamepadButtonCode.LeftStick
+
+        delta
+          state.Buttons.RightStick
+          prev.Buttons.RightStick
+          GamepadButtonCode.RightStick
+
+        delta state.Buttons.Back prev.Buttons.Back GamepadButtonCode.Select
+        delta state.Buttons.Start prev.Buttons.Start GamepadButtonCode.Start
+
+        delta
+          state.Buttons.BigButton
+          prev.Buttons.BigButton
+          GamepadButtonCode.Home
+
+        // D-pad lives on a separate GamePadDPad struct, not on GamePadButtons.
+        delta state.DPad.Up prev.DPad.Up GamepadButtonCode.DPadUp
+        delta state.DPad.Right prev.DPad.Right GamepadButtonCode.DPadRight
+        delta state.DPad.Down prev.DPad.Down GamepadButtonCode.DPadDown
+        delta state.DPad.Left prev.DPad.Left GamepadButtonCode.DPadLeft
+
+        // Triggers: expose as digital presses at a threshold (analog values
+        // flow through the GamepadAnalog below). 0.5 matches the original Mibo.
+        let ltDigital = state.Triggers.Left >= 0.5f
+        let ltPrev = prev.Triggers.Left >= 0.5f
+        let rtDigital = state.Triggers.Right >= 0.5f
+        let rtPrev = prev.Triggers.Right >= 0.5f
+
+        if ltDigital && not ltPrev then
+          pressed.Add GamepadButtonCode.LeftTrigger
+        elif not ltDigital && ltPrev then
+          released.Add GamepadButtonCode.LeftTrigger
+
+        if rtDigital && not rtPrev then
+          pressed.Add GamepadButtonCode.RightTrigger
+        elif not rtDigital && rtPrev then
+          released.Add GamepadButtonCode.RightTrigger
+
+        let analog = {
+          LeftThumbstick =
+            Vector2(state.ThumbSticks.Left.X, -state.ThumbSticks.Left.Y)
+          RightThumbstick =
+            Vector2(state.ThumbSticks.Right.X, -state.ThumbSticks.Right.Y)
+          LeftTrigger = state.Triggers.Left
+          RightTrigger = state.Triggers.Right
+        }
+
+        let hasChange =
+          pressed.Count > 0
+          || released.Count > 0
+          || analog.LeftThumbstick <> Vector2.Zero
+          || analog.RightThumbstick <> Vector2.Zero
+          || analog.LeftTrigger <> 0.0f
+          || analog.RightTrigger <> 0.0f
+
+        if hasChange then
+          triggerDelta {
+            PlayerIndex = i
+            Buttons = {
+              Pressed = pressed.ToArray()
+              Released = released.ToArray()
+            }
+            Analog = analog
+          }
+
+      prevGamepad[i] <- state
+
+// ─────────────────────────────────────────────────────────────────────────────
+// IInput factory (MonoGame implementation).
+// ─────────────────────────────────────────────────────────────────────────────
+
+module Input =
+
+  let internal create(_game: Microsoft.Xna.Framework.Game) : IInput =
+    let keyboardDelta = Event<KeyboardDelta>()
+    let mouseDelta = Event<MouseDelta>()
+    let touchDelta = Event<TouchDelta>()
+    let gamepadDelta = Event<GamepadDelta>()
+    let gamepadConnection = Event<GamepadConnection>()
+
+    let pressedKeysBuf = ResizeArray<KeyCode>(8)
+    let releasedKeysBuf = ResizeArray<KeyCode>(8)
+    let mutable prevKeyboard = Keyboard.GetState()
+    let mutable prevMouse = Mouse.GetState()
+    let prevConnected = Array.create 4 false
+    let prevGamepad = Array.init 4 (fun i -> GamePad.GetState(i))
+
+    { new IInput with
+        member _.Poll() =
+          InputPolling.pollKeyboard
+            &prevKeyboard
+            pressedKeysBuf
+            releasedKeysBuf
+            keyboardDelta.Trigger
+
+          InputPolling.pollMouse &prevMouse mouseDelta.Trigger
+          InputPolling.pollTouch touchDelta.Trigger
+
+          InputPolling.pollGamepad
+            prevGamepad
+            prevConnected
+            gamepadDelta.Trigger
+            gamepadConnection.Trigger
+
+        member _.KeyboardDelta = keyboardDelta.Publish
+        member _.MouseDelta = mouseDelta.Publish
+        member _.TouchDelta = touchDelta.Publish
+        member _.GamepadDelta = gamepadDelta.Publish
+        member _.GamepadConnection = gamepadConnection.Publish
+
+        // MonoGame has no built-in high-level gesture detection matching the
+        // Core GestureKind set. Gestures are a known 80/20 gap — this stream
+        // stays empty until a gesture recognizer is layered on.
+        member _.GestureDelta =
+          { new IObservable<GestureDelta> with
+              member _.Subscribe(_observer) =
+                { new IDisposable with
+                    member _.Dispose() = ()
+                }
+          }
+    }

--- a/src/Mibo.MonoGame/Input.fs
+++ b/src/Mibo.MonoGame/Input.fs
@@ -414,7 +414,7 @@ module private InputPolling =
           Released = released.ToArray()
         }
         ScrollDelta = float32 scrollDelta
-        ScrollDeltaV = Vector2(float32 scrollDeltaH, 0.0f)
+        ScrollDeltaV = Vector2(float32 scrollDeltaH, float32 scrollDelta)
       }
 
     prevMouse <- curr

--- a/src/Mibo.MonoGame/InputMapper.fs
+++ b/src/Mibo.MonoGame/InputMapper.fs
@@ -1,0 +1,314 @@
+namespace Mibo.Input
+
+open System
+open System.Collections.Generic
+open System.Numerics
+open Microsoft.Xna.Framework.Input
+open Mibo.Elmish
+
+// Trigger, InputMap<'Action>, ActionState<'Action>, IInputMapper<'Action>, and
+// the InputMapper service accessors (getService/tryGetService) all live in Core.
+// This file contains only the MonoGame-specific factory + polling logic that
+// evaluates whether a Core Trigger is currently held, by translating to the
+// native MonoGame key/button and reading Keyboard/Mouse/GamePad state.
+//
+// Mirrors the raylib InputMapper.fs shape: buildActions (shared logic) +
+// subscribe/subscribeStatic (observable-driven) + createService (poll-driven).
+
+module InputMapper =
+
+  let internal buildActions
+    (getMap: unit -> InputMap<'Action>)
+    (prevComboStates: Map<Set<KeyCode>, bool>)
+    (pressed: Trigger[])
+    (released: Trigger[])
+    (isKeyDown: KeyCode -> bool)
+    (isMouseButtonDown: MouseButtonCode -> bool)
+    (isGamepadButtonDown: int -> GamepadButtonCode -> bool)
+    : ActionState<'Action> * Map<Set<KeyCode>, bool> =
+    let map = getMap()
+    let mutable started = Set.empty
+    let mutable releasedSet = Set.empty
+    let mutable held = Set.empty
+    let mutable heldTriggers = Set.empty
+    let mutable values = Map.empty
+    let mutable comboStates = prevComboStates
+
+    for kv in map.TriggerToActions do
+      let isDown =
+        match kv.Key with
+        | Key k -> isKeyDown k
+        | KeyCombo keys -> keys |> Set.forall isKeyDown
+        | MouseButton b -> isMouseButtonDown b
+        | GamepadButton(p, b) -> isGamepadButtonDown p b
+
+      if isDown then
+        heldTriggers <- heldTriggers |> Set.add kv.Key
+
+        for a in kv.Value do
+          held <- held |> Set.add a
+          values <- values |> Map.add a 1.0f
+
+      match kv.Key with
+      | KeyCombo keys ->
+        let wasHeld =
+          comboStates |> Map.tryFind keys |> Option.defaultValue false
+
+        comboStates <- comboStates |> Map.add keys isDown
+
+        if isDown && not wasHeld then
+          for a in kv.Value do
+            started <- started |> Set.add a
+        elif not isDown && wasHeld then
+          for a in kv.Value do
+            releasedSet <- releasedSet |> Set.add a
+      | _ -> ()
+
+    for t in pressed do
+      map.TriggerToActions
+      |> Map.tryFind t
+      |> Option.iter(fun actions ->
+        for a in actions do
+          started <- started |> Set.add a)
+
+    for t in released do
+      map.TriggerToActions
+      |> Map.tryFind t
+      |> Option.iter(fun actions ->
+        for a in actions do
+          releasedSet <- releasedSet |> Set.add a)
+
+    releasedSet <- releasedSet |> Set.filter(fun a -> not(held.Contains a))
+
+    ({
+      Held = held
+      Started = started
+      Released = releasedSet
+      Values = values
+      HeldTriggers = heldTriggers
+     },
+     comboStates)
+
+  // MonoGame whole-state pollers for the "is this held right now?" queries.
+  // MonoGame gives whole-state snapshots, so these read Keyboard/Mouse/GamePad
+  // state on demand. Used by both subscribe (per-event) and createService
+  // (per-Update).
+  let private isKeyDownFor (kb: KeyboardState) (k: KeyCode) : bool =
+    kb.IsKeyDown(KeyCode.toMonoGameKey k)
+
+  let private isMouseButtonDownFor
+    (ms: MouseState)
+    (b: MouseButtonCode)
+    : bool =
+    match b with
+    | MouseButtonCode.Left -> ms.LeftButton = ButtonState.Pressed
+    | MouseButtonCode.Right -> ms.RightButton = ButtonState.Pressed
+    | MouseButtonCode.Middle -> ms.MiddleButton = ButtonState.Pressed
+    | MouseButtonCode.Extra1 -> ms.XButton1 = ButtonState.Pressed
+    | MouseButtonCode.Extra2 -> ms.XButton2 = ButtonState.Pressed
+    | _ -> false
+
+  let private isGamepadButtonDownFor
+    (gp: GamePadState)
+    (playerIndex: int)
+    (b: GamepadButtonCode)
+    : bool =
+    // playerIndex is carried for API parity with the Trigger DU (which is
+    // player-tagged); the caller has already routed to this player's state,
+    // so no cross-check is needed (and GamePadState has no PlayerIndex field).
+    if not gp.IsConnected then
+      false
+    else
+      let btn = GamepadButtonCode.toMonoGameButton b
+
+      match btn with
+      | Buttons.DPadUp -> gp.DPad.Up = ButtonState.Pressed
+      | Buttons.DPadRight -> gp.DPad.Right = ButtonState.Pressed
+      | Buttons.DPadDown -> gp.DPad.Down = ButtonState.Pressed
+      | Buttons.DPadLeft -> gp.DPad.Left = ButtonState.Pressed
+      | Buttons.LeftTrigger -> gp.Triggers.Left >= 0.5f
+      | Buttons.RightTrigger -> gp.Triggers.Right >= 0.5f
+      | _ -> gp.IsButtonDown(btn)
+
+  /// <summary>
+  /// Elmish subscription that builds an <see cref="T:Mibo.Input.ActionState`1"/> from
+  /// the registered <see cref="T:Mibo.Input.IInput"/> observables and the supplied map.
+  /// Backend-neutral apart from the "is key down" poller, which reads MonoGame state.
+  /// </summary>
+  let subscribe
+    (getMap: unit -> InputMap<'Action>)
+    (toMsg: ActionState<'Action> -> 'Msg)
+    (ctx: GameContext)
+    : Sub<'Msg> =
+    let subId = SubId.ofString "Mibo/Input/InputMapper/subscribe"
+
+    let subscribeFn(dispatch: Dispatch<'Msg>) =
+      let input = Input.getService ctx
+      let mutable prevComboStates = Map.empty<Set<KeyCode>, bool>
+
+      let doBuild (pressed: Trigger[]) (released: Trigger[]) =
+        // Snapshot MonoGame state for the "held right now?" queries.
+        let kb = Keyboard.GetState()
+        let ms = Mouse.GetState()
+        let g0 = GamePad.GetState(0)
+        let g1 = GamePad.GetState(1)
+        let g2 = GamePad.GetState(2)
+        let g3 = GamePad.GetState(3)
+
+        let isGpDown (p: int) (b: GamepadButtonCode) =
+          match p with
+          | 0 -> isGamepadButtonDownFor g0 0 b
+          | 1 -> isGamepadButtonDownFor g1 1 b
+          | 2 -> isGamepadButtonDownFor g2 2 b
+          | _ -> isGamepadButtonDownFor g3 3 b
+
+        let state, newComboStates =
+          buildActions
+            getMap
+            prevComboStates
+            pressed
+            released
+            (isKeyDownFor kb)
+            (isMouseButtonDownFor ms)
+            isGpDown
+
+        prevComboStates <- newComboStates
+        state
+
+      let subKey: IDisposable =
+        input.KeyboardDelta.Subscribe(fun (d: KeyboardDelta) ->
+          let pressed = d.Pressed |> Array.map Key
+          let released = d.Released |> Array.map Key
+          doBuild pressed released |> toMsg |> dispatch)
+
+      let subMouse: IDisposable =
+        input.MouseDelta.Subscribe(fun (d: MouseDelta) ->
+          let pressed = d.Buttons.Pressed |> Array.map Trigger.MouseButton
+          let released = d.Buttons.Released |> Array.map Trigger.MouseButton
+          doBuild pressed released |> toMsg |> dispatch)
+
+      let subGamepad: IDisposable =
+        input.GamepadDelta.Subscribe(fun (d: GamepadDelta) ->
+          let pressed =
+            d.Buttons.Pressed
+            |> Array.map(fun b -> Trigger.GamepadButton(d.PlayerIndex, b))
+
+          let released =
+            d.Buttons.Released
+            |> Array.map(fun b -> Trigger.GamepadButton(d.PlayerIndex, b))
+
+          doBuild pressed released |> toMsg |> dispatch)
+
+      { new IDisposable with
+          member _.Dispose() =
+            subKey.Dispose()
+            subMouse.Dispose()
+            subGamepad.Dispose()
+      }
+
+    Sub.Active(subId, subscribeFn)
+
+  /// <summary>
+  /// Elmish subscription variant for a fixed (non-changing) InputMap.
+  /// </summary>
+  let subscribeStatic
+    (map: InputMap<'Action>)
+    (toMsg: ActionState<'Action> -> 'Msg)
+    (ctx: GameContext)
+    : Sub<'Msg> =
+    subscribe (fun () -> map) toMsg ctx
+
+  /// <summary>
+  /// Creates the backend-specific <see cref="T:Mibo.Input.IInputMapper`1"/> service.
+  /// Polls MonoGame state on each <c>Update()</c>. Registered into GameContext
+  /// by the runtime host when <c>MonoGameProgram.withInputMapper</c> is set.
+  /// </summary>
+  let internal createService
+    (initialMap: InputMap<'Action>)
+    : IInputMapper<'Action> =
+    let mutable map = initialMap
+    let mutable state = ActionState.empty
+    let mutable prevComboStates = Map.empty<Set<KeyCode>, bool>
+
+    { new IInputMapper<'Action> with
+        member _.CurrentState = state
+
+        member _.Update() =
+          let kb = Keyboard.GetState()
+          let ms = Mouse.GetState()
+          let g0 = GamePad.GetState(0)
+          let g1 = GamePad.GetState(1)
+          let g2 = GamePad.GetState(2)
+          let g3 = GamePad.GetState(3)
+
+          let isGpDown (p: int) (b: GamepadButtonCode) =
+            match p with
+            | 0 -> isGamepadButtonDownFor g0 0 b
+            | 1 -> isGamepadButtonDownFor g1 1 b
+            | 2 -> isGamepadButtonDownFor g2 2 b
+            | _ -> isGamepadButtonDownFor g3 3 b
+
+          // For the poll-driven service, derive Held/Started/Released from the
+          // current "is this trigger held?" snapshot, diffing Held against the
+          // previous frame's Held to get edges (the standard polling-mapper
+          // pattern). KeyCombo edge tracking needs its own prev-state map.
+          let mutable started = Set.empty
+          let mutable releasedSet = Set.empty
+          let mutable held = Set.empty
+          let mutable heldTriggers = Set.empty
+          let mutable values = Map.empty
+
+          for kv in map.TriggerToActions do
+            let isDown =
+              match kv.Key with
+              | Key k -> isKeyDownFor kb k
+              | KeyCombo keys -> keys |> Set.forall(isKeyDownFor kb)
+              | MouseButton b -> isMouseButtonDownFor ms b
+              | GamepadButton(p, b) -> isGpDown p b
+
+            if isDown then
+              heldTriggers <- heldTriggers |> Set.add kv.Key
+
+              for a in kv.Value do
+                held <- held |> Set.add a
+                values <- values |> Map.add a 1.0f
+
+            match kv.Key with
+            | KeyCombo keys ->
+              let wasHeld =
+                prevComboStates |> Map.tryFind keys |> Option.defaultValue false
+
+              prevComboStates <- prevComboStates |> Map.add keys isDown
+
+              if isDown && not wasHeld then
+                for a in kv.Value do
+                  started <- started |> Set.add a
+              elif not isDown && wasHeld then
+                for a in kv.Value do
+                  releasedSet <- releasedSet |> Set.add a
+            | _ -> ()
+
+          // Derived edges for single keys/buttons: a trigger that is held now
+          // but wasn't last frame → Started; was held but no longer → Released.
+          let prevHeld = state.Held
+
+          for a in held do
+            if not(prevHeld.Contains a) then
+              started <- started |> Set.add a
+
+          for a in prevHeld do
+            if not(held.Contains a) then
+              releasedSet <- releasedSet |> Set.add a
+
+          for a in releasedSet do
+            held <- held |> Set.remove a
+            values <- values |> Map.remove a
+
+          state <- {
+            Held = held
+            Started = started
+            Released = releasedSet
+            Values = values
+            HeldTriggers = heldTriggers
+          }
+    }

--- a/src/Mibo.MonoGame/InputMapper.fs
+++ b/src/Mibo.MonoGame/InputMapper.fs
@@ -300,9 +300,12 @@ module InputMapper =
             if not(held.Contains a) then
               releasedSet <- releasedSet |> Set.add a
 
-          for a in releasedSet do
-            held <- held |> Set.remove a
-            values <- values |> Map.remove a
+          // An action may appear in releasedSet via a KeyCombo release while
+          // still held by another trigger. Filter rather than mutate held —
+          // matches buildActions (line ~81). Mutating held here would
+          // incorrectly deactivate an action still held by another binding.
+          releasedSet <-
+            releasedSet |> Set.filter(fun a -> not(held.Contains a))
 
           state <- {
             Held = held

--- a/src/Mibo.MonoGame/Mibo.MonoGame.fsproj
+++ b/src/Mibo.MonoGame/Mibo.MonoGame.fsproj
@@ -8,7 +8,11 @@
 
   <ItemGroup>
     <Compile Include="GameContext.fs" />
+    <Compile Include="Input.fs" />
+    <Compile Include="InputMapper.fs" />
+    <Compile Include="Assets.fs" />
     <Compile Include="Runtime.fs" />
+    <Compile Include="Program.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mibo.MonoGame/Mibo.MonoGame.fsproj
+++ b/src/Mibo.MonoGame/Mibo.MonoGame.fsproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <OutputType>Library</OutputType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="GameContext.fs" />
+    <Compile Include="Runtime.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mibo.Core\Mibo.Core.fsproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MonoGame.Framework.Native" Version="3.8.4.1" />
+    <PackageReference Include="FSharp.UMX" Version="1.1.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/Mibo.MonoGame/Program.fs
+++ b/src/Mibo.MonoGame/Program.fs
@@ -1,0 +1,56 @@
+namespace Mibo.Elmish
+
+open Mibo.Input
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MonoGame-specific Program builder extensions.
+//
+// Mirrors RaylibProgram: the backend-neutral Program builder (mkProgram,
+// withConfig, withRenderer, withTick, withFixedStep, withDispatchMode,
+// withSubscription, withAssets, withAssetsBasePath, withInput,
+// withServiceRegistration) lives in Mibo.Core.
+//
+// This module holds the only backend-coupled builder: withInputMapper, which
+// instantiates the MonoGame IInputMapper implementation. It registers the
+// service via a ServiceRegistration callback that MiboGame runs before Init,
+// so the Core Program type never references a backend factory.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>MonoGame-specific <see cref="T:Mibo.Elmish.Program"/> builder extensions.</summary>
+module MonoGameProgram =
+
+  /// <summary>
+  /// Configures the game to register an <see cref="T:Mibo.Input.IInputMapper`1"/> service
+  /// backed by MonoGame's polling API.
+  /// </summary>
+  /// <remarks>
+  /// <para>This registers <see cref="T:Mibo.Input.IInput"/> automatically (equivalent to <see cref="M:Mibo.Elmish.Program.withInput"/>).</para>
+  /// <para>The mapper is registered as a service via a <see cref="F:Mibo.Elmish.Program.ServiceRegistrations"/>
+  /// callback that <c>MiboGame</c> runs before <c>Init</c>, so the Core Program
+  /// type does not reference the MonoGame factory directly.</para>
+  /// <para>If you want to stay fully "Elmish" (no service access), consider using
+  /// <see cref="M:Mibo.Input.InputMapper.subscribe"/> instead and handle a single message.</para>
+  /// </remarks>
+  /// <example>
+  /// <code>
+  /// program |&gt; MonoGameProgram.withInputMapper inputMap
+  /// </code>
+  /// </example>
+  let withInputMapper<'Model, 'Msg, 'Action when 'Action: comparison>
+    (initialMap: InputMap<'Action>)
+    (program: Program<'Model, 'Msg>)
+    : Program<'Model, 'Msg> =
+    let program = program |> Program.withInput
+
+    // Register the MonoGame-backed IInputMapper service before Init runs.
+    // The host invokes ServiceRegistrations after IInput is available.
+    let withRegistration =
+      program
+      |> Program.withServiceRegistration(fun ctx ->
+        let mapper = InputMapper.createService initialMap
+        GameContext.register<IInputMapper<'Action>> mapper ctx)
+
+    {
+      withRegistration with
+          HasInputMapper = true
+    }

--- a/src/Mibo.MonoGame/Runtime.fs
+++ b/src/Mibo.MonoGame/Runtime.fs
@@ -58,6 +58,10 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
 
     graphics.SynchronizeWithVerticalRetrace <- config.TargetFPS <= 0
 
+    // Disable MG fixed timestep when TargetFPS <= 0 (unlocked/VSync intent).
+    // MG defaults IsFixedTimeStep=true (fixed 60fps), which would override VSync.
+    this.IsFixedTimeStep <- config.TargetFPS > 0
+
     if config.TargetFPS > 0 then
       this.TargetElapsedTime <-
         TimeSpan.FromSeconds(1.0 / float config.TargetFPS)
@@ -161,6 +165,12 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
         match renderers[i] with
         | :? IDisposable as d -> d.Dispose()
         | _ -> ()
+
+      ctxOpt
+      |> ValueOption.iter(fun ctx ->
+        match GameContext.tryGetService<IAssets> ctx with
+        | ValueSome assets -> assets.Dispose()
+        | _ -> ())
 
       loop.DisposeSubs()
 

--- a/src/Mibo.MonoGame/Runtime.fs
+++ b/src/Mibo.MonoGame/Runtime.fs
@@ -1,0 +1,161 @@
+namespace Mibo.Elmish
+
+open System
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Graphics
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MiboGame: the MonoGame-backed Elmish host.
+//
+// Mirrors RaylibGame's responsibilities, but expressed through the MonoGame
+// Game lifecycle (Initialize → LoadContent → Update → Draw) instead of a flat
+// Run() loop. Owns no message-processing state of its own — it delegates all of
+// that (dispatch queue, execCmd, updateSubs, deferred effects, FixedStep, tick,
+// message pump) to the shared ElmishLoop (Mibo.Core). This host is only the
+// I/O shell: window/graphics lifecycle, input polling, rendering dispatch, and
+// the per-frame time mapping.
+//
+// Work ordering each frame (matches ElmishLoop.TickFrame + RaylibGame):
+//   Update: poll input → ElmishLoop.TickFrame (deferred drain → FixedStep →
+//           tick → message pump → subscription diff)
+//   Draw:   iterate renderers in add-order (reversed, since the list is
+//           ::-prepended)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>
+/// The MonoGame-backed game host. Subclasses <c>Microsoft.Xna.Framework.Game</c>
+/// and drives a shared <see cref="T:Mibo.Elmish.ElmishLoop`2"/> from
+/// <c>Update</c>/<c>Draw</c>.
+/// </summary>
+/// <remarks>
+/// Construct one with a <see cref="T:Mibo.Elmish.Program`2"/> and call
+/// <c>Run()</c>. The host owns the MonoGame window/graphics lifecycle and
+/// delegates message processing to <c>ElmishLoop</c> — it holds no
+/// dispatch/update state of its own.
+/// </remarks>
+type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
+  inherit Game()
+
+  let graphics = new GraphicsDeviceManager(this)
+
+  let loop = ElmishLoop.create(ElmishLoop.coreOfProgram program)
+  let renderers = ResizeArray<IRenderer<'Model>>()
+  // inputServiceOpt is wired in a later Phase 4 step when Mibo.MonoGame.Input lands.
+  let mutable ctxOpt: GameContext voption = ValueNone
+
+  // ── Config: apply the cumulative GameConfig callbacks once, in the ctor,
+  // before Initialize runs (mirrors RaylibGame applying config before InitWindow).
+  do
+    let config =
+      List.fold
+        (fun c f -> f c)
+        GameConfig.defaultConfig
+        (List.rev program.Config)
+
+    graphics.PreferredBackBufferWidth <- config.Width
+    graphics.PreferredBackBufferHeight <- config.Height
+
+    graphics.SynchronizeWithVerticalRetrace <- config.TargetFPS <= 0
+
+    if config.TargetFPS > 0 then
+      this.TargetElapsedTime <-
+        TimeSpan.FromSeconds(1.0 / float config.TargetFPS)
+
+    this.Window.Title <- config.Title
+    this.IsMouseVisible <- true
+
+  // ── Initialize: build renderers and register input (the MG GraphicsDevice
+  // exists by now). LoadContent (below) finishes wiring and starts the loop.
+  override _.Initialize() =
+    // Reverse to match add-order (the list is ::-prepended, like Config and
+    // ServiceRegistrations). Same rationale as RaylibGame: without this the
+    // last renderer added draws first.
+    for f in List.rev program.Renderers do
+      renderers.Add(f())
+
+    base.Initialize()
+
+  // ── LoadContent: build the GameContext, register MonoGame handles + backend
+  // services, then start the shared loop (calls program.Init, execCmd, subs).
+  override _.LoadContent() =
+    base.LoadContent()
+
+    let ctx =
+      GameContext.create(
+        this.Window.ClientBounds.Width,
+        this.Window.ClientBounds.Height
+      )
+
+    ctxOpt <- ValueSome ctx
+
+    // Register MonoGame handles so user init/update code can resolve them.
+    MonoGameGameContext.register this ctx
+
+    // NOTE: input service registration (IInput) lands in a later Phase 4 step
+    // when the Mibo.MonoGame input module exists. For now, programs that use
+    // input subscriptions won't find an IInput in the registry.
+
+    // Run backend-specific service registrations (e.g. IInputMapper) before
+    // Init so user init code sees every registered service.
+    for register in List.rev program.ServiceRegistrations do
+      register ctx
+
+    // Initialize the shared loop (calls program.Init, execCmd, updateSubs).
+    loop.Init(ctx)
+
+  // ── Update: advance the shared loop. (Input polling lands in a later step.)
+  override _.Update(gameTime: GameTime) =
+    base.Update gameTime
+
+    match ctxOpt with
+    | ValueSome ctx ->
+      // Reflect window resize into the portable context dimensions.
+      let bounds = this.Window.ClientBounds
+
+      if
+        bounds.Width <> ctx.WindowWidth || bounds.Height <> ctx.WindowHeight
+      then
+        ctx.UpdateDimensions(bounds.Width, bounds.Height)
+
+      loop.TickFrame(
+        gameTime.ElapsedGameTime,
+        {
+          TotalTime = gameTime.TotalGameTime
+          ElapsedGameTime = gameTime.ElapsedGameTime
+        }
+      )
+      |> ignore
+    | ValueNone -> ()
+
+    if loop.ShouldQuit then
+      this.Exit()
+
+  // ── Draw: render in add-order. Mibo.MonoGame ships no default renderers;
+  // users implement IRenderer<'Model> against SpriteBatch/draw calls.
+  override _.Draw(gameTime: GameTime) =
+    base.Draw gameTime
+
+    match ctxOpt with
+    | ValueSome ctx ->
+      let gameTime = {
+        TotalTime = gameTime.TotalGameTime
+        ElapsedGameTime = gameTime.ElapsedGameTime
+      }
+
+      for i = 0 to renderers.Count - 1 do
+        renderers[i].Draw(ctx, loop.Model, gameTime)
+    | ValueNone -> ()
+
+  override _.Dispose(disposing) =
+    if disposing then
+      for i = 0 to renderers.Count - 1 do
+        match renderers[i] with
+        | :? IDisposable as d -> d.Dispose()
+        | _ -> ()
+
+      loop.DisposeSubs()
+
+    base.Dispose(disposing)
+
+  interface IDisposable with
+    member this.Dispose() = this.Dispose(true)

--- a/src/Mibo.MonoGame/Runtime.fs
+++ b/src/Mibo.MonoGame/Runtime.fs
@@ -3,6 +3,7 @@ namespace Mibo.Elmish
 open System
 open Microsoft.Xna.Framework
 open Microsoft.Xna.Framework.Graphics
+open Mibo.Input
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MiboGame: the MonoGame-backed Elmish host.
@@ -40,7 +41,7 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
 
   let loop = ElmishLoop.create(ElmishLoop.coreOfProgram program)
   let renderers = ResizeArray<IRenderer<'Model>>()
-  // inputServiceOpt is wired in a later Phase 4 step when Mibo.MonoGame.Input lands.
+  let mutable inputServiceOpt: IInput voption = ValueNone
   let mutable ctxOpt: GameContext voption = ValueNone
 
   // ── Config: apply the cumulative GameConfig callbacks once, in the ctor,
@@ -64,8 +65,8 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
     this.Window.Title <- config.Title
     this.IsMouseVisible <- true
 
-  // ── Initialize: build renderers and register input (the MG GraphicsDevice
-  // exists by now). LoadContent (below) finishes wiring and starts the loop.
+  // ── Initialize: build renderers (the MG GraphicsDevice exists by now).
+  // LoadContent (below) finishes wiring and starts the loop.
   override _.Initialize() =
     // Reverse to match add-order (the list is ::-prepended, like Config and
     // ServiceRegistrations). Same rationale as RaylibGame: without this the
@@ -91,9 +92,15 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
     // Register MonoGame handles so user init/update code can resolve them.
     MonoGameGameContext.register this ctx
 
-    // NOTE: input service registration (IInput) lands in a later Phase 4 step
-    // when the Mibo.MonoGame input module exists. For now, programs that use
-    // input subscriptions won't find an IInput in the registry.
+    // Register the MonoGame asset service (always, mirroring RaylibGame which
+    // registers IAssets unconditionally). Built over the host's ContentManager.
+    let assets = AssetsService.create this.Content
+    GameContext.register<IAssets> assets ctx
+
+    if program.HasInput then
+      let inputService = Input.create this
+      GameContext.register<IInput> inputService ctx
+      inputServiceOpt <- ValueSome inputService
 
     // Run backend-specific service registrations (e.g. IInputMapper) before
     // Init so user init code sees every registered service.
@@ -103,9 +110,11 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
     // Initialize the shared loop (calls program.Init, execCmd, updateSubs).
     loop.Init(ctx)
 
-  // ── Update: advance the shared loop. (Input polling lands in a later step.)
+  // ── Update: poll hardware input, then advance the shared loop.
   override _.Update(gameTime: GameTime) =
     base.Update gameTime
+
+    inputServiceOpt |> ValueOption.iter(fun svc -> svc.Poll())
 
     match ctxOpt with
     | ValueSome ctx ->

--- a/src/Mibo.Raylib/InputMapper.fs
+++ b/src/Mibo.Raylib/InputMapper.fs
@@ -235,9 +235,12 @@ module InputMapper =
                 held <- held |> Set.add a
                 values <- values |> Map.add a 1.0f
 
-          for a in releasedSet do
-            held <- held |> Set.remove a
-            values <- values |> Map.remove a
+          // An action may appear in releasedSet via a KeyCombo release while
+          // still held by another trigger. Filter rather than mutate held —
+          // matches buildActions (line ~77). Mutating held here would
+          // incorrectly deactivate an action still held by another binding.
+          releasedSet <-
+            releasedSet |> Set.filter(fun a -> not(held.Contains a))
 
           state <- {
             Held = held


### PR DESCRIPTION
# Phase 4 — Fresh `Mibo.MonoGame` backend

Implements the MonoGame backend against the existing `Mibo.Core` contracts, as
the second pluggable backend alongside `Mibo.Raylib`. Tracking `vnext` — see
`PLAN.md` for the full design record and decisions.

## Summary

A new `src/Mibo.MonoGame` project (`net8.0`, `MonoGame.Framework.Native` 3.8.4.1)
that implements every Core contract a Mibo host needs:

- **Runtime host** — `MiboGame : Microsoft.Xna.Framework.Game`, driving the
  shared `ElmishLoop` (Phase 2) from `Update`/`Draw`. Owns no message-processing
  state of its own — delegates the dispatch queue, `execCmd`, subscription
  diffing, FixedStep, and tick to Core.
- **`MonoGameGameContext`** — registers `GraphicsDevice`/`ContentManager`/`Game`
  into the Core `GameContext` service registry (mirroring how raylib registers
  `IInput`/`IAssets`). Zero Core changes; `InternalsVisibleTo("Mibo.MonoGame")`
  was already provisioned.
- **`Input.fs`** — `KeyCode.ofMonoGameKey`/`toMonoGameKey` +
  `GamepadButtonCode.ofMonoGameButton`/`toMonoGameButton`, whole-state pollers,
  and `Input.create`. Covers the same 80/20 surface the raylib backend maps.
- **`InputMapper.fs`** — `buildActions` (shared logic) + `subscribe`/
  `subscribeStatic` + `createService`, mirroring the raylib implementation.
- **`Assets.fs`** — `IAssets` over `ContentManager` (typed loaders cached in
  dictionaries), extending Core `IAssetCache`.
- **`Program.fs`** — `MonoGameProgram.withInputMapper`.

## What's NOT included (by design — see PLAN.md decisions)

- **No renderers.** Per the explicit decision, the MonoGame backend ships no
  default `IRenderer<'Model>` implementations. Users implement their own against
  `SpriteBatch`/draw calls.
- **No content pipeline shaders** (`.fxb`). No default shaders ship.
- **No platform package prescription.** The library references
  `MonoGame.Framework.Native` only — the WindowsDX/DesktopGL/OpenGL choice is
  the app author's (decision 4).

## Verification

- `dotnet build` (whole solution: Core, Raylib, MonoGame, Tests, all samples) — **0 errors**.
- `dotnet fantomas` on the new files — clean.

## Parity notes (surfaces real MonoGame API differences)

- MonoGame gives **whole-state snapshots** (`KeyboardState`/`MouseState`/
  `GamePadState`); pollers diff against the previous frame's state.
- **D-pad lives on `GamePadState.DPad`**, not `GamePadButtons`.
- **Triggers** exposed digitally at a 0.5 threshold (analog via `GamepadAnalog`).
- **No `RightSuper` mapping** (MonoGame has only `LeftWindows`).
- **No separate numpad Enter** (MonoGame shares `Keys.Enter`).
- **Gestures are a known 80/20 gap** — MonoGame has no built-in high-level
  gesture detection matching raylib's; `GestureDelta` stays empty until a
  recognizer is layered on.

## Remaining before merge

The library compiles and is API-complete. A runtime smoke test (boot a
`MiboGame`, process one tick, exit) needs a real `GraphicsDevice`, which isn't
available in CI — that's a manual desktop verification step. Reviewers with a
desktop environment: a minimal `MiboGame` + `Run()` confirming a window opens
and closes cleanly is the acceptance check.

## Follow-up

Phase 5 (parity verification) is the optional final phase: confirm Core has
zero backend references, and that a sample runs on both backends with matching
simulation behavior.
