### PR TITLE
feat(vnext): full MonoGame 2D renderer + Raylib Next alignment with Core.Next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,6 @@
 - MonoGame 2D camera transform support (`BeginCamera` / `BeginCameraConfig`) using a `Matrix` built from `Camera2DState`.
 - MonoGame loose-file asset loading helpers: `IAssets.TextureFromFile` and `IAssets.SoundFromFile`.
 - Raylib Next `LightContext2D` implemented in `Mibo.Elmish.Next.Graphics2D.Lighting`, using Core.Next light data types and its own SDF shadow raymarching shader state.
-
-### Changed
-
-- Raylib Next `LightDraw` DSL now consumes Core.Next `Animation` and `Lighting` types, while legacy Raylib namespaces remain untouched.
-- MonoGame `AssetsService.createFromContext` now resolves the registered `GraphicsDevice` so loose-file texture loading works out of the box.
-
-### Added
-
 - Shared backend-neutral 2D lighting types in `Mibo.Core` (`Mibo.Elmish.Next.Graphics2D.Lighting`): `AmbientLight2D`, `DirectionalLight2D`, `PointLight2D`, `Occluder2D` using neutral `Base.Color` and `System.Numerics.Vector2`. These let both Raylib and MonoGame backends speak the same command language without each backend duplicating the data model.
 - Shared particle types in `Mibo.Core` (`Mibo.Elmish.Next.Graphics2D`): `Particle2D` render snapshot and `ParticleSimulation.fadeAndCompact` helper, using neutral `Rect`/`Color`. Backends expose their own native `Particle2D` structs and the DSL converts into this neutral payload.
 - `GridOccluders` helper moved to `Mibo.Core` (`Mibo.Elmish.Next.Graphics2D.Lighting`), operating only on `CellGrid2D` and `Vector2` so it is backend-agnostic.
@@ -30,7 +22,7 @@
 - Raylib backend `RenderBuffer2D`/`RenderBuffer3D` subclasses carrying registries as `member val` properties (assigned once at construction, never reassigned). The DSL reaches registries through the buffer instance — no global state, no partial application.
 - Raylib backend DSL: `Draw.*` (37 functions), `LightDraw.*` (9 functions), `ParticleDraw.*` — pipe-friendly, take native raylib types, resolve handles via `buffer.Textures.Register`/etc., construct Core `Command2D` directly. Same call-site signatures as the old `Draw.*`. The intermediate `Command2D.*` factory module is eliminated.
 - Prototype `Renderer2D<'Model>` in the raylib backend dispatching Core `Command2D` to raylib draw calls via handle resolution and neutral→raylib type conversion.
-- `SpriteState` and `TextState` in `Mibo.Elmish.Next.Graphics2D` — same fields as the old types (native `Texture2D`/`Font`/`Color`/`Rectangle`), using the new `RenderLayer` measure. Builder modules (`SpriteState.create`/`withLayer`/etc., `TextState.create`/`withFontSize`/etc.) unchanged.
+- `SpriteState` and `TextState` in `Mibo.Elmish.Next.Graphics2D` — same fields as the old types (native `Texture2D`/`Font`/`Color`/`Rectangle`), using the new `RenderLayer` measure. Builder modules (`SpriteState.create`/`withLayer`/etc., `TextState.create`/withFontSize`/etc.) unchanged.
 - `ParticleData` struct in Core (`Mibo.Elmish.Next.Graphics2D`) — neutral particle payload (`Vector2` position/size, `float32` rotation, `Rect` source, `Color`).
 - `Cmd.Msg of 'Msg` case in the `Cmd<'Msg>` struct DU: a zero-allocation alternative to `Single(Effect(...))` for `Cmd.ofMsg`. `Cmd.ofMsg` now returns `Msg msg` directly instead of wrapping the message in an `Effect` delegate. `Cmd.map` on a `Msg` stays allocation-free (`Msg(f msg)`). The runtime dispatches `Msg` directly without invoking a delegate. `batch` and `batch2` preserve the `Msg` case in their fast paths.
 - `Mibo.Core.Tests` project: 11 backend-agnostic test files extracted from `Mibo.Raylib.Tests` into a standalone project that references only `Mibo.Core` (no Raylib dependency). Covers Elmish Cmd/Sub, HeadlessLoop/GameTime, Layout, Layout3D, HexGrid, HexLayout, LayeredHex, HexGrid3D, HexLayout3D, LayeredHex3D, Spatial2D, and Spatial3D (503 tests).
@@ -47,6 +39,8 @@
 
 ### Changed
 
+- Raylib Next `LightDraw` DSL now consumes Core.Next `Animation` and `Lighting` types, while legacy Raylib namespaces remain untouched.
+- MonoGame `AssetsService.createFromContext` now resolves the registered `GraphicsDevice` so loose-file texture loading works out of the box.
 - **Breaking:** `Cmd<'Msg>` discriminated union has new `Msg of 'Msg` case between `Empty` and `Single`. Users with exhaustive pattern matches on `Cmd<'Msg>` must handle the new case (or add a wildcard match). `Cmd.ofMsg` now returns `Msg` instead of `Single(Effect(...))`. See `docs/migration-to-vnext.md` (Phase 3b) for the full migration guide.
 - **Breaking:** the input surface now uses backend-neutral codes instead of raylib's native enums. See `docs/migration-to-vnext.md` (Phase 1b) for the full migration guide. Highlights:
   - `InputMap.key` takes `KeyCode` instead of `Raylib_cs.KeyboardKey`. Bindings become portable across backends.
@@ -58,6 +52,11 @@
 
 ### Fixed
 
+- MonoGame 2D renderer geometry crashes flagged in PR #32 review: `roundedRect` vertex allocation was undersized (`4 + 4*seg` written as `12 + 4*seg`), `FillRectRounded` passed an overflowing `primitiveCount` and had no center vertex for fan triangulation, `RingOutline` read `verts.[j*6+2]` out of bounds at `j = segments`, and `CircleSector` ignored its `startAngle`/`endAngle` (drew a full circle). Added `roundedRectFill`, `sectorTriangles`, and `ringOutlines` helpers and corrected all call sites.
+- MonoGame `AssetsService` leaked loose-file assets: `TextureFromFile`/`SoundFromFile` (loaded via `FromStream`, not owned by `ContentManager`) were dropped from `Clear()`/`Dispose()` without being disposed. Both paths now dispose `fileTextures`/`fileSounds` before clearing.
+- MonoGame `lineTriangles` returned a pre-allocated array with uninitialized trailing elements when degenerate segments were skipped; it now slices to the actual written length.
+- MonoGame `RectRoundedOutline` closing edge connected the last perimeter vertex to index 1 instead of index 0; the edge loop now closes the perimeter correctly.
+- Raylib Next `LightContext2D.Dispose()` unconditionally called `UnloadShader` on both shaders, risking double-free when user-supplied (possibly shared) shaders were passed in. It now tracks ownership and only unloads internally-loaded shaders. The duplicated lit/normal-map uniform-location caching was also collapsed into a single `ShaderUniformLocations` record + shared `cacheLocationsFor` path (public API unchanged).
 - `Cmd.batch` silently dropped a single `NowAndDeferNextFrame([|eff|], [||])` passed as the only command. The single-effect fast path only matched `Msg`/`Single`/`Batch of 1`, so `NowAndDeferNextFrame` fell through to the wildcard and the effect was lost. Added the missing case and initialize the accumulator to `Empty` explicitly.
 - `HeadlessRunner.StepUntil` had an off-by-one: the predicate was tested _before_ each `Step`, so a predicate satisfied by the final permitted step returned `false`. Also, once `met`/`ShouldQuit` became true the loop kept spinning up to `maxFrames`. Rewritten as a `while` loop that steps first and exits immediately when the predicate (or `ShouldQuit`) becomes true. The documented "quit counts as met" behaviour is preserved.
 - MonoGame `InputPolling.pollMouse` now diffs `XButton1`/`XButton2` and emits `MouseButtonCode.Extra1`/`Extra2` on the `MouseDelta` stream, matching the raylib backend. Previously, the event-driven mouse subscription path never surfaced back/forward button presses (the poll-driven `InputMapper` path handled them via `isMouseButtonDownFor`), so the two input paths within MonoGame diverged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- MonoGame 2D renderer implements the full Core.Next `Command2D` surface, using `SpriteBatch` for textured work and `BasicEffect` vertex geometry for primitives.
+- MonoGame 2D camera transform support (`BeginCamera` / `BeginCameraConfig`) using a `Matrix` built from `Camera2DState`.
+- MonoGame loose-file asset loading helpers: `IAssets.TextureFromFile` and `IAssets.SoundFromFile`.
+- Raylib Next `LightContext2D` implemented in `Mibo.Elmish.Next.Graphics2D.Lighting`, using Core.Next light data types and its own SDF shadow raymarching shader state.
+
+### Changed
+
+- Raylib Next `LightDraw` DSL now consumes Core.Next `Animation` and `Lighting` types, while legacy Raylib namespaces remain untouched.
+- MonoGame `AssetsService.createFromContext` now resolves the registered `GraphicsDevice` so loose-file texture loading works out of the box.
+
+### Added
+
 - Shared backend-neutral 2D lighting types in `Mibo.Core` (`Mibo.Elmish.Next.Graphics2D.Lighting`): `AmbientLight2D`, `DirectionalLight2D`, `PointLight2D`, `Occluder2D` using neutral `Base.Color` and `System.Numerics.Vector2`. These let both Raylib and MonoGame backends speak the same command language without each backend duplicating the data model.
 - Shared particle types in `Mibo.Core` (`Mibo.Elmish.Next.Graphics2D`): `Particle2D` render snapshot and `ParticleSimulation.fadeAndCompact` helper, using neutral `Rect`/`Color`. Backends expose their own native `Particle2D` structs and the DSL converts into this neutral payload.
 - `GridOccluders` helper moved to `Mibo.Core` (`Mibo.Elmish.Next.Graphics2D.Lighting`), operating only on `CellGrid2D` and `Vector2` so it is backend-agnostic.

--- a/src/Mibo.Core/Next/Animation/Animation.fs
+++ b/src/Mibo.Core/Next/Animation/Animation.fs
@@ -268,6 +268,12 @@ module SpriteSheet =
   let static' (texture: int<Texture>) (sourceRect: Rect) : SpriteSheet =
     single texture [| sourceRect |] 1.0f false
 
+  /// <summary>Get the frame width of a sprite sheet in pixels.</summary>
+  let inline frameWidth(sheet: SpriteSheet) : int = sheet.FrameSize.X
+
+  /// <summary>Get the frame height of a sprite sheet in pixels.</summary>
+  let inline frameHeight(sheet: SpriteSheet) : int = sheet.FrameSize.Y
+
   /// <summary>
   /// Try to get the index for an animation name.
   /// </summary>

--- a/src/Mibo.MonoGame/Assets.fs
+++ b/src/Mibo.MonoGame/Assets.fs
@@ -169,6 +169,15 @@ type AssetsService
         value
 
     member _.Clear() =
+      // Loose-file assets are loaded via Texture2D.FromStream / SoundEffect.FromStream
+      // and are NOT owned by ContentManager, so they must be disposed here
+      // (the XNB-loaded caches below are left for ContentManager.Unload).
+      for kvp in fileTextures do
+        kvp.Value.Dispose()
+
+      for kvp in fileSounds do
+        kvp.Value.Dispose()
+
       typedCache.Clear()
       textures.Clear()
       fileTextures.Clear()
@@ -182,10 +191,18 @@ type AssetsService
       // Dispose user-created IDisposable assets. ContentManager owns the
       // XNB-loaded textures/fonts/etc., so the typed-loader caches below are
       // left for ContentManager.Unload — only the generic typedCache is ours.
+      // Loose-file assets (FromStream) are unmanaged by ContentManager too,
+      // so they are disposed here as well.
       for kvp in typedCache do
         match kvp.Value with
         | :? IDisposable as d -> d.Dispose()
         | _ -> ()
+
+      for kvp in fileTextures do
+        kvp.Value.Dispose()
+
+      for kvp in fileSounds do
+        kvp.Value.Dispose()
 
       typedCache.Clear()
       textures.Clear()

--- a/src/Mibo.MonoGame/Assets.fs
+++ b/src/Mibo.MonoGame/Assets.fs
@@ -2,6 +2,7 @@ namespace Mibo.Elmish
 
 open System
 open System.Collections.Generic
+open System.IO
 open Microsoft.Xna.Framework
 open Microsoft.Xna.Framework.Audio
 open Microsoft.Xna.Framework.Content
@@ -43,11 +44,17 @@ type IAssets =
   /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Graphics.Texture2D"/> from the content pipeline.</summary>
   abstract Texture: path: string -> Texture2D
 
+  /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Graphics.Texture2D"/> from a loose file.</summary>
+  abstract TextureFromFile: path: string -> Texture2D
+
   /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Graphics.SpriteFont"/> from the content pipeline.</summary>
   abstract Font: path: string -> SpriteFont
 
   /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Audio.SoundEffect"/> from the content pipeline.</summary>
   abstract Sound: path: string -> SoundEffect
+
+  /// <summary>Loads and caches a <see cref="T:Microsoft.Xna.Framework.Audio.SoundEffect"/> from a loose file.</summary>
+  abstract SoundFromFile: path: string -> SoundEffect
 
   /// <summary>Loads and caches a 3D <see cref="T:Microsoft.Xna.Framework.Graphics.Model"/> from the content pipeline.</summary>
   abstract Model: path: string -> Model
@@ -60,18 +67,24 @@ type IAssets =
 /// <c>ContentManager</c>, with dictionary-based caches per asset type.
 /// </summary>
 /// <param name="content">The MonoGame content manager used to load XNB assets.</param>
-type AssetsService(content: ContentManager) =
+type AssetsService
+  (content: ContentManager, graphicsDevice: GraphicsDevice voption) =
 
   let typedCache = Dictionary<string, obj>()
 
   let textures = Dictionary<string, Texture2D>()
+  let fileTextures = Dictionary<string, Texture2D>()
   let fonts = Dictionary<string, SpriteFont>()
   let sounds = Dictionary<string, SoundEffect>()
+  let fileSounds = Dictionary<string, SoundEffect>()
   let models = Dictionary<string, Model>()
   let effects = Dictionary<string, Effect>()
 
   /// <summary>The <c>ContentManager</c> this service loads from.</summary>
   member _.Content = content
+
+  /// <summary>The graphics device used for loose-file texture loading.</summary>
+  member _.GraphicsDevice = graphicsDevice
 
   interface IAssets with
     member _.Texture(path) =
@@ -81,6 +94,20 @@ type AssetsService(content: ContentManager) =
         let tex = content.Load<Texture2D>(path)
         textures.Add(path, tex)
         tex
+
+    member _.TextureFromFile(path) =
+      match fileTextures.TryGetValue(path) with
+      | true, tex -> tex
+      | _ ->
+        match graphicsDevice with
+        | ValueNone ->
+          invalidOp
+            $"TextureFromFile requires a GraphicsDevice. Use AssetsService.createFromContext or provide a device."
+        | ValueSome gd ->
+          use stream = File.OpenRead(path)
+          let tex = Texture2D.FromStream(gd, stream)
+          fileTextures.Add(path, tex)
+          tex
 
     member _.Font(path) =
       match fonts.TryGetValue(path) with
@@ -96,6 +123,15 @@ type AssetsService(content: ContentManager) =
       | _ ->
         let sound = content.Load<SoundEffect>(path)
         sounds.Add(path, sound)
+        sound
+
+    member _.SoundFromFile(path) =
+      match fileSounds.TryGetValue(path) with
+      | true, sound -> sound
+      | _ ->
+        use stream = File.OpenRead(path)
+        let sound = SoundEffect.FromStream(stream)
+        fileSounds.Add(path, sound)
         sound
 
     member _.Model(path) =
@@ -135,8 +171,10 @@ type AssetsService(content: ContentManager) =
     member _.Clear() =
       typedCache.Clear()
       textures.Clear()
+      fileTextures.Clear()
       fonts.Clear()
       sounds.Clear()
+      fileSounds.Clear()
       models.Clear()
       effects.Clear()
 
@@ -151,21 +189,33 @@ type AssetsService(content: ContentManager) =
 
       typedCache.Clear()
       textures.Clear()
+      fileTextures.Clear()
       fonts.Clear()
       sounds.Clear()
+      fileSounds.Clear()
       models.Clear()
       effects.Clear()
 
 /// Factory for <see cref="T:Mibo.Elmish.IAssets"/> implementations.
 module AssetsService =
-  /// <summary>Creates an asset service over the given <c>ContentManager</c>.</summary>
+  /// <summary>Creates an asset service over the given <c>ContentManager</c>.
+  /// Loose-file texture loading requires a GraphicsDevice; use createFromContext for full support.
+  /// </summary>
   let create(content: ContentManager) : IAssets =
-    new AssetsService(content) :> IAssets
+    new AssetsService(content, ValueNone) :> IAssets
+
+  /// <summary>Creates an asset service with an explicit graphics device for loose-file texture loading.</summary>
+  let createWithDevice
+    (content: ContentManager)
+    (graphicsDevice: GraphicsDevice)
+    : IAssets =
+    new AssetsService(content, ValueSome graphicsDevice) :> IAssets
 
   /// <summary>
   /// Creates an asset service from a <see cref="T:Mibo.Elmish.GameContext"/>,
-  /// resolving the registered <c>ContentManager</c> (registered by the host).
+  /// resolving the registered <c>ContentManager</c> and <c>GraphicsDevice</c>.
   /// </summary>
   let createFromContext(ctx: GameContext) : IAssets =
     let content = MonoGameGameContext.getContentManager ctx
-    create content
+    let gd = MonoGameGameContext.getGraphicsDevice ctx
+    new AssetsService(content, ValueSome gd) :> IAssets

--- a/src/Mibo.MonoGame/Next/Conversions.fs
+++ b/src/Mibo.MonoGame/Next/Conversions.fs
@@ -54,7 +54,21 @@ module Convert =
 
   let inline toSysVec2(v: Vector2) : System.Numerics.Vector2 = v.ToNumerics()
 
-// Matrix interop deferred to camera phase.
-// MonoGame provides: Matrix.op_Implicit(m: Matrix4x4) and m.ToNumerics()
-// let inline toMgMatrix(m: System.Numerics.Matrix4x4) : Matrix = Matrix.op_Implicit m
-// let inline toSysMatrix(m: Matrix) : System.Numerics.Matrix4x4 = m.ToNumerics()
+  let inline toMgMatrix(m: System.Numerics.Matrix4x4) : Matrix =
+    Matrix.op_Implicit m
+
+  let inline toSysMatrix(m: Matrix) : System.Numerics.Matrix4x4 = m.ToNumerics()
+
+  let cameraTransform(camera: Graphics2D.Camera2DState) : Matrix =
+    // MonoGame / XNA 2D camera convention:
+    // Translate world by -Target, scale by Zoom, rotate by -Rotation,
+    // then translate by Offset (viewport center).
+    let t = toMgVec2 camera.Target
+    let o = toMgVec2 camera.Offset
+
+    Matrix.CreateTranslation(-t.X, -t.Y, 0.0f)
+    * Matrix.CreateRotationZ(float32 -camera.Rotation)
+    * Matrix.CreateScale(camera.Zoom, camera.Zoom, 1.0f)
+    * Matrix.CreateTranslation(o.X, o.Y, 0.0f)
+
+  let inline mgRect(x, y, w, h) = Rectangle(x, y, w, h)

--- a/src/Mibo.MonoGame/Next/Graphics2D/ParticleDraw.fs
+++ b/src/Mibo.MonoGame/Next/Graphics2D/ParticleDraw.fs
@@ -4,12 +4,13 @@ open Microsoft.Xna.Framework
 open Microsoft.Xna.Framework.Graphics
 open Mibo.Elmish.Next
 open Mibo.Elmish.Next.Graphics2D.Base
+open Mibo.Elmish.Next.Graphics2D.Lighting
 
 module ParticleDraw =
 
   let particles
     (texture: Texture2D)
-    (data: Particle2D[])
+    (data: Graphics2D.Particle2D[])
     (count: int)
     (layer: int<RenderLayer>)
     (buffer: RenderBuffer2D)

--- a/src/Mibo.MonoGame/Next/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.MonoGame/Next/Graphics2D/Renderer2D.fs
@@ -34,6 +34,36 @@ module private Geometry =
 
     arr
 
+  // Circle sector (pie slice) as an explicit TriangleList: center vertex plus
+  // one triangle per angular step over [startAngle, endAngle]. This honors the
+  // sector angles that `circleTriangles` ignores.
+  let sectorTriangles
+    (center: System.Numerics.Vector2)
+    (radius: float32)
+    (startAngle: float32)
+    (endAngle: float32)
+    (c: Color)
+    (segments: int)
+    =
+    let centerV = v3 center.X center.Y
+    let steps = max 1 segments
+    let arr = Array.zeroCreate<VertexPositionColor>(steps * 3)
+    let span = endAngle - startAngle
+    let step = span / float32 steps
+
+    for i = 0 to steps - 1 do
+      let a0 = startAngle + float32 i * step
+      let a1 = startAngle + float32(i + 1) * step
+      let x0 = center.X + cos a0 * radius
+      let y0 = center.Y + sin a0 * radius
+      let x1 = center.X + cos a1 * radius
+      let y1 = center.Y + sin a1 * radius
+      arr.[i * 3] <- VertexPositionColor(centerV, c)
+      arr.[i * 3 + 1] <- VertexPositionColor(v3 x0 y0, c)
+      arr.[i * 3 + 2] <- VertexPositionColor(v3 x1 y1, c)
+
+    arr
+
   let ringTriangles
     (center: System.Numerics.Vector2)
     (innerR: float32)
@@ -94,6 +124,45 @@ module private Geometry =
         )
 
     arr
+
+  // Inner and outer outline polylines for a ring, as separate closed
+  // LineStrip arrays (steps + 1 points each: one per step plus the closing
+  // point that repeats the first). Reads directly from `ringTriangles`'s
+  // stable vertex layout (outer at +0, inner at +2 per quad) without
+  // re-tessellating.
+  let ringOutlines
+    (center: System.Numerics.Vector2)
+    (innerR: float32)
+    (outerR: float32)
+    (startAngle: float32)
+    (endAngle: float32)
+    (segments: int)
+    (c: Color)
+    =
+    let steps = max 1 segments
+    let span = endAngle - startAngle
+    let step = span / float32 steps
+    let inner = Array.zeroCreate<VertexPositionColor>(steps + 1)
+    let outer = Array.zeroCreate<VertexPositionColor>(steps + 1)
+
+    for i = 0 to steps do
+      let a = startAngle + float32 i * step
+      let ca = cos a
+      let sa = sin a
+
+      inner.[i] <-
+        VertexPositionColor(
+          v3 (center.X + ca * innerR) (center.Y + sa * innerR),
+          c
+        )
+
+      outer.[i] <-
+        VertexPositionColor(
+          v3 (center.X + ca * outerR) (center.Y + sa * outerR),
+          c
+        )
+
+    inner, outer
 
   let ellipseTriangles
     (centerX: int)
@@ -175,7 +244,8 @@ module private Geometry =
     let h = rect.Height
     let r = MathF.Min(roundness * 0.5f, MathF.Min(w * 0.5f, h * 0.5f))
     let cornerSegs = max 2 segmentsPerCorner
-    let totalVerts = 4 + cornerSegs * 4
+    // 8 explicit edge midpoints + 4 corners * (cornerSegs + 1) arc points.
+    let totalVerts = 12 + cornerSegs * 4
     let arr = Array.zeroCreate<VertexPositionColor>(totalVerts)
     let mutable idx = 0
 
@@ -203,6 +273,33 @@ module private Geometry =
     add(0.0f, r)
     corner(r, r, MathF.PI)
     arr
+
+  // Fan-triangulate the outline produced by `roundedRect` into an explicit
+  // TriangleList: one center vertex, then (verts.Length - 1) triangles formed
+  // by the center + each perimeter edge. Matches the `circleTriangles`/
+  // `polyTriangles` center+pair idiom so callers can use a plain
+  // `TriangleList` with `primitiveCount = verts.Length / 3`.
+  let roundedRectFill
+    (rect: Mibo.Elmish.Next.Graphics2D.Rect)
+    (roundness: float32)
+    (c: Color)
+    (segmentsPerCorner: int)
+    =
+    let outline = roundedRect rect roundness c segmentsPerCorner
+    let centerV = v3 (rect.X + rect.Width * 0.5f) (rect.Y + rect.Height * 0.5f)
+    let center = VertexPositionColor(centerV, c)
+    // Close the perimeter loop by repeating the first point at the end.
+    let triangles = Array.zeroCreate<VertexPositionColor>(outline.Length * 3)
+    let mutable idx = 0
+
+    for i = 0 to outline.Length - 1 do
+      let next = outline.[(i + 1) % outline.Length]
+      triangles.[idx] <- center
+      triangles.[idx + 1] <- outline.[i]
+      triangles.[idx + 2] <- next
+      idx <- idx + 3
+
+    triangles
 
   let lineTriangles
     (points: System.Numerics.Vector2[])
@@ -236,7 +333,8 @@ module private Geometry =
           arr.[idx + 5] <- VertexPositionColor(v3 p2.X p2.Y, c)
           idx <- idx + 6
 
-      arr
+      // Slice off the uninitialized tail left by skipped degenerate segments.
+      if idx = arr.Length then arr else arr.[.. idx - 1]
 
   let triangleFanAsTriangles
     (center: System.Numerics.Vector2)
@@ -711,7 +809,7 @@ type Renderer2D<'Model>
           flush()
 
           let verts =
-            Geometry.roundedRect
+            Geometry.roundedRectFill
               rect
               roundness
               (Convert.toMgColor color)
@@ -721,7 +819,7 @@ type Renderer2D<'Model>
             device
             verts
             PrimitiveType.TriangleList
-            (verts.Length - 2)
+            (verts.Length / 3)
         | Command2D.RectRoundedOutline(rect,
                                        roundness,
                                        segments,
@@ -738,14 +836,14 @@ type Renderer2D<'Model>
               (Convert.toMgColor color)
               segments
 
-          let edges =
-            Array.zeroCreate<VertexPositionColor>((verts.Length - 1) * 2)
+          let edges = Array.zeroCreate<VertexPositionColor>(verts.Length * 2)
 
-          for j = 1 to verts.Length - 1 do
-            edges.[(j - 1) * 2] <- verts.[j]
-            edges.[(j - 1) * 2 + 1] <- verts.[j % (verts.Length - 1) + 1]
+          // Closed perimeter: edge i connects verts.[i] to verts.[(i+1) % len].
+          for j = 0 to verts.Length - 1 do
+            edges.[j * 2] <- verts.[j]
+            edges.[j * 2 + 1] <- verts.[(j + 1) % verts.Length]
 
-          drawPrimitives device edges PrimitiveType.LineList (edges.Length / 2)
+          drawPrimitives device edges PrimitiveType.LineList (verts.Length)
         | Command2D.RectGradientV(x, y, w, h, top, bottom, _) ->
           flush()
 
@@ -817,9 +915,11 @@ type Renderer2D<'Model>
           flush()
 
           let verts =
-            Geometry.circleTriangles
+            Geometry.sectorTriangles
               center
               radius
+              startAngle
+              endAngle
               (Convert.toMgColor color)
               (max 1 segments)
 
@@ -899,26 +999,20 @@ type Renderer2D<'Model>
                                 _) ->
           flush()
           let color = Convert.toMgColor color
+          let steps = max 1 segments
 
-          let verts =
-            Geometry.ringTriangles
+          let inner, outer =
+            Geometry.ringOutlines
               center
               innerR
               outerR
               startAngle
               endAngle
-              (max 1 segments)
+              steps
               color
 
-          let inner = Array.zeroCreate<VertexPositionColor>(segments + 1)
-          let outer = Array.zeroCreate<VertexPositionColor>(segments + 1)
-
-          for j = 0 to segments do
-            inner.[j] <- verts.[j * 6 + 2]
-            outer.[j] <- verts.[j * 6]
-
-          drawPrimitives device inner PrimitiveType.LineStrip segments
-          drawPrimitives device outer PrimitiveType.LineStrip segments
+          drawPrimitives device inner PrimitiveType.LineStrip steps
+          drawPrimitives device outer PrimitiveType.LineStrip steps
         | Command2D.FillEllipse(centerX, centerY, radiusH, radiusV, color, _) ->
           flush()
 

--- a/src/Mibo.MonoGame/Next/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.MonoGame/Next/Graphics2D/Renderer2D.fs
@@ -7,6 +7,429 @@ open Mibo.Elmish
 open Mibo.Elmish.Next
 open Mibo.Elmish.Next.Graphics2D
 
+module private Geometry =
+
+  let inline v3 (x: float32) (y: float32) = Vector3(x, y, 0.0f)
+
+  let circleTriangles
+    (center: System.Numerics.Vector2)
+    (radius: float32)
+    (c: Color)
+    (segments: int)
+    =
+    let centerV = v3 center.X center.Y
+    let arr = Array.zeroCreate<VertexPositionColor>(segments * 3)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments - 1 do
+      let a0 = float32 i * step
+      let a1 = float32(i + 1) * step
+      let x0 = center.X + cos a0 * radius
+      let y0 = center.Y + sin a0 * radius
+      let x1 = center.X + cos a1 * radius
+      let y1 = center.Y + sin a1 * radius
+      arr.[i * 3] <- VertexPositionColor(centerV, c)
+      arr.[i * 3 + 1] <- VertexPositionColor(v3 x0 y0, c)
+      arr.[i * 3 + 2] <- VertexPositionColor(v3 x1 y1, c)
+
+    arr
+
+  let ringTriangles
+    (center: System.Numerics.Vector2)
+    (innerR: float32)
+    (outerR: float32)
+    (startAngle: float32)
+    (endAngle: float32)
+    (segments: int)
+    (c: Color)
+    =
+    let span = endAngle - startAngle
+    let steps = max 1 segments
+    let step = span / float32 steps
+    let arr = Array.zeroCreate<VertexPositionColor>(steps * 6)
+
+    for i = 0 to steps - 1 do
+      let a0 = startAngle + float32 i * step
+      let a1 = startAngle + float32(i + 1) * step
+      let c0 = cos a0
+      let s0 = sin a0
+      let c1 = cos a1
+      let s1 = sin a1
+      let idx = i * 6
+
+      arr.[idx] <-
+        VertexPositionColor(
+          v3 (center.X + c0 * outerR) (center.Y + s0 * outerR),
+          c
+        )
+
+      arr.[idx + 1] <-
+        VertexPositionColor(
+          v3 (center.X + c1 * outerR) (center.Y + s1 * outerR),
+          c
+        )
+
+      arr.[idx + 2] <-
+        VertexPositionColor(
+          v3 (center.X + c0 * innerR) (center.Y + s0 * innerR),
+          c
+        )
+
+      arr.[idx + 3] <-
+        VertexPositionColor(
+          v3 (center.X + c1 * outerR) (center.Y + s1 * outerR),
+          c
+        )
+
+      arr.[idx + 4] <-
+        VertexPositionColor(
+          v3 (center.X + c1 * innerR) (center.Y + s1 * innerR),
+          c
+        )
+
+      arr.[idx + 5] <-
+        VertexPositionColor(
+          v3 (center.X + c0 * innerR) (center.Y + s0 * innerR),
+          c
+        )
+
+    arr
+
+  let ellipseTriangles
+    (centerX: int)
+    (centerY: int)
+    (radiusH: float32)
+    (radiusV: float32)
+    (c: Color)
+    (segments: int)
+    =
+    let cx = float32 centerX
+    let cy = float32 centerY
+    let centerV = v3 cx cy
+    let arr = Array.zeroCreate<VertexPositionColor>(segments * 3)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments - 1 do
+      let a0 = float32 i * step
+      let a1 = float32(i + 1) * step
+      let x0 = cx + cos a0 * radiusH
+      let y0 = cy + sin a0 * radiusV
+      let x1 = cx + cos a1 * radiusH
+      let y1 = cy + sin a1 * radiusV
+      arr.[i * 3] <- VertexPositionColor(centerV, c)
+      arr.[i * 3 + 1] <- VertexPositionColor(v3 x0 y0, c)
+      arr.[i * 3 + 2] <- VertexPositionColor(v3 x1 y1, c)
+
+    arr
+
+  let polyTriangles
+    (center: System.Numerics.Vector2)
+    (sides: int)
+    (radius: float32)
+    (rotation: float32)
+    (c: Color)
+    =
+    let segments = max 3 sides
+    let arr = Array.zeroCreate<VertexPositionColor>(segments * 3)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments - 1 do
+      let a0 = float32 i * step + rotation
+      let a1 = float32(i + 1) * step + rotation
+      let x0 = center.X + cos a0 * radius
+      let y0 = center.Y + sin a0 * radius
+      let x1 = center.X + cos a1 * radius
+      let y1 = center.Y + sin a1 * radius
+      arr.[i * 3] <- VertexPositionColor(v3 center.X center.Y, c)
+      arr.[i * 3 + 1] <- VertexPositionColor(v3 x0 y0, c)
+      arr.[i * 3 + 2] <- VertexPositionColor(v3 x1 y1, c)
+
+    arr
+
+  let bezierPoints
+    (start: System.Numerics.Vector2)
+    (control: System.Numerics.Vector2)
+    (finish: System.Numerics.Vector2)
+    (segments: int)
+    =
+    let arr = Array.zeroCreate<System.Numerics.Vector2>(segments + 1)
+    let inv = 1.0f / float32 segments
+
+    for i = 0 to segments do
+      let t = float32 i * inv
+      let u = 1.0f - t
+      let p = u * u * start + 2.0f * u * t * control + t * t * finish
+      arr.[i] <- p
+
+    arr
+
+  let roundedRect
+    (rect: Mibo.Elmish.Next.Graphics2D.Rect)
+    (roundness: float32)
+    (c: Color)
+    (segmentsPerCorner: int)
+    =
+    let x = rect.X
+    let y = rect.Y
+    let w = rect.Width
+    let h = rect.Height
+    let r = MathF.Min(roundness * 0.5f, MathF.Min(w * 0.5f, h * 0.5f))
+    let cornerSegs = max 2 segmentsPerCorner
+    let totalVerts = 4 + cornerSegs * 4
+    let arr = Array.zeroCreate<VertexPositionColor>(totalVerts)
+    let mutable idx = 0
+
+    let inline add(x', y') =
+      arr.[idx] <- VertexPositionColor(v3 (x + x') (y + y'), c)
+      idx <- idx + 1
+
+    let corner(cx, cy, startAngle) =
+      let step = MathF.PI / 2.0f / float32 cornerSegs
+
+      for i = 0 to cornerSegs do
+        let a = startAngle + float32 i * step
+        add(cx + cos a * r, cy + sin a * r)
+
+    add(r, 0.0f)
+    add(w - r, 0.0f)
+    corner(w - r, r, -MathF.PI / 2.0f)
+    add(w, r)
+    add(w, h - r)
+    corner(w - r, h - r, 0.0f)
+    add(w - r, h)
+    add(r, h)
+    corner(r, h - r, MathF.PI / 2.0f)
+    add(0.0f, h - r)
+    add(0.0f, r)
+    corner(r, r, MathF.PI)
+    arr
+
+  let lineTriangles
+    (points: System.Numerics.Vector2[])
+    (thickness: float32)
+    (c: Color)
+    =
+    if points.Length < 2 then
+      Array.empty
+    else
+      let halfThick = thickness * 0.5f
+      let arr = Array.zeroCreate<VertexPositionColor>((points.Length - 1) * 6)
+      let mutable idx = 0
+
+      for i = 0 to points.Length - 2 do
+        let a = points.[i]
+        let b = points.[i + 1]
+        let d = b - a
+        let len = d.Length()
+
+        if len > 0.0001f then
+          let perp = System.Numerics.Vector2(-d.Y, d.X) / len * halfThick
+          let p0 = a + perp
+          let p1 = b + perp
+          let p2 = a - perp
+          let p3 = b - perp
+          arr.[idx] <- VertexPositionColor(v3 p0.X p0.Y, c)
+          arr.[idx + 1] <- VertexPositionColor(v3 p1.X p1.Y, c)
+          arr.[idx + 2] <- VertexPositionColor(v3 p2.X p2.Y, c)
+          arr.[idx + 3] <- VertexPositionColor(v3 p1.X p1.Y, c)
+          arr.[idx + 4] <- VertexPositionColor(v3 p3.X p3.Y, c)
+          arr.[idx + 5] <- VertexPositionColor(v3 p2.X p2.Y, c)
+          idx <- idx + 6
+
+      arr
+
+  let triangleFanAsTriangles
+    (center: System.Numerics.Vector2)
+    (points: System.Numerics.Vector2[])
+    (c: Color)
+    =
+    if points.Length < 2 then
+      Array.empty
+    else
+      let centerV = VertexPositionColor(v3 center.X center.Y, c)
+      let arr = Array.zeroCreate<VertexPositionColor>((points.Length - 1) * 3)
+
+      for i = 0 to points.Length - 2 do
+        arr.[i * 3] <- centerV
+        arr.[i * 3 + 1] <- VertexPositionColor(v3 points.[i].X points.[i].Y, c)
+
+        arr.[i * 3 + 2] <-
+          VertexPositionColor(v3 points.[i + 1].X points.[i + 1].Y, c)
+
+      arr
+
+  let triangleStripAsTriangles (points: System.Numerics.Vector2[]) (c: Color) =
+    if points.Length < 3 then
+      Array.empty
+    else
+      let arr = Array.zeroCreate<VertexPositionColor>((points.Length - 2) * 3)
+
+      for i = 0 to points.Length - 3 do
+        arr.[i * 3] <- VertexPositionColor(v3 points.[i].X points.[i].Y, c)
+
+        arr.[i * 3 + 1] <-
+          VertexPositionColor(v3 points.[i + 1].X points.[i + 1].Y, c)
+
+        arr.[i * 3 + 2] <-
+          VertexPositionColor(v3 points.[i + 2].X points.[i + 2].Y, c)
+
+      arr
+
+  let quad
+    (rect: Mibo.Elmish.Next.Graphics2D.Rect)
+    (tl: Mibo.Elmish.Next.Graphics2D.Base.Color)
+    (bl: Mibo.Elmish.Next.Graphics2D.Base.Color)
+    (tr: Mibo.Elmish.Next.Graphics2D.Base.Color)
+    (br: Mibo.Elmish.Next.Graphics2D.Base.Color)
+    =
+    let x = rect.X
+    let y = rect.Y
+    let w = rect.Width
+    let h = rect.Height
+    let c0 = Convert.toMgColor tl
+    let c1 = Convert.toMgColor tr
+    let c2 = Convert.toMgColor bl
+    let c3 = Convert.toMgColor br
+    let arr = Array.zeroCreate<VertexPositionColor>(6)
+    arr.[0] <- VertexPositionColor(v3 x y, c0)
+    arr.[1] <- VertexPositionColor(v3 (x + w) y, c1)
+    arr.[2] <- VertexPositionColor(v3 x (y + h), c2)
+    arr.[3] <- arr.[1]
+    arr.[4] <- VertexPositionColor(v3 (x + w) (y + h), c3)
+    arr.[5] <- arr.[2]
+    arr
+
+  let gradientCircle
+    (centerX: int)
+    (centerY: int)
+    (radius: float32)
+    (inner: Color)
+    (outer: Color)
+    (segments: int)
+    =
+    let cx = float32 centerX
+    let cy = float32 centerY
+    let arr = Array.zeroCreate<VertexPositionColor>(segments * 3)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments - 1 do
+      let a0 = float32 i * step
+      let a1 = float32(i + 1) * step
+      let x0 = cx + cos a0 * radius
+      let y0 = cy + sin a0 * radius
+      let x1 = cx + cos a1 * radius
+      let y1 = cy + sin a1 * radius
+      arr.[i * 3] <- VertexPositionColor(v3 cx cy, inner)
+      arr.[i * 3 + 1] <- VertexPositionColor(v3 x0 y0, outer)
+      arr.[i * 3 + 2] <- VertexPositionColor(v3 x1 y1, outer)
+
+    arr
+
+  let lineAsQuad
+    (start: System.Numerics.Vector2)
+    (finish: System.Numerics.Vector2)
+    (thickness: float32)
+    (c: Color)
+    =
+    let d = finish - start
+    let len = d.Length()
+
+    if len <= 0.0001f then
+      Array.empty
+    else
+      let perp = System.Numerics.Vector2(-d.Y, d.X) / len * (thickness * 0.5f)
+      let p0 = start + perp
+      let p1 = finish + perp
+      let p2 = start - perp
+      let p3 = finish - perp
+
+      [|
+        VertexPositionColor(v3 p0.X p0.Y, c)
+        VertexPositionColor(v3 p1.X p1.Y, c)
+        VertexPositionColor(v3 p2.X p2.Y, c)
+        VertexPositionColor(v3 p1.X p1.Y, c)
+        VertexPositionColor(v3 p3.X p3.Y, c)
+        VertexPositionColor(v3 p2.X p2.Y, c)
+      |]
+
+  let circleOutline
+    (center: System.Numerics.Vector2)
+    (radius: float32)
+    (c: Color)
+    (segments: int)
+    =
+    let arr = Array.zeroCreate<VertexPositionColor>(segments + 1)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments do
+      let a = float32 i * step
+      let x = center.X + cos a * radius
+      let y = center.Y + sin a * radius
+      arr.[i] <- VertexPositionColor(v3 x y, c)
+
+    arr
+
+  let sectorOutline
+    (center: System.Numerics.Vector2)
+    (radius: float32)
+    (startAngle: float32)
+    (endAngle: float32)
+    (segments: int)
+    (c: Color)
+    =
+    let span = endAngle - startAngle
+    let steps = max 1 segments
+    let step = span / float32 steps
+    let arr = Array.zeroCreate<VertexPositionColor>(steps + 1)
+
+    for i = 0 to steps do
+      let a = startAngle + float32 i * step
+      let x = center.X + cos a * radius
+      let y = center.Y + sin a * radius
+      arr.[i] <- VertexPositionColor(v3 x y, c)
+
+    arr
+
+  let ellipseOutline
+    (centerX: int)
+    (centerY: int)
+    (radiusH: float32)
+    (radiusV: float32)
+    (c: Color)
+    (segments: int)
+    =
+    let cx = float32 centerX
+    let cy = float32 centerY
+    let arr = Array.zeroCreate<VertexPositionColor>(segments + 1)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments do
+      let a = float32 i * step
+      let x = cx + cos a * radiusH
+      let y = cy + sin a * radiusV
+      arr.[i] <- VertexPositionColor(v3 x y, c)
+
+    arr
+
+  let polyOutline
+    (center: System.Numerics.Vector2)
+    (sides: int)
+    (radius: float32)
+    (rotation: float32)
+    (c: Color)
+    =
+    let segments = max 3 sides
+    let arr = Array.zeroCreate<VertexPositionColor>(segments + 1)
+    let step = MathF.PI * 2.0f / float32 segments
+
+    for i = 0 to segments do
+      let a = float32 i * step + rotation
+      let x = center.X + cos a * radius
+      let y = center.Y + sin a * radius
+      arr.[i] <- VertexPositionColor(v3 x y, c)
+
+    arr
+
 type Renderer2D<'Model>
   (
     view: GameContext -> 'Model -> RenderBuffer2D -> unit,
@@ -15,6 +438,7 @@ type Renderer2D<'Model>
 
   let buffer = new RenderBuffer2D()
   let mutable spriteBatch: SpriteBatch voption = ValueNone
+  let mutable basicEffect: BasicEffect voption = ValueNone
   let mutable pixel: Texture2D voption = ValueNone
   let mutable circleTex: Texture2D voption = ValueNone
   let mutable rasterDefault: RasterizerState voption = ValueNone
@@ -25,6 +449,7 @@ type Renderer2D<'Model>
   let mutable activeBlend: BlendState = BlendState.AlphaBlend
   let mutable activeTransform = Matrix.Identity
   let mutable scissorRect = Rectangle.Empty
+  let mutable lineWidth = 1.0f
 
   let initResources(ctx: GameContext) =
     match spriteBatch with
@@ -32,6 +457,19 @@ type Renderer2D<'Model>
     | ValueNone ->
       let gd = MonoGameGameContext.getGraphicsDevice ctx
       spriteBatch <- ValueSome(new SpriteBatch(gd))
+      basicEffect <- ValueSome(new BasicEffect(gd))
+      basicEffect.Value.VertexColorEnabled <- true
+
+      basicEffect.Value.Projection <-
+        Matrix.CreateOrthographicOffCenter(
+          0.0f,
+          float32 gd.PresentationParameters.BackBufferWidth,
+          float32 gd.PresentationParameters.BackBufferHeight,
+          0.0f,
+          0.0f,
+          1.0f
+        )
+
       let px = new Texture2D(gd, 1, 1)
       px.SetData([| Color.White |])
       pixel <- ValueSome px
@@ -47,7 +485,7 @@ type Renderer2D<'Model>
           let dy = float32 y - center + 0.5f
 
           if dx * dx + dy * dy <= radius * radius then
-            data[y * size + x] <- Color.White
+            data.[y * size + x] <- Color.White
 
       ct.SetData(data)
       circleTex <- ValueSome ct
@@ -62,30 +500,6 @@ type Renderer2D<'Model>
       rasterScissor.Value
     else
       rasterDefault.Value
-
-  let drawLine
-    (sb: SpriteBatch)
-    (start: System.Numerics.Vector2)
-    (finish: System.Numerics.Vector2)
-    (thickness: int)
-    (color: Color)
-    =
-    let diff = finish - start
-    let len = diff.Length()
-
-    if len > 0.5f then
-      let angle = atan2 diff.Y diff.X
-
-      sb.Draw(
-        getPixel(),
-        Rectangle(int start.X, int start.Y, int len, max 1 thickness),
-        Nullable(Rectangle(0, 0, 1, 1)),
-        color,
-        angle,
-        Vector2.Zero,
-        SpriteEffects.None,
-        0.0f
-      )
 
   let flush() =
     match spriteBatch with
@@ -132,15 +546,40 @@ type Renderer2D<'Model>
       activeBlend <- blend
       activeTransform <- transform
 
+  let drawPrimitives
+    (device: GraphicsDevice)
+    (vertices: VertexPositionColor[])
+    (primitiveType: PrimitiveType)
+    (primitiveCount: int)
+    =
+    match basicEffect with
+    | ValueNone -> ()
+    | ValueSome fx ->
+      fx.World <- activeTransform
+
+      fx.Projection <-
+        Matrix.CreateOrthographicOffCenter(
+          0.0f,
+          float32 device.PresentationParameters.BackBufferWidth,
+          float32 device.PresentationParameters.BackBufferHeight,
+          0.0f,
+          0.0f,
+          1.0f
+        )
+
+      for pass in fx.CurrentTechnique.Passes do
+        pass.Apply()
+        device.DrawUserPrimitives(primitiveType, vertices, 0, primitiveCount)
+
   let handleLitSprite
     (
       hCtx: int<LightContext>,
       hTex: int<Texture>,
-      dest: Rect,
-      source: Rect,
+      dest: Mibo.Elmish.Next.Graphics2D.Rect,
+      source: Mibo.Elmish.Next.Graphics2D.Rect,
       origin: System.Numerics.Vector2,
       rotation: float32,
-      color: Color,
+      color: Mibo.Elmish.Next.Graphics2D.Base.Color,
       hNorm: int<Texture> voption
     ) =
     let lightCtx = buffer.LightContexts.Resolve hCtx
@@ -157,7 +596,7 @@ type Renderer2D<'Model>
 
     match hNorm with
     | ValueSome hNm ->
-      effect.Parameters["NormalMap"].SetValue(buffer.Textures.Resolve hNm)
+      effect.Parameters.["NormalMap"].SetValue(buffer.Textures.Resolve hNm)
     | ValueNone -> ()
 
     flush()
@@ -170,7 +609,7 @@ type Renderer2D<'Model>
         tex,
         Convert.toMgRect dest,
         Nullable(Convert.toMgRect source),
-        color,
+        Convert.toMgColor color,
         rotation,
         Convert.toMgVec2 origin,
         SpriteEffects.None,
@@ -203,8 +642,7 @@ type Renderer2D<'Model>
       | ValueNone -> ()
 
       for i = 0 to buffer.Count - 1 do
-        match buffer[i] with
-        // ── Sprite & Text ──────────────────────────────────────
+        match buffer.[i] with
         | Command2D.Sprite(hTex, dest, source, origin, rotation, color, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
 
@@ -218,7 +656,6 @@ type Renderer2D<'Model>
             SpriteEffects.None,
             0.0f
           )
-
         | Command2D.Text(hFont, text, position, _fontSize, _spacing, color, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
 
@@ -228,8 +665,6 @@ type Renderer2D<'Model>
             Convert.toMgVec2 position,
             Convert.toMgColor color
           )
-
-        // ── Rectangles ─────────────────────────────────────────
         | Command2D.FillRect(rect, color, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
 
@@ -239,7 +674,6 @@ type Renderer2D<'Model>
             Nullable(Rectangle(0, 0, 1, 1)),
             Convert.toMgColor color
           )
-
         | Command2D.RectOutline(rect, thickness, color, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
           let r = Convert.toMgRect rect
@@ -273,49 +707,83 @@ type Renderer2D<'Model>
             Nullable(Rectangle(0, 0, 1, 1)),
             c
           )
+        | Command2D.FillRectRounded(rect, roundness, segments, color, _) ->
+          flush()
 
-        | Command2D.FillRectRounded _ -> ()
-        | Command2D.RectRoundedOutline _ -> ()
+          let verts =
+            Geometry.roundedRect
+              rect
+              roundness
+              (Convert.toMgColor color)
+              segments
 
+          drawPrimitives
+            device
+            verts
+            PrimitiveType.TriangleList
+            (verts.Length - 2)
+        | Command2D.RectRoundedOutline(rect,
+                                       roundness,
+                                       segments,
+                                       _thickness,
+                                       color,
+                                       _) ->
+          flush()
+          device.RasterizerState <- getRasterizer()
+
+          let verts =
+            Geometry.roundedRect
+              rect
+              roundness
+              (Convert.toMgColor color)
+              segments
+
+          let edges =
+            Array.zeroCreate<VertexPositionColor>((verts.Length - 1) * 2)
+
+          for j = 1 to verts.Length - 1 do
+            edges.[(j - 1) * 2] <- verts.[j]
+            edges.[(j - 1) * 2 + 1] <- verts.[j % (verts.Length - 1) + 1]
+
+          drawPrimitives device edges PrimitiveType.LineList (edges.Length / 2)
         | Command2D.RectGradientV(x, y, w, h, top, bottom, _) ->
-          ensureActive(ValueNone, activeBlend, activeTransform)
-          let halfH = h / 2
+          flush()
 
-          sb.Draw(
-            getPixel(),
-            Rectangle(x, y, w, halfH),
-            Nullable(Rectangle(0, 0, 1, 1)),
-            Convert.toMgColor top
-          )
+          let rect = {
+            X = float32 x
+            Y = float32 y
+            Width = float32 w
+            Height = float32 h
+          }
 
-          sb.Draw(
-            getPixel(),
-            Rectangle(x, y + halfH, w, h - halfH),
-            Nullable(Rectangle(0, 0, 1, 1)),
-            Convert.toMgColor bottom
-          )
+          let verts =
+            Geometry.quad rect top { top with A = bottom.A } bottom {
+              bottom with
+                  A = top.A
+            }
 
+          drawPrimitives device verts PrimitiveType.TriangleList 2
         | Command2D.RectGradientH(x, y, w, h, left, right, _) ->
-          ensureActive(ValueNone, activeBlend, activeTransform)
-          let halfW = w / 2
+          flush()
 
-          sb.Draw(
-            getPixel(),
-            Rectangle(x, y, halfW, h),
-            Nullable(Rectangle(0, 0, 1, 1)),
-            Convert.toMgColor left
-          )
+          let rect = {
+            X = float32 x
+            Y = float32 y
+            Width = float32 w
+            Height = float32 h
+          }
 
-          sb.Draw(
-            getPixel(),
-            Rectangle(x + halfW, y, w - halfW, h),
-            Nullable(Rectangle(0, 0, 1, 1)),
-            Convert.toMgColor right
-          )
+          let verts =
+            Geometry.quad rect left right { left with A = right.A } {
+              right with
+                  A = left.A
+            }
 
-        | Command2D.RectGradient _ -> ()
-
-        // ── Circles & Ellipses ─────────────────────────────────
+          drawPrimitives device verts PrimitiveType.TriangleList 2
+        | Command2D.RectGradient(rect, tl, bl, tr, br, _) ->
+          flush()
+          let verts = Geometry.quad rect tl bl tr br
+          drawPrimitives device verts PrimitiveType.TriangleList 2
         | Command2D.FillCircle(center, radius, color, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
           let d = int(radius * 2.0f)
@@ -331,27 +799,168 @@ type Renderer2D<'Model>
             Nullable(Rectangle(0, 0, 64, 64)),
             Convert.toMgColor color
           )
-
         | Command2D.CircleOutline(center, radius, color, _) ->
+          flush()
+          let steps = max 16 (int(radius * 0.5f))
+
+          let verts =
+            Geometry.circleOutline center radius (Convert.toMgColor color) steps
+
+          drawPrimitives device verts PrimitiveType.LineStrip steps
+        | Command2D.CircleSector(center,
+                                 radius,
+                                 startAngle,
+                                 endAngle,
+                                 segments,
+                                 color,
+                                 _) ->
+          flush()
+
+          let verts =
+            Geometry.circleTriangles
+              center
+              radius
+              (Convert.toMgColor color)
+              (max 1 segments)
+
+          drawPrimitives
+            device
+            verts
+            PrimitiveType.TriangleList
+            (verts.Length / 3)
+        | Command2D.CircleSectorOutline(center,
+                                        radius,
+                                        startAngle,
+                                        endAngle,
+                                        segments,
+                                        color,
+                                        _) ->
+          flush()
+
+          let verts =
+            Geometry.sectorOutline
+              center
+              radius
+              startAngle
+              endAngle
+              (max 1 segments)
+              (Convert.toMgColor color)
+
+          drawPrimitives device verts PrimitiveType.LineStrip (verts.Length - 1)
+        | Command2D.CircleGradient(centerX, centerY, radius, inner, outer, _) ->
+          flush()
+
+          let verts =
+            Geometry.gradientCircle
+              centerX
+              centerY
+              radius
+              (Convert.toMgColor inner)
+              (Convert.toMgColor outer)
+              32
+
+          drawPrimitives
+            device
+            verts
+            PrimitiveType.TriangleList
+            (verts.Length / 3)
+        | Command2D.FillRing(center,
+                             innerR,
+                             outerR,
+                             startAngle,
+                             endAngle,
+                             segments,
+                             color,
+                             _) ->
+          flush()
+
+          let verts =
+            Geometry.ringTriangles
+              center
+              innerR
+              outerR
+              startAngle
+              endAngle
+              (max 1 segments)
+              (Convert.toMgColor color)
+
+          drawPrimitives
+            device
+            verts
+            PrimitiveType.TriangleList
+            (verts.Length / 3)
+        | Command2D.RingOutline(center,
+                                innerR,
+                                outerR,
+                                startAngle,
+                                endAngle,
+                                segments,
+                                color,
+                                _) ->
+          flush()
+          let color = Convert.toMgColor color
+
+          let verts =
+            Geometry.ringTriangles
+              center
+              innerR
+              outerR
+              startAngle
+              endAngle
+              (max 1 segments)
+              color
+
+          let inner = Array.zeroCreate<VertexPositionColor>(segments + 1)
+          let outer = Array.zeroCreate<VertexPositionColor>(segments + 1)
+
+          for j = 0 to segments do
+            inner.[j] <- verts.[j * 6 + 2]
+            outer.[j] <- verts.[j * 6]
+
+          drawPrimitives device inner PrimitiveType.LineStrip segments
+          drawPrimitives device outer PrimitiveType.LineStrip segments
+        | Command2D.FillEllipse(centerX, centerY, radiusH, radiusV, color, _) ->
+          flush()
+
+          let verts =
+            Geometry.ellipseTriangles
+              centerX
+              centerY
+              radiusH
+              radiusV
+              (Convert.toMgColor color)
+              32
+
+          drawPrimitives
+            device
+            verts
+            PrimitiveType.TriangleList
+            (verts.Length / 3)
+        | Command2D.EllipseOutline(centerX, centerY, radiusH, radiusV, color, _) ->
+          flush()
+
+          let verts =
+            Geometry.ellipseOutline
+              centerX
+              centerY
+              radiusH
+              radiusV
+              (Convert.toMgColor color)
+              64
+
+          drawPrimitives device verts PrimitiveType.LineStrip (verts.Length - 1)
+        | Command2D.Line(start, finish, color, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
           let c = Convert.toMgColor color
-          let steps = max 16 (int(radius * 0.5f))
-          let stepAngle = MathF.PI * 2.0f / float32 steps
+          let diff = Convert.toMgVec2 finish - Convert.toMgVec2 start
+          let len = diff.Length()
 
-          for s = 0 to steps - 1 do
-            let a1 = float32 s * stepAngle
-            let a2 = float32(s + 1) * stepAngle
-            let x1 = center.X + cos a1 * radius
-            let y1 = center.Y + sin a1 * radius
-            let x2 = center.X + cos a2 * radius
-            let y2 = center.Y + sin a2 * radius
-            let diff = Vector2(x2 - x1, y2 - y1)
-            let len = diff.Length()
+          if len > 0.5f then
             let angle = atan2 diff.Y diff.X
 
             sb.Draw(
               getPixel(),
-              Rectangle(int x1, int y1, int len, 1),
+              Rectangle(int start.X, int start.Y, int len, 1),
               Nullable(Rectangle(0, 0, 1, 1)),
               c,
               angle,
@@ -359,43 +968,128 @@ type Renderer2D<'Model>
               SpriteEffects.None,
               0.0f
             )
-
-        | Command2D.CircleSector _ -> ()
-        | Command2D.CircleSectorOutline _ -> ()
-        | Command2D.CircleGradient _ -> ()
-        | Command2D.FillRing _ -> ()
-        | Command2D.RingOutline _ -> ()
-        | Command2D.FillEllipse _ -> ()
-        | Command2D.EllipseOutline _ -> ()
-
-        // ── Lines & Curves ─────────────────────────────────────
-        | Command2D.Line(start, finish, color, _) ->
-          ensureActive(ValueNone, activeBlend, activeTransform)
-          drawLine sb start finish 1 (Convert.toMgColor color)
-
         | Command2D.LineThick(start, finish, thickness, color, _) ->
-          ensureActive(ValueNone, activeBlend, activeTransform)
-          drawLine sb start finish (int thickness) (Convert.toMgColor color)
+          flush()
 
+          let verts =
+            Geometry.lineAsQuad
+              start
+              finish
+              (max lineWidth thickness)
+              (Convert.toMgColor color)
+
+          if verts.Length > 0 then
+            drawPrimitives
+              device
+              verts
+              PrimitiveType.TriangleList
+              (verts.Length / 3)
         | Command2D.LineStrip(points, color, _) ->
-          ensureActive(ValueNone, activeBlend, activeTransform)
+          flush()
+
+          let verts =
+            Geometry.lineTriangles
+              points
+              (max 1.0f lineWidth)
+              (Convert.toMgColor color)
+
+          if verts.Length > 0 then
+            drawPrimitives
+              device
+              verts
+              PrimitiveType.TriangleList
+              (verts.Length / 3)
+        | Command2D.Bezier(start, control, finish, thickness, color, _) ->
+          flush()
+          let pts = Geometry.bezierPoints start control finish 24
+
+          let verts =
+            Geometry.lineTriangles
+              pts
+              (max lineWidth thickness)
+              (Convert.toMgColor color)
+
+          if verts.Length > 0 then
+            drawPrimitives
+              device
+              verts
+              PrimitiveType.TriangleList
+              (verts.Length / 3)
+        | Command2D.Triangle(v1, v2, v3, color, _) ->
+          flush()
           let c = Convert.toMgColor color
 
-          for j = 0 to points.Length - 2 do
-            drawLine sb points[j] points[j + 1] 1 c
+          let verts = [|
+            VertexPositionColor(Geometry.v3 v1.X v1.Y, c)
+            VertexPositionColor(Geometry.v3 v2.X v2.Y, c)
+            VertexPositionColor(Geometry.v3 v3.X v3.Y, c)
+          |]
 
-        | Command2D.Bezier _ -> ()
-        | Command2D.Triangle _ -> ()
-        | Command2D.TriangleFan _ -> ()
-        | Command2D.TriangleStrip _ -> ()
-        | Command2D.FillPoly _ -> ()
-        | Command2D.PolyOutline _ -> ()
+          drawPrimitives device verts PrimitiveType.TriangleList 1
+        | Command2D.TriangleFan(points, color, _) ->
+          flush()
 
-        // ── Camera (stub — matrix interop deferred) ────────────
-        | Command2D.BeginCamera _ -> flush()
+          if points.Length >= 3 then
+            let c = Convert.toMgColor color
+            let verts = Geometry.triangleFanAsTriangles points.[0] points c
 
+            drawPrimitives
+              device
+              verts
+              PrimitiveType.TriangleList
+              (verts.Length / 3)
+        | Command2D.TriangleStrip(points, color, _) ->
+          flush()
+
+          if points.Length >= 3 then
+            let verts =
+              Geometry.triangleStripAsTriangles points (Convert.toMgColor color)
+
+            drawPrimitives
+              device
+              verts
+              PrimitiveType.TriangleList
+              (verts.Length / 3)
+        | Command2D.FillPoly(center, sides, radius, rotation, color, _) ->
+          flush()
+
+          let verts =
+            Geometry.polyTriangles
+              center
+              sides
+              radius
+              rotation
+              (Convert.toMgColor color)
+
+          drawPrimitives
+            device
+            verts
+            PrimitiveType.TriangleList
+            (verts.Length / 3)
+        | Command2D.PolyOutline(center,
+                                sides,
+                                radius,
+                                rotation,
+                                _thickness,
+                                color,
+                                _) ->
+          flush()
+
+          let verts =
+            Geometry.polyOutline
+              center
+              sides
+              radius
+              rotation
+              (Convert.toMgColor color)
+
+          drawPrimitives device verts PrimitiveType.LineStrip (verts.Length - 1)
+        | Command2D.BeginCamera(cam, _) ->
+          flush()
+          activeTransform <- Convert.cameraTransform cam
         | Command2D.BeginCameraConfig(config, _) ->
           flush()
+          activeTransform <- Convert.cameraTransform config.Camera
 
           match config.Viewport with
           | ValueSome vp ->
@@ -406,60 +1100,42 @@ type Renderer2D<'Model>
           match config.ClearColor with
           | ValueSome c -> device.Clear(Convert.toMgColor c)
           | ValueNone -> ()
-
         | Command2D.EndCamera _ ->
           flush()
           activeTransform <- Matrix.Identity
           device.Viewport <- Viewport(0, 0, ctx.WindowWidth, ctx.WindowHeight)
-
-        // ── Shader & Target ────────────────────────────────────
         | Command2D.BeginShader(hEffect, _) ->
           flush()
           activeEffect <- ValueSome(buffer.Shaders.Resolve hEffect)
-
         | Command2D.EndShader _ ->
           flush()
           activeEffect <- ValueNone
-
         | Command2D.BeginTarget(hTarget, _) ->
           flush()
           device.SetRenderTarget(buffer.RenderTargets.Resolve hTarget)
-
         | Command2D.EndTarget _ ->
           flush()
           device.SetRenderTarget(null)
-
-        // ── Render State ───────────────────────────────────────
         | Command2D.SetBlend(mode, _) ->
           flush()
           activeBlend <- Convert.toMgBlendState mode
-
         | Command2D.SetScissor(x, y, w, h, _) ->
           flush()
           scissorRect <- Rectangle(x, y, w, h)
-
         | Command2D.ClearScissor _ ->
           flush()
           scissorRect <- Rectangle.Empty
-
-        | Command2D.SetLineWidth _ -> ()
-
+        | Command2D.SetLineWidth(width, _) -> lineWidth <- width
         | Command2D.SetViewport(x, y, w, h, _) ->
           flush()
           device.Viewport <- Viewport(x, y, w, h)
-
-        // ── Escape Hatch ───────────────────────────────────────
         | Command2D.DrawImmediate(action, _) ->
           flush()
           action()
-
         | Command2D.Clear(color, _) ->
           flush()
           device.Clear(Convert.toMgColor color)
-
-        // ── Lighting ───────────────────────────────────────────
         | Command2D.NoopLight _ -> ()
-
         | Command2D.LitSprite(hCtx,
                               hTex,
                               dest,
@@ -476,25 +1152,20 @@ type Renderer2D<'Model>
             source,
             origin,
             rotation,
-            Convert.toMgColor color,
+            color,
             hNorm
           )
-
         | Command2D.EndLighting(hCtx, _) -> handleEndLighting hCtx
-
         | Command2D.EnableShadows(hCtx, _) ->
           buffer.LightContexts.Resolve(hCtx).UniformsDirty <- true
-
         | Command2D.DisableShadows(hCtx, _) ->
           buffer.LightContexts.Resolve(hCtx).UniformsDirty <- true
-
-        // ── Particles ──────────────────────────────────────────
         | Command2D.Particle(hTex, pData, count, _) ->
           ensureActive(ValueNone, activeBlend, activeTransform)
           let tex = buffer.Textures.Resolve hTex
 
           for j = 0 to count - 1 do
-            let p = pData[j]
+            let p = pData.[j]
             let halfW = p.Size.X * 0.5f
             let halfH = p.Size.Y * 0.5f
 
@@ -520,6 +1191,7 @@ type Renderer2D<'Model>
   interface IDisposable with
     member _.Dispose() =
       spriteBatch |> ValueOption.iter(fun sb -> sb.Dispose())
+      basicEffect |> ValueOption.iter(fun fx -> fx.Dispose())
       pixel |> ValueOption.iter(fun px -> px.Dispose())
       circleTex |> ValueOption.iter(fun ct -> ct.Dispose())
       rasterDefault |> ValueOption.iter(fun r -> r.Dispose())

--- a/src/Mibo.MonoGame/Runtime.fs
+++ b/src/Mibo.MonoGame/Runtime.fs
@@ -98,7 +98,7 @@ type MiboGame<'Model, 'Msg>(program: Program<'Model, 'Msg>) as this =
 
     // Register the MonoGame asset service (always, mirroring RaylibGame which
     // registers IAssets unconditionally). Built over the host's ContentManager.
-    let assets = AssetsService.create this.Content
+    let assets = AssetsService.createFromContext ctx
     GameContext.register<IAssets> assets ctx
 
     if program.HasInput then

--- a/src/Mibo.Raylib/Mibo.Raylib.fsproj
+++ b/src/Mibo.Raylib/Mibo.Raylib.fsproj
@@ -45,6 +45,7 @@
     <Compile Include="Graphics3D/Pipelines/ForwardPbrPipeline.fs" />
     <Compile Include="Layout3D/Renderer3D.fs" />
     <Compile Include="Next/Conversions.fs" />
+    <Compile Include="Next/Graphics2D/Lighting/LightContext.fs" />
     <Compile Include="Next/ResourceRegistry.fs" />
     <Compile Include="Next/Graphics2D/State.fs" />
     <Compile Include="Next/Graphics2D/RenderBuffer2D.fs" />

--- a/src/Mibo.Raylib/Mibo.Raylib.fsproj
+++ b/src/Mibo.Raylib/Mibo.Raylib.fsproj
@@ -54,6 +54,7 @@
     <Compile Include="Next/Graphics2D/LightDraw.fs" />
     <Compile Include="Next/Graphics2D/ParticleDraw.fs" />
     <Compile Include="Next/Graphics2D/Renderer2D.fs" />
+    <Compile Include="Next/Animation.fs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Mibo.Core\Mibo.Core.fsproj" />

--- a/src/Mibo.Raylib/Next/Animation.fs
+++ b/src/Mibo.Raylib/Next/Animation.fs
@@ -1,0 +1,82 @@
+namespace Mibo.Elmish.Next.Animation
+
+open System.Numerics
+open Raylib_cs
+open Mibo.Elmish.Next
+open Mibo.Elmish.Next.Graphics2D
+
+/// <summary>
+/// Raylib-specific sprite-sheet shims that keep user asset loading unchanged.
+/// </summary>
+/// <remarks>
+/// The Core.Next <see cref="T:Mibo.Elmish.Next.Animation.SpriteSheet"/> stores
+/// opaque <c>int&lt;Texture&gt;</c> handles. These helpers register the native
+/// <c>Texture2D</c> with the current render buffer and return a ready-to-use
+/// neutral sheet, so sample/game code can keep calling <c>assets.Texture</c>
+/// and pass the resulting <c>Texture2D</c> through.
+/// </remarks>
+[<RequireQualifiedAccess>]
+module SpriteSheet =
+
+  /// <summary>
+  /// Create a sprite sheet from explicit frame rectangles, registering the
+  /// native texture with the render buffer.
+  /// </summary>
+  let fromTexture2D
+    (buffer: RenderBuffer2D)
+    (texture: Texture2D)
+    (origin: Vector2)
+    (animations: struct (string * Animation)[])
+    : SpriteSheet =
+    let h = buffer.Textures.Register texture
+    SpriteSheet.fromFrames h origin animations
+
+  /// <summary>
+  /// Create a sprite sheet from a uniform grid layout, registering the
+  /// native texture with the render buffer.
+  /// </summary>
+  let fromGridTexture2D
+    (buffer: RenderBuffer2D)
+    (texture: Texture2D)
+    (frameWidth: int)
+    (frameHeight: int)
+    (columns: int)
+    (animations: GridAnimationDef[])
+    : SpriteSheet =
+    let h = buffer.Textures.Register texture
+    SpriteSheet.fromGrid h frameWidth frameHeight columns animations
+
+  /// <summary>
+  /// Create a single-animation sprite sheet, registering the native texture.
+  /// </summary>
+  let singleTexture2D
+    (buffer: RenderBuffer2D)
+    (texture: Texture2D)
+    (frames: Rect[])
+    (fps: float32)
+    (loop: bool)
+    : SpriteSheet =
+    let h = buffer.Textures.Register texture
+    SpriteSheet.single h frames fps loop
+
+  /// <summary>
+  /// Create a static single-frame sprite sheet, registering the native texture.
+  /// </summary>
+  let staticTexture2D
+    (buffer: RenderBuffer2D)
+    (texture: Texture2D)
+    (sourceRect: Rect)
+    : SpriteSheet =
+    let h = buffer.Textures.Register texture
+    SpriteSheet.static' h sourceRect
+
+  /// <summary>
+  /// Add a normal map to a sprite sheet, registering the native texture.
+  /// </summary>
+  let withTexture2DNormalMap
+    (buffer: RenderBuffer2D)
+    (normalMap: Texture2D)
+    (sheet: SpriteSheet)
+    : SpriteSheet =
+    let h = buffer.Textures.Register normalMap
+    SpriteSheet.withNormalMap h sheet

--- a/src/Mibo.Raylib/Next/Graphics2D/LightDraw.fs
+++ b/src/Mibo.Raylib/Next/Graphics2D/LightDraw.fs
@@ -5,16 +5,14 @@ open Mibo.Elmish.Next.Graphics2D.Base
 open System.Numerics
 open Raylib_cs
 open Mibo.Elmish.Next
-open Mibo.Animation
+open Mibo.Elmish.Next.Animation
+open Mibo.Elmish.Next.Graphics2D.Lighting
 
 module LightDraw =
 
   let inline setAmbient
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
-    (
-      layer: int<RenderLayer>,
-      ambient: Mibo.Elmish.Graphics2D.Lighting.AmbientLight2D
-    )
+    (lightCtx: LightContext2D)
+    (layer: int<RenderLayer>, ambient: AmbientLight2D)
     (buffer: RenderBuffer2D)
     =
     lightCtx.Ambient <- ambient.Color
@@ -22,9 +20,9 @@ module LightDraw =
     buffer
 
   let inline addPointLight
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
-    (light: Mibo.Elmish.Graphics2D.Lighting.PointLight2D)
+    (light: PointLight2D)
     (buffer: RenderBuffer2D)
     =
     lightCtx.PointLights.Add light
@@ -32,9 +30,9 @@ module LightDraw =
     buffer
 
   let inline addDirectionalLight
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
-    (light: Mibo.Elmish.Graphics2D.Lighting.DirectionalLight2D)
+    (light: DirectionalLight2D)
     (buffer: RenderBuffer2D)
     =
     lightCtx.DirLights.Add light
@@ -42,9 +40,9 @@ module LightDraw =
     buffer
 
   let inline addOccluder
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
-    (occluder: Mibo.Elmish.Graphics2D.Lighting.Occluder2D)
+    (occluder: Occluder2D)
     (buffer: RenderBuffer2D)
     =
     lightCtx.Occluders.Add occluder
@@ -52,7 +50,7 @@ module LightDraw =
     buffer
 
   let inline litSprite
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (sprite: SpriteState)
     (buffer: RenderBuffer2D)
     =
@@ -81,7 +79,7 @@ module LightDraw =
     buffer
 
   let inline litAnimatedSprite
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
     (dest: Rectangle)
     (animSprite: AnimatedSprite)
@@ -89,34 +87,29 @@ module LightDraw =
     =
     let src = AnimatedSprite.currentSource animSprite
 
-    let src =
-      if animSprite.FlipX then
-        Rectangle(src.X, src.Y, -src.Width, src.Height)
-      else
-        src
-
-    let src =
-      if animSprite.FlipY then
-        Rectangle(src.X, src.Y, src.Width, -src.Height)
-      else
-        src
+    let src = {
+      src with
+          Width = if animSprite.FlipX then -src.Width else src.Width
+          Height = if animSprite.FlipY then -src.Height else src.Height
+    }
 
     litSprite
       lightCtx
       ({
-        Texture = animSprite.Sheet.Texture
+        Texture = buffer.Textures.Resolve animSprite.Sheet.Texture
         Dest = dest
-        Source = src
+        Source = Convert.toRaylibRect src
         Origin = animSprite.Sheet.Origin
         Rotation = animSprite.Rotation
-        Color = animSprite.Color
+        Color = Convert.toRaylibColor animSprite.Color
         Layer = layer
-        NormalMap = animSprite.Sheet.NormalMap
+        NormalMap =
+          animSprite.Sheet.NormalMap |> ValueOption.map buffer.Textures.Resolve
       })
       buffer
 
   let inline endLighting
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
     (buffer: RenderBuffer2D)
     =
@@ -127,7 +120,7 @@ module LightDraw =
     buffer
 
   let inline enableShadows
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
     (buffer: RenderBuffer2D)
     =
@@ -140,7 +133,7 @@ module LightDraw =
     buffer
 
   let inline disableShadows
-    (lightCtx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D)
+    (lightCtx: LightContext2D)
     (layer: int<RenderLayer>)
     (buffer: RenderBuffer2D)
     =

--- a/src/Mibo.Raylib/Next/Graphics2D/Lighting/LightContext.fs
+++ b/src/Mibo.Raylib/Next/Graphics2D/Lighting/LightContext.fs
@@ -102,11 +102,10 @@ type LightContext2D
     NormalMap = -1
   }
 
-  let litLocs = mkLocations()
-  let nmLocs = mkLocations()
+  let mutable litLocs = mkLocations()
+  let mutable nmLocs = mkLocations()
 
-  let cacheLocationsFor (shader: Shader) (locs: ShaderUniformLocations) =
-    let mutable locs = locs
+  let cacheLocationsFor (shader: Shader) (locs: byref<ShaderUniformLocations>) =
 
     if not locs.Cached then
       locs.AmbientColor <- Raylib.GetShaderLocation(shader, "ambientColor")
@@ -155,8 +154,8 @@ type LightContext2D
       locs.NormalMap <- Raylib.GetShaderLocation(shader, "normalMap")
       locs.Cached <- true
 
-  let cacheLocations() = cacheLocationsFor litShader litLocs
-  let cacheNmLocations() = cacheLocationsFor nmShader nmLocs
+  let cacheLocations() = cacheLocationsFor litShader &litLocs
+  let cacheNmLocations() = cacheLocationsFor nmShader &nmLocs
 
   // ------------------------------------------------------------------
   // Upload helpers (DisableRuntimeMarshalling safe)

--- a/src/Mibo.Raylib/Next/Graphics2D/Lighting/LightContext.fs
+++ b/src/Mibo.Raylib/Next/Graphics2D/Lighting/LightContext.fs
@@ -1,0 +1,421 @@
+#nowarn "9"
+
+namespace Mibo.Elmish.Next.Graphics2D.Lighting
+
+open System
+open System.Collections.Generic
+open System.Numerics
+open FSharp.NativeInterop
+open Raylib_cs
+open Mibo.Elmish.Next
+open Mibo.Elmish.Next.Graphics2D.Base
+
+/// <summary>
+/// Raylib Next light context. Accepts the Core.Next backend-neutral light types
+/// and uploads them to the built-in SDF shadow raymarching shader.
+/// </summary>
+type LightContext2D
+  (
+    ?litShader: Shader,
+    ?litNormalMapShader: Shader,
+    ?maxDirLights: int,
+    ?maxPointLights: int,
+    ?maxOccluders: int,
+    ?softness: float32,
+    ?maxShadowDistance: float32
+  ) =
+
+  let maxDir = defaultArg maxDirLights 4
+  let maxPoint = defaultArg maxPointLights 16
+  let maxOccluderCount = defaultArg maxOccluders 128
+
+  let litShader =
+    defaultArg litShader (Mibo.Elmish.Graphics2D.Lighting.LitShader.load())
+
+  let nmShader =
+    defaultArg
+      litNormalMapShader
+      (Mibo.Elmish.Graphics2D.Lighting.LitShader.loadNormalMap())
+
+  let shadowSoftness = defaultArg softness 0.05f
+  let shadowMaxDist = defaultArg maxShadowDistance 5000.0f
+
+  let dirLights = ResizeArray<DirectionalLight2D>()
+  let pointLights = ResizeArray<PointLight2D>()
+  let occluders = ResizeArray<Occluder2D>()
+
+  let mutable ambientColor: Color = { R = 0uy; G = 0uy; B = 0uy; A = 255uy }
+
+  let colorToVec3(c: Color) =
+    Vector3(float32 c.R / 255.0f, float32 c.G / 255.0f, float32 c.B / 255.0f)
+
+  // ------------------------------------------------------------------
+  // Uniform locations
+  // ------------------------------------------------------------------
+
+  let mutable locsCached = false
+
+  let mutable locAmbientColor = -1
+  let mutable locDirCount = -1
+  let locDirDirs = Array.zeroCreate<int> maxDir
+  let locDirColors = Array.zeroCreate<int> maxDir
+  let locDirIntensities = Array.zeroCreate<int> maxDir
+  let locDirShadowIdx = Array.zeroCreate<int> maxDir
+
+  let mutable locPointCount = -1
+  let locPointPos = Array.zeroCreate<int> maxPoint
+  let locPointColors = Array.zeroCreate<int> maxPoint
+  let locPointIntensities = Array.zeroCreate<int> maxPoint
+  let locPointRadii = Array.zeroCreate<int> maxPoint
+  let locPointFalloffs = Array.zeroCreate<int> maxPoint
+  let locPointShadowIdx = Array.zeroCreate<int> maxPoint
+
+  let locOccluders = Array.zeroCreate<int> maxOccluderCount
+  let mutable locOccluderCount = -1
+  let mutable locSoftness = -1
+  let mutable locMaxDist = -1
+  let mutable locNormalMap = -1
+
+  let mutable nmLocsCached = false
+
+  let mutable nmLocAmbientColor = -1
+  let mutable nmLocDirCount = -1
+  let nmLocDirDirs = Array.zeroCreate<int> maxDir
+  let nmLocDirColors = Array.zeroCreate<int> maxDir
+  let nmLocDirIntensities = Array.zeroCreate<int> maxDir
+  let nmLocDirShadowIdx = Array.zeroCreate<int> maxDir
+
+  let mutable nmLocPointCount = -1
+  let nmLocPointPos = Array.zeroCreate<int> maxPoint
+  let nmLocPointColors = Array.zeroCreate<int> maxPoint
+  let nmLocPointIntensities = Array.zeroCreate<int> maxPoint
+  let nmLocPointRadii = Array.zeroCreate<int> maxPoint
+  let nmLocPointFalloffs = Array.zeroCreate<int> maxPoint
+  let nmLocPointShadowIdx = Array.zeroCreate<int> maxPoint
+
+  let nmLocOccluders = Array.zeroCreate<int> maxOccluderCount
+  let mutable nmLocOccluderCount = -1
+  let mutable nmLocSoftness = -1
+  let mutable nmLocMaxDist = -1
+  let mutable nmLocNormalMap = -1
+
+  let cacheLocations() =
+    if not locsCached then
+      locAmbientColor <- Raylib.GetShaderLocation(litShader, "ambientColor")
+      locDirCount <- Raylib.GetShaderLocation(litShader, "dirLightCount")
+
+      for i = 0 to maxDir - 1 do
+        locDirDirs[i] <-
+          Raylib.GetShaderLocation(litShader, $"dirLightDirs[{i}]")
+
+        locDirColors[i] <-
+          Raylib.GetShaderLocation(litShader, $"dirLightColors[{i}]")
+
+        locDirIntensities[i] <-
+          Raylib.GetShaderLocation(litShader, $"dirLightIntensities[{i}]")
+
+        locDirShadowIdx[i] <-
+          Raylib.GetShaderLocation(litShader, $"dirLightShadowIdx[{i}]")
+
+      locPointCount <- Raylib.GetShaderLocation(litShader, "pointLightCount")
+
+      for i = 0 to maxPoint - 1 do
+        locPointPos[i] <-
+          Raylib.GetShaderLocation(litShader, $"pointLightPos[{i}]")
+
+        locPointColors[i] <-
+          Raylib.GetShaderLocation(litShader, $"pointLightColors[{i}]")
+
+        locPointIntensities[i] <-
+          Raylib.GetShaderLocation(litShader, $"pointLightIntensities[{i}]")
+
+        locPointRadii[i] <-
+          Raylib.GetShaderLocation(litShader, $"pointLightRadii[{i}]")
+
+        locPointFalloffs[i] <-
+          Raylib.GetShaderLocation(litShader, $"pointLightFalloffs[{i}]")
+
+        locPointShadowIdx[i] <-
+          Raylib.GetShaderLocation(litShader, $"pointLightShadowIdx[{i}]")
+
+      for i = 0 to maxOccluderCount - 1 do
+        locOccluders[i] <-
+          Raylib.GetShaderLocation(litShader, $"occluders[{i}]")
+
+      locOccluderCount <- Raylib.GetShaderLocation(litShader, "occluderCount")
+      locSoftness <- Raylib.GetShaderLocation(litShader, "shadowSoftness")
+      locMaxDist <- Raylib.GetShaderLocation(litShader, "shadowMaxDistance")
+      locNormalMap <- Raylib.GetShaderLocation(litShader, "normalMap")
+
+      locsCached <- true
+
+  let cacheNmLocations() =
+    if not nmLocsCached then
+      nmLocAmbientColor <- Raylib.GetShaderLocation(nmShader, "ambientColor")
+      nmLocDirCount <- Raylib.GetShaderLocation(nmShader, "dirLightCount")
+
+      for i = 0 to maxDir - 1 do
+        nmLocDirDirs[i] <-
+          Raylib.GetShaderLocation(nmShader, $"dirLightDirs[{i}]")
+
+        nmLocDirColors[i] <-
+          Raylib.GetShaderLocation(nmShader, $"dirLightColors[{i}]")
+
+        nmLocDirIntensities[i] <-
+          Raylib.GetShaderLocation(nmShader, $"dirLightIntensities[{i}]")
+
+        nmLocDirShadowIdx[i] <-
+          Raylib.GetShaderLocation(nmShader, $"dirLightShadowIdx[{i}]")
+
+      nmLocPointCount <- Raylib.GetShaderLocation(nmShader, "pointLightCount")
+
+      for i = 0 to maxPoint - 1 do
+        nmLocPointPos[i] <-
+          Raylib.GetShaderLocation(nmShader, $"pointLightPos[{i}]")
+
+        nmLocPointColors[i] <-
+          Raylib.GetShaderLocation(nmShader, $"pointLightColors[{i}]")
+
+        nmLocPointIntensities[i] <-
+          Raylib.GetShaderLocation(nmShader, $"pointLightIntensities[{i}]")
+
+        nmLocPointRadii[i] <-
+          Raylib.GetShaderLocation(nmShader, $"pointLightRadii[{i}]")
+
+        nmLocPointFalloffs[i] <-
+          Raylib.GetShaderLocation(nmShader, $"pointLightFalloffs[{i}]")
+
+        nmLocPointShadowIdx[i] <-
+          Raylib.GetShaderLocation(nmShader, $"pointLightShadowIdx[{i}]")
+
+      for i = 0 to maxOccluderCount - 1 do
+        nmLocOccluders[i] <-
+          Raylib.GetShaderLocation(nmShader, $"occluders[{i}]")
+
+      nmLocOccluderCount <- Raylib.GetShaderLocation(nmShader, "occluderCount")
+      nmLocSoftness <- Raylib.GetShaderLocation(nmShader, "shadowSoftness")
+      nmLocMaxDist <- Raylib.GetShaderLocation(nmShader, "shadowMaxDistance")
+      nmLocNormalMap <- Raylib.GetShaderLocation(nmShader, "normalMap")
+
+      nmLocsCached <- true
+
+  // ------------------------------------------------------------------
+  // Upload helpers (DisableRuntimeMarshalling safe)
+  // ------------------------------------------------------------------
+
+  let setShaderInt (shader: Shader) (loc: int) (value: int) =
+    use p = fixed &value
+
+    Raylib.SetShaderValue(
+      shader,
+      loc,
+      NativePtr.toVoidPtr p,
+      ShaderUniformDataType.Int
+    )
+
+  let setShaderFloat (shader: Shader) (loc: int) (value: float32) =
+    use p = fixed &value
+
+    Raylib.SetShaderValue(
+      shader,
+      loc,
+      NativePtr.toVoidPtr p,
+      ShaderUniformDataType.Float
+    )
+
+  let setShaderVec2 (shader: Shader) (loc: int) (value: Vector2) =
+    use p = fixed &value
+
+    Raylib.SetShaderValue(
+      shader,
+      loc,
+      NativePtr.toVoidPtr p,
+      ShaderUniformDataType.Vec2
+    )
+
+  let setShaderVec3 (shader: Shader) (loc: int) (value: Vector3) =
+    use p = fixed &value
+
+    Raylib.SetShaderValue(
+      shader,
+      loc,
+      NativePtr.toVoidPtr p,
+      ShaderUniformDataType.Vec3
+    )
+
+  let setShaderVec4 (shader: Shader) (loc: int) (value: Vector4) =
+    use p = fixed &value
+
+    Raylib.SetShaderValue(
+      shader,
+      loc,
+      NativePtr.toVoidPtr p,
+      ShaderUniformDataType.Vec4
+    )
+
+  let uploadToShader
+    (shader: Shader)
+    (locAmbientColor: int)
+    (locDirCount: int)
+    (locDirDirs: int[])
+    (locDirColors: int[])
+    (locDirIntensities: int[])
+    (locDirShadowIdx: int[])
+    (locPointCount: int)
+    (locPointPos: int[])
+    (locPointColors: int[])
+    (locPointIntensities: int[])
+    (locPointRadii: int[])
+    (locPointFalloffs: int[])
+    (locPointShadowIdx: int[])
+    (locOccluders: int[])
+    (locOccluderCount: int)
+    (locSoftness: int)
+    (locMaxDist: int)
+    (shadowsEnabled: bool)
+    =
+    setShaderVec3 shader locAmbientColor (colorToVec3 ambientColor)
+
+    let dirCount = min dirLights.Count maxDir
+    setShaderInt shader locDirCount dirCount
+
+    for i = 0 to dirCount - 1 do
+      let l = dirLights[i]
+      setShaderVec2 shader locDirDirs[i] l.Direction
+      setShaderVec3 shader locDirColors[i] (colorToVec3 l.Color)
+      setShaderFloat shader locDirIntensities[i] l.Intensity
+      setShaderInt shader locDirShadowIdx[i] (if l.CastsShadows then 0 else -1)
+
+    let ptCount = min pointLights.Count maxPoint
+    setShaderInt shader locPointCount ptCount
+
+    for i = 0 to ptCount - 1 do
+      let l = pointLights[i]
+      setShaderVec2 shader locPointPos[i] l.Position
+      setShaderVec3 shader locPointColors[i] (colorToVec3 l.Color)
+      setShaderFloat shader locPointIntensities[i] l.Intensity
+      setShaderFloat shader locPointRadii[i] l.Radius
+      setShaderFloat shader locPointFalloffs[i] l.Falloff
+
+      setShaderInt
+        shader
+        locPointShadowIdx[i]
+        (if l.CastsShadows then 0 else -1)
+
+    let ocCount =
+      if shadowsEnabled then
+        min occluders.Count maxOccluderCount
+      else
+        0
+
+    setShaderInt shader locOccluderCount ocCount
+
+    for i = 0 to ocCount - 1 do
+      let o = occluders[i]
+
+      setShaderVec4
+        shader
+        locOccluders[i]
+        (Vector4(o.P1.X, o.P1.Y, o.P2.X, o.P2.Y))
+
+    setShaderFloat shader locSoftness shadowSoftness
+    setShaderFloat shader locMaxDist shadowMaxDist
+
+  /// <summary>Whether the lit shader is currently active. Managed by commands.</summary>
+  member val ShaderActive = false with get, set
+
+  /// <summary>Whether light uniforms need to be re-uploaded to the GPU.</summary>
+  member val UniformsDirty = true with get, set
+
+  /// <summary>Whether shadow raymarching is enabled for this context. Default true.</summary>
+  member val ShadowsEnabled = true with get, set
+
+  /// <summary>Ensures uniform locations are cached.</summary>
+  member _.EnsureLocationsCached() =
+    cacheLocations()
+    cacheNmLocations()
+
+  /// <summary>Clears accumulated lights, occluders, and resets ambient to black.</summary>
+  member this.Reset() =
+    dirLights.Clear()
+    pointLights.Clear()
+    occluders.Clear()
+    ambientColor <- { R = 0uy; G = 0uy; B = 0uy; A = 255uy }
+    this.ShaderActive <- false
+    this.UniformsDirty <- true
+    this.ShadowsEnabled <- true
+
+  /// <summary>Current ambient light color.</summary>
+  member _.Ambient
+    with get () = ambientColor
+    and set (v) = ambientColor <- v
+
+  /// <summary>Directional lights accumulated this frame.</summary>
+  member _.DirLights = dirLights
+
+  /// <summary>Point lights accumulated this frame.</summary>
+  member _.PointLights = pointLights
+
+  /// <summary>Occluder segments accumulated this frame.</summary>
+  member _.Occluders = occluders
+
+  /// <summary>The standard lit-sprite shader (no normal map).</summary>
+  member _.Shader = litShader
+
+  /// <summary>The normal-mapped lit-sprite shader.</summary>
+  member _.NormalMapShader = nmShader
+
+  /// <summary>Uniform location for the normalMap sampler in the normal-map shader.</summary>
+  member _.LocNormalMap = nmLocNormalMap
+
+  /// <summary>Uploads all accumulated light data to the GPU for both shader variants.</summary>
+  member this.UploadUniforms() =
+    cacheLocations()
+    cacheNmLocations()
+
+    uploadToShader
+      litShader
+      locAmbientColor
+      locDirCount
+      locDirDirs
+      locDirColors
+      locDirIntensities
+      locDirShadowIdx
+      locPointCount
+      locPointPos
+      locPointColors
+      locPointIntensities
+      locPointRadii
+      locPointFalloffs
+      locPointShadowIdx
+      locOccluders
+      locOccluderCount
+      locSoftness
+      locMaxDist
+      this.ShadowsEnabled
+
+    uploadToShader
+      nmShader
+      nmLocAmbientColor
+      nmLocDirCount
+      nmLocDirDirs
+      nmLocDirColors
+      nmLocDirIntensities
+      nmLocDirShadowIdx
+      nmLocPointCount
+      nmLocPointPos
+      nmLocPointColors
+      nmLocPointIntensities
+      nmLocPointRadii
+      nmLocPointFalloffs
+      nmLocPointShadowIdx
+      nmLocOccluders
+      nmLocOccluderCount
+      nmLocSoftness
+      nmLocMaxDist
+      this.ShadowsEnabled
+
+  interface IDisposable with
+    member _.Dispose() =
+      Raylib.UnloadShader(litShader)
+      Raylib.UnloadShader(nmShader)

--- a/src/Mibo.Raylib/Next/Graphics2D/Lighting/LightContext.fs
+++ b/src/Mibo.Raylib/Next/Graphics2D/Lighting/LightContext.fs
@@ -10,6 +10,32 @@ open Raylib_cs
 open Mibo.Elmish.Next
 open Mibo.Elmish.Next.Graphics2D.Base
 
+// All uniform locations for one shader variant. Held in a mutable record so
+// the lit and normal-map shaders share a single caching/upload path instead
+// of duplicating ~100 lines of GetShaderLocation + setShader* calls.
+[<Struct>]
+type ShaderUniformLocations = {
+  mutable Cached: bool
+  mutable AmbientColor: int
+  mutable DirCount: int
+  DirDirs: int[]
+  DirColors: int[]
+  DirIntensities: int[]
+  DirShadowIdx: int[]
+  mutable PointCount: int
+  PointPos: int[]
+  PointColors: int[]
+  PointIntensities: int[]
+  PointRadii: int[]
+  PointFalloffs: int[]
+  PointShadowIdx: int[]
+  Occluders: int[]
+  mutable OccluderCount: int
+  mutable Softness: int
+  mutable MaxDist: int
+  mutable NormalMap: int
+}
+
 /// <summary>
 /// Raylib Next light context. Accepts the Core.Next backend-neutral light types
 /// and uploads them to the built-in SDF shadow raymarching shader.
@@ -28,6 +54,11 @@ type LightContext2D
   let maxDir = defaultArg maxDirLights 4
   let maxPoint = defaultArg maxPointLights 16
   let maxOccluderCount = defaultArg maxOccluders 128
+  // Track ownership so Dispose only unloads shaders this context created via
+  // the default loaders. User-supplied shaders may be shared across contexts or
+  // managed elsewhere, so unloading them risks double-free / use-after-free.
+  let ownsLitShader = litShader.IsNone
+  let ownsNmShader = litNormalMapShader.IsNone
 
   let litShader =
     defaultArg litShader (Mibo.Elmish.Graphics2D.Lighting.LitShader.load())
@@ -49,155 +80,83 @@ type LightContext2D
   let colorToVec3(c: Color) =
     Vector3(float32 c.R / 255.0f, float32 c.G / 255.0f, float32 c.B / 255.0f)
 
-  // ------------------------------------------------------------------
-  // Uniform locations
-  // ------------------------------------------------------------------
+  let mkLocations() : ShaderUniformLocations = {
+    Cached = false
+    AmbientColor = -1
+    DirCount = -1
+    DirDirs = Array.zeroCreate<int> maxDir
+    DirColors = Array.zeroCreate<int> maxDir
+    DirIntensities = Array.zeroCreate<int> maxDir
+    DirShadowIdx = Array.zeroCreate<int> maxDir
+    PointCount = -1
+    PointPos = Array.zeroCreate<int> maxPoint
+    PointColors = Array.zeroCreate<int> maxPoint
+    PointIntensities = Array.zeroCreate<int> maxPoint
+    PointRadii = Array.zeroCreate<int> maxPoint
+    PointFalloffs = Array.zeroCreate<int> maxPoint
+    PointShadowIdx = Array.zeroCreate<int> maxPoint
+    Occluders = Array.zeroCreate<int> maxOccluderCount
+    OccluderCount = -1
+    Softness = -1
+    MaxDist = -1
+    NormalMap = -1
+  }
 
-  let mutable locsCached = false
+  let litLocs = mkLocations()
+  let nmLocs = mkLocations()
 
-  let mutable locAmbientColor = -1
-  let mutable locDirCount = -1
-  let locDirDirs = Array.zeroCreate<int> maxDir
-  let locDirColors = Array.zeroCreate<int> maxDir
-  let locDirIntensities = Array.zeroCreate<int> maxDir
-  let locDirShadowIdx = Array.zeroCreate<int> maxDir
+  let cacheLocationsFor (shader: Shader) (locs: ShaderUniformLocations) =
+    let mutable locs = locs
 
-  let mutable locPointCount = -1
-  let locPointPos = Array.zeroCreate<int> maxPoint
-  let locPointColors = Array.zeroCreate<int> maxPoint
-  let locPointIntensities = Array.zeroCreate<int> maxPoint
-  let locPointRadii = Array.zeroCreate<int> maxPoint
-  let locPointFalloffs = Array.zeroCreate<int> maxPoint
-  let locPointShadowIdx = Array.zeroCreate<int> maxPoint
-
-  let locOccluders = Array.zeroCreate<int> maxOccluderCount
-  let mutable locOccluderCount = -1
-  let mutable locSoftness = -1
-  let mutable locMaxDist = -1
-  let mutable locNormalMap = -1
-
-  let mutable nmLocsCached = false
-
-  let mutable nmLocAmbientColor = -1
-  let mutable nmLocDirCount = -1
-  let nmLocDirDirs = Array.zeroCreate<int> maxDir
-  let nmLocDirColors = Array.zeroCreate<int> maxDir
-  let nmLocDirIntensities = Array.zeroCreate<int> maxDir
-  let nmLocDirShadowIdx = Array.zeroCreate<int> maxDir
-
-  let mutable nmLocPointCount = -1
-  let nmLocPointPos = Array.zeroCreate<int> maxPoint
-  let nmLocPointColors = Array.zeroCreate<int> maxPoint
-  let nmLocPointIntensities = Array.zeroCreate<int> maxPoint
-  let nmLocPointRadii = Array.zeroCreate<int> maxPoint
-  let nmLocPointFalloffs = Array.zeroCreate<int> maxPoint
-  let nmLocPointShadowIdx = Array.zeroCreate<int> maxPoint
-
-  let nmLocOccluders = Array.zeroCreate<int> maxOccluderCount
-  let mutable nmLocOccluderCount = -1
-  let mutable nmLocSoftness = -1
-  let mutable nmLocMaxDist = -1
-  let mutable nmLocNormalMap = -1
-
-  let cacheLocations() =
-    if not locsCached then
-      locAmbientColor <- Raylib.GetShaderLocation(litShader, "ambientColor")
-      locDirCount <- Raylib.GetShaderLocation(litShader, "dirLightCount")
+    if not locs.Cached then
+      locs.AmbientColor <- Raylib.GetShaderLocation(shader, "ambientColor")
+      locs.DirCount <- Raylib.GetShaderLocation(shader, "dirLightCount")
 
       for i = 0 to maxDir - 1 do
-        locDirDirs[i] <-
-          Raylib.GetShaderLocation(litShader, $"dirLightDirs[{i}]")
+        locs.DirDirs[i] <-
+          Raylib.GetShaderLocation(shader, $"dirLightDirs[{i}]")
 
-        locDirColors[i] <-
-          Raylib.GetShaderLocation(litShader, $"dirLightColors[{i}]")
+        locs.DirColors[i] <-
+          Raylib.GetShaderLocation(shader, $"dirLightColors[{i}]")
 
-        locDirIntensities[i] <-
-          Raylib.GetShaderLocation(litShader, $"dirLightIntensities[{i}]")
+        locs.DirIntensities[i] <-
+          Raylib.GetShaderLocation(shader, $"dirLightIntensities[{i}]")
 
-        locDirShadowIdx[i] <-
-          Raylib.GetShaderLocation(litShader, $"dirLightShadowIdx[{i}]")
+        locs.DirShadowIdx[i] <-
+          Raylib.GetShaderLocation(shader, $"dirLightShadowIdx[{i}]")
 
-      locPointCount <- Raylib.GetShaderLocation(litShader, "pointLightCount")
-
-      for i = 0 to maxPoint - 1 do
-        locPointPos[i] <-
-          Raylib.GetShaderLocation(litShader, $"pointLightPos[{i}]")
-
-        locPointColors[i] <-
-          Raylib.GetShaderLocation(litShader, $"pointLightColors[{i}]")
-
-        locPointIntensities[i] <-
-          Raylib.GetShaderLocation(litShader, $"pointLightIntensities[{i}]")
-
-        locPointRadii[i] <-
-          Raylib.GetShaderLocation(litShader, $"pointLightRadii[{i}]")
-
-        locPointFalloffs[i] <-
-          Raylib.GetShaderLocation(litShader, $"pointLightFalloffs[{i}]")
-
-        locPointShadowIdx[i] <-
-          Raylib.GetShaderLocation(litShader, $"pointLightShadowIdx[{i}]")
-
-      for i = 0 to maxOccluderCount - 1 do
-        locOccluders[i] <-
-          Raylib.GetShaderLocation(litShader, $"occluders[{i}]")
-
-      locOccluderCount <- Raylib.GetShaderLocation(litShader, "occluderCount")
-      locSoftness <- Raylib.GetShaderLocation(litShader, "shadowSoftness")
-      locMaxDist <- Raylib.GetShaderLocation(litShader, "shadowMaxDistance")
-      locNormalMap <- Raylib.GetShaderLocation(litShader, "normalMap")
-
-      locsCached <- true
-
-  let cacheNmLocations() =
-    if not nmLocsCached then
-      nmLocAmbientColor <- Raylib.GetShaderLocation(nmShader, "ambientColor")
-      nmLocDirCount <- Raylib.GetShaderLocation(nmShader, "dirLightCount")
-
-      for i = 0 to maxDir - 1 do
-        nmLocDirDirs[i] <-
-          Raylib.GetShaderLocation(nmShader, $"dirLightDirs[{i}]")
-
-        nmLocDirColors[i] <-
-          Raylib.GetShaderLocation(nmShader, $"dirLightColors[{i}]")
-
-        nmLocDirIntensities[i] <-
-          Raylib.GetShaderLocation(nmShader, $"dirLightIntensities[{i}]")
-
-        nmLocDirShadowIdx[i] <-
-          Raylib.GetShaderLocation(nmShader, $"dirLightShadowIdx[{i}]")
-
-      nmLocPointCount <- Raylib.GetShaderLocation(nmShader, "pointLightCount")
+      locs.PointCount <- Raylib.GetShaderLocation(shader, "pointLightCount")
 
       for i = 0 to maxPoint - 1 do
-        nmLocPointPos[i] <-
-          Raylib.GetShaderLocation(nmShader, $"pointLightPos[{i}]")
+        locs.PointPos[i] <-
+          Raylib.GetShaderLocation(shader, $"pointLightPos[{i}]")
 
-        nmLocPointColors[i] <-
-          Raylib.GetShaderLocation(nmShader, $"pointLightColors[{i}]")
+        locs.PointColors[i] <-
+          Raylib.GetShaderLocation(shader, $"pointLightColors[{i}]")
 
-        nmLocPointIntensities[i] <-
-          Raylib.GetShaderLocation(nmShader, $"pointLightIntensities[{i}]")
+        locs.PointIntensities[i] <-
+          Raylib.GetShaderLocation(shader, $"pointLightIntensities[{i}]")
 
-        nmLocPointRadii[i] <-
-          Raylib.GetShaderLocation(nmShader, $"pointLightRadii[{i}]")
+        locs.PointRadii[i] <-
+          Raylib.GetShaderLocation(shader, $"pointLightRadii[{i}]")
 
-        nmLocPointFalloffs[i] <-
-          Raylib.GetShaderLocation(nmShader, $"pointLightFalloffs[{i}]")
+        locs.PointFalloffs[i] <-
+          Raylib.GetShaderLocation(shader, $"pointLightFalloffs[{i}]")
 
-        nmLocPointShadowIdx[i] <-
-          Raylib.GetShaderLocation(nmShader, $"pointLightShadowIdx[{i}]")
+        locs.PointShadowIdx[i] <-
+          Raylib.GetShaderLocation(shader, $"pointLightShadowIdx[{i}]")
 
       for i = 0 to maxOccluderCount - 1 do
-        nmLocOccluders[i] <-
-          Raylib.GetShaderLocation(nmShader, $"occluders[{i}]")
+        locs.Occluders[i] <- Raylib.GetShaderLocation(shader, $"occluders[{i}]")
 
-      nmLocOccluderCount <- Raylib.GetShaderLocation(nmShader, "occluderCount")
-      nmLocSoftness <- Raylib.GetShaderLocation(nmShader, "shadowSoftness")
-      nmLocMaxDist <- Raylib.GetShaderLocation(nmShader, "shadowMaxDistance")
-      nmLocNormalMap <- Raylib.GetShaderLocation(nmShader, "normalMap")
+      locs.OccluderCount <- Raylib.GetShaderLocation(shader, "occluderCount")
+      locs.Softness <- Raylib.GetShaderLocation(shader, "shadowSoftness")
+      locs.MaxDist <- Raylib.GetShaderLocation(shader, "shadowMaxDistance")
+      locs.NormalMap <- Raylib.GetShaderLocation(shader, "normalMap")
+      locs.Cached <- true
 
-      nmLocsCached <- true
+  let cacheLocations() = cacheLocationsFor litShader litLocs
+  let cacheNmLocations() = cacheLocationsFor nmShader nmLocs
 
   // ------------------------------------------------------------------
   // Upload helpers (DisableRuntimeMarshalling safe)
@@ -255,51 +214,39 @@ type LightContext2D
 
   let uploadToShader
     (shader: Shader)
-    (locAmbientColor: int)
-    (locDirCount: int)
-    (locDirDirs: int[])
-    (locDirColors: int[])
-    (locDirIntensities: int[])
-    (locDirShadowIdx: int[])
-    (locPointCount: int)
-    (locPointPos: int[])
-    (locPointColors: int[])
-    (locPointIntensities: int[])
-    (locPointRadii: int[])
-    (locPointFalloffs: int[])
-    (locPointShadowIdx: int[])
-    (locOccluders: int[])
-    (locOccluderCount: int)
-    (locSoftness: int)
-    (locMaxDist: int)
+    (locs: ShaderUniformLocations)
     (shadowsEnabled: bool)
     =
-    setShaderVec3 shader locAmbientColor (colorToVec3 ambientColor)
+    setShaderVec3 shader locs.AmbientColor (colorToVec3 ambientColor)
 
     let dirCount = min dirLights.Count maxDir
-    setShaderInt shader locDirCount dirCount
+    setShaderInt shader locs.DirCount dirCount
 
     for i = 0 to dirCount - 1 do
       let l = dirLights[i]
-      setShaderVec2 shader locDirDirs[i] l.Direction
-      setShaderVec3 shader locDirColors[i] (colorToVec3 l.Color)
-      setShaderFloat shader locDirIntensities[i] l.Intensity
-      setShaderInt shader locDirShadowIdx[i] (if l.CastsShadows then 0 else -1)
-
-    let ptCount = min pointLights.Count maxPoint
-    setShaderInt shader locPointCount ptCount
-
-    for i = 0 to ptCount - 1 do
-      let l = pointLights[i]
-      setShaderVec2 shader locPointPos[i] l.Position
-      setShaderVec3 shader locPointColors[i] (colorToVec3 l.Color)
-      setShaderFloat shader locPointIntensities[i] l.Intensity
-      setShaderFloat shader locPointRadii[i] l.Radius
-      setShaderFloat shader locPointFalloffs[i] l.Falloff
+      setShaderVec2 shader locs.DirDirs[i] l.Direction
+      setShaderVec3 shader locs.DirColors[i] (colorToVec3 l.Color)
+      setShaderFloat shader locs.DirIntensities[i] l.Intensity
 
       setShaderInt
         shader
-        locPointShadowIdx[i]
+        locs.DirShadowIdx[i]
+        (if l.CastsShadows then 0 else -1)
+
+    let ptCount = min pointLights.Count maxPoint
+    setShaderInt shader locs.PointCount ptCount
+
+    for i = 0 to ptCount - 1 do
+      let l = pointLights[i]
+      setShaderVec2 shader locs.PointPos[i] l.Position
+      setShaderVec3 shader locs.PointColors[i] (colorToVec3 l.Color)
+      setShaderFloat shader locs.PointIntensities[i] l.Intensity
+      setShaderFloat shader locs.PointRadii[i] l.Radius
+      setShaderFloat shader locs.PointFalloffs[i] l.Falloff
+
+      setShaderInt
+        shader
+        locs.PointShadowIdx[i]
         (if l.CastsShadows then 0 else -1)
 
     let ocCount =
@@ -308,18 +255,18 @@ type LightContext2D
       else
         0
 
-    setShaderInt shader locOccluderCount ocCount
+    setShaderInt shader locs.OccluderCount ocCount
 
     for i = 0 to ocCount - 1 do
       let o = occluders[i]
 
       setShaderVec4
         shader
-        locOccluders[i]
+        locs.Occluders[i]
         (Vector4(o.P1.X, o.P1.Y, o.P2.X, o.P2.Y))
 
-    setShaderFloat shader locSoftness shadowSoftness
-    setShaderFloat shader locMaxDist shadowMaxDist
+    setShaderFloat shader locs.Softness shadowSoftness
+    setShaderFloat shader locs.MaxDist shadowMaxDist
 
   /// <summary>Whether the lit shader is currently active. Managed by commands.</summary>
   member val ShaderActive = false with get, set
@@ -366,56 +313,19 @@ type LightContext2D
   member _.NormalMapShader = nmShader
 
   /// <summary>Uniform location for the normalMap sampler in the normal-map shader.</summary>
-  member _.LocNormalMap = nmLocNormalMap
+  member _.LocNormalMap = nmLocs.NormalMap
 
   /// <summary>Uploads all accumulated light data to the GPU for both shader variants.</summary>
   member this.UploadUniforms() =
     cacheLocations()
     cacheNmLocations()
-
-    uploadToShader
-      litShader
-      locAmbientColor
-      locDirCount
-      locDirDirs
-      locDirColors
-      locDirIntensities
-      locDirShadowIdx
-      locPointCount
-      locPointPos
-      locPointColors
-      locPointIntensities
-      locPointRadii
-      locPointFalloffs
-      locPointShadowIdx
-      locOccluders
-      locOccluderCount
-      locSoftness
-      locMaxDist
-      this.ShadowsEnabled
-
-    uploadToShader
-      nmShader
-      nmLocAmbientColor
-      nmLocDirCount
-      nmLocDirDirs
-      nmLocDirColors
-      nmLocDirIntensities
-      nmLocDirShadowIdx
-      nmLocPointCount
-      nmLocPointPos
-      nmLocPointColors
-      nmLocPointIntensities
-      nmLocPointRadii
-      nmLocPointFalloffs
-      nmLocPointShadowIdx
-      nmLocOccluders
-      nmLocOccluderCount
-      nmLocSoftness
-      nmLocMaxDist
-      this.ShadowsEnabled
+    uploadToShader litShader litLocs this.ShadowsEnabled
+    uploadToShader nmShader nmLocs this.ShadowsEnabled
 
   interface IDisposable with
     member _.Dispose() =
-      Raylib.UnloadShader(litShader)
-      Raylib.UnloadShader(nmShader)
+      if ownsLitShader then
+        Raylib.UnloadShader(litShader)
+
+      if ownsNmShader then
+        Raylib.UnloadShader(nmShader)

--- a/src/Mibo.Raylib/Next/Graphics2D/ParticleDraw.fs
+++ b/src/Mibo.Raylib/Next/Graphics2D/ParticleDraw.fs
@@ -3,7 +3,7 @@ namespace Mibo.Elmish.Next.Graphics2D
 open Raylib_cs
 open Mibo.Elmish.Next
 open Mibo.Elmish.Next.Graphics2D.Base
-open Mibo.Elmish.Graphics2D.Lighting
+open Mibo.Elmish.Next.Graphics2D.Lighting
 
 module ParticleDraw =
 
@@ -28,8 +28,8 @@ module ParticleDraw =
               Position = p.Position
               Size = p.Size
               Rotation = p.Rotation
-              SourceRect = Convert.toRect(p.SourceRect)
-              Color = Convert.toColor(p.Color)
+              SourceRect = p.SourceRect
+              Color = p.Color
             }
             : ParticleData)
 

--- a/src/Mibo.Raylib/Next/ResourceRegistry.fs
+++ b/src/Mibo.Raylib/Next/ResourceRegistry.fs
@@ -141,9 +141,9 @@ type RaylibModelRegistry() =
 
 type LightContextRegistry() =
   let fwd = Dictionary<obj, int<LightContext>>()
-  let rev = ResizeArray<Mibo.Elmish.Graphics2D.Lighting.LightContext2D>()
+  let rev = ResizeArray<Mibo.Elmish.Next.Graphics2D.Lighting.LightContext2D>()
 
-  member _.Register(ctx: Mibo.Elmish.Graphics2D.Lighting.LightContext2D) =
+  member _.Register(ctx: Mibo.Elmish.Next.Graphics2D.Lighting.LightContext2D) =
     let key = box ctx
 
     match fwd.TryGetValue key with


### PR DESCRIPTION
## Phase 2: Backend Next alignment and full MonoGame 2D renderer

This PR continues the `vnext` refactor by completing the MonoGame 2D renderer and aligning the Raylib `Next` namespace to consume the Core.Next shared infrastructure.

### What changed

#### MonoGame backend
- `Renderer2D` now dispatches the **entire** `Command2D` surface:
  - Sprites, text, rectangles, rectangle outlines, rounded rectangles, rounded rectangle outlines.
  - Vertical, horizontal, and 4-corner gradients.
  - Filled/outlined circles, circle sectors, rings, ellipses, and polygons.
  - Lines, thick lines, line strips, and quadratic Bézier curves.
  - Triangles, triangle fans, and triangle strips.
- Primitive shapes are rendered with a `BasicEffect` + `GraphicsDevice.DrawUserPrimitives`; textured work stays in `SpriteBatch`.
- Camera commands (`BeginCamera`, `BeginCameraConfig`, `EndCamera`) now build and apply the correct 2D transform `Matrix` from `Camera2DState`.
- Render targets, scissor rectangles, blend modes, viewports, and shader effects are handled with proper `SpriteBatch` flushing.
- `AssetsService` gained loose-file loaders:
  - `IAssets.TextureFromFile` — loads `Texture2D` via `Texture2D.FromStream`.
  - `IAssets.SoundFromFile` — loads `SoundEffect` via `SoundEffect.FromStream`.
- `AssetsService.createFromContext` now resolves the registered `GraphicsDevice` so `TextureFromFile` works without extra setup.

#### Raylib backend (Next namespace only)
- Added a new `Mibo.Elmish.Next.Graphics2D.Lighting.LightContext2D` that owns the SDF shadow raymarching shader state and uses the Core.Next light types (`AmbientLight2D`, `DirectionalLight2D`, `PointLight2D`, `Occluder2D`).
- `Mibo.Raylib.Next.Graphics2D.LightDraw` now consumes Core.Next `Animation` and `Lighting` types.
- `ResourceRegistry` updated to register/resolve the new Next `LightContext2D`.
- Legacy `Mibo.Elmish.*` and `Mibo.Animation.*` namespaces remain untouched and compile unchanged.

### Verification

- `dotnet build src/Mibo.Core/Mibo.Core.fsproj` — passes.
- `dotnet build src/Mibo.MonoGame/Mibo.MonoGame.fsproj` — passes.
- `dotnet build src/Mibo.Raylib/Mibo.Raylib.fsproj` — passes.
- `dotnet test src/Mibo.Raylib.Tests/Mibo.Raylib.Tests.fsproj` — **390 passed**.
- `dotnet fantomas .` applied.

### Scope notes

- No sample changes are included in this PR; sample work is Phase 3.
- This PR targets `vnext`.
