### PR TITLE
fix(monogame): scope input polling to window area

### DIFF
--- a/src/Mibo.MonoGame/Input.fs
+++ b/src/Mibo.MonoGame/Input.fs
@@ -599,24 +599,25 @@ module Input =
 
     { new IInput with
         member _.Poll() =
-          // MonoGame's Mouse/Keyboard/Touch state queries report globally
+          // MonoGame's Mouse/Keyboard state queries report globally
           // (screen-level), not just for the focused window — matching XNA's
           // original behavior.  raylib (GLFW) only updates mouse position via
-          // a cursor callback that fires when the cursor is over the window.
-          // To match, check if the cursor is within the window client bounds
-          // before processing mouse/touch.  Keyboard still requires focus
-          // (IsActive) since GLFW keyboard events only fire for focused windows.
-          // Gamepad polling is always active (controllers are not window-scoped).
+          // a cursor callback that fires when the cursor is over the window,
+          // and keyboard events only fire for focused windows.
+          // To match:
+          //   - Mouse: gated by cursorOverWindow (cursor within client bounds)
+          //   - Keyboard + Touch: gated by IsActive (window focus)
+          //   - Gamepad: always active (controllers are not window-scoped)
           // Users who need global input reporting should poll IInput directly
           // from a custom subscription or service.
           let curr = Mouse.GetState()
           let bounds = game.Window.ClientBounds
 
           let cursorOverWindow =
-            curr.X >= 0
-            && curr.X < bounds.Width
-            && curr.Y >= 0
-            && curr.Y < bounds.Height
+            curr.X >= bounds.X
+            && curr.X < bounds.X + bounds.Width
+            && curr.Y >= bounds.Y
+            && curr.Y < bounds.Y + bounds.Height
 
           if game.IsActive then
             InputPolling.pollKeyboard
@@ -625,9 +626,12 @@ module Input =
               releasedKeysBuf
               keyboardDelta.Trigger
 
+            InputPolling.pollTouch touchDelta.Trigger
+          else
+            prevKeyboard <- Keyboard.GetState()
+
           if cursorOverWindow then
             InputPolling.pollMouse &prevMouse mouseDelta.Trigger
-            InputPolling.pollTouch touchDelta.Trigger
           else
             // Advance previous state so there is no stale delta jump when
             // the cursor re-enters the window.

--- a/src/Mibo.MonoGame/Input.fs
+++ b/src/Mibo.MonoGame/Input.fs
@@ -583,7 +583,7 @@ module private InputPolling =
 
 module Input =
 
-  let internal create(_game: Microsoft.Xna.Framework.Game) : IInput =
+  let internal create(game: Microsoft.Xna.Framework.Game) : IInput =
     let keyboardDelta = Event<KeyboardDelta>()
     let mouseDelta = Event<MouseDelta>()
     let touchDelta = Event<TouchDelta>()
@@ -599,14 +599,39 @@ module Input =
 
     { new IInput with
         member _.Poll() =
-          InputPolling.pollKeyboard
-            &prevKeyboard
-            pressedKeysBuf
-            releasedKeysBuf
-            keyboardDelta.Trigger
+          // MonoGame's Mouse/Keyboard/Touch state queries report globally
+          // (screen-level), not just for the focused window — matching XNA's
+          // original behavior.  raylib (GLFW) only updates mouse position via
+          // a cursor callback that fires when the cursor is over the window.
+          // To match, check if the cursor is within the window client bounds
+          // before processing mouse/touch.  Keyboard still requires focus
+          // (IsActive) since GLFW keyboard events only fire for focused windows.
+          // Gamepad polling is always active (controllers are not window-scoped).
+          // Users who need global input reporting should poll IInput directly
+          // from a custom subscription or service.
+          let curr = Mouse.GetState()
+          let bounds = game.Window.ClientBounds
 
-          InputPolling.pollMouse &prevMouse mouseDelta.Trigger
-          InputPolling.pollTouch touchDelta.Trigger
+          let cursorOverWindow =
+            curr.X >= 0
+            && curr.X < bounds.Width
+            && curr.Y >= 0
+            && curr.Y < bounds.Height
+
+          if game.IsActive then
+            InputPolling.pollKeyboard
+              &prevKeyboard
+              pressedKeysBuf
+              releasedKeysBuf
+              keyboardDelta.Trigger
+
+          if cursorOverWindow then
+            InputPolling.pollMouse &prevMouse mouseDelta.Trigger
+            InputPolling.pollTouch touchDelta.Trigger
+          else
+            // Advance previous state so there is no stale delta jump when
+            // the cursor re-enters the window.
+            prevMouse <- curr
 
           InputPolling.pollGamepad
             prevGamepad


### PR DESCRIPTION
## Summary

- MonoGame's `Mouse.GetState()` reports global cursor position (XNA behavior), causing phantom input when the game window is unfocused or the cursor is outside it
- Add cursor-in-bounds check (`game.Window.ClientBounds`) for mouse/touch polling to match raylib (GLFW) `CursorPosCallback` semantics
- Keyboard gated behind `game.IsActive` (GLFW key callbacks only fire for focused windows)
- Gamepad remains always-active (not window-scoped)

## Problem

When both a raylib and MonoGame client connect to the same server (e.g. PingPong sample), the MonoGame client sends `MovePaddle` messages for its assigned side even when its window is not focused — because `Mouse.GetState()` returns the global screen cursor position. This causes the raylib client's non-assigned paddle to track the raylib window's mouse movement, making it appear that the raylib client controls both paddles.

## Behavior parity

| Input | raylib (GLFW) | MonoGame (fixed) |
|-------|--------------|-----------------|
| Mouse/Touch | `CursorPosCallback` — only when cursor over window | `cursorOverWindow` bounds check |
| Keyboard | Key callbacks — only when focused | `game.IsActive` |
| Gamepad | Always (not window-scoped) | Always |

## Escape hatch

Users who need global/unfocused input reporting should poll `IInput` directly from a custom subscription or service.
