### PR TITLE
feat(3d): instanced draws + shadow sampling in beginEffect scope

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,9 @@ Changelog Format:
 
 ## [Unreleased]
 
-Content that is pending for release goes here.
+### Added
+
+- Instanced draws inside a `beginEffect`/`endEffect` scope are now shaded by the user shader when it opts into instancing (raylib: `in mat4 instanceTransform;`; MonoGame: an `Instanced` technique reading `TEXCOORD1..4`). Effects that don't opt in keep the previous PBR-instanced fallback. Skinned + instanced remains unsupported. See `docs/shader-uniforms.md` → "Instancing (opt-in)".
 
 ## [1.0.0] - 2026.01.13
 
@@ -145,3 +147,14 @@ When capturing the View-Projection matrix for shadow mapping:
 - **MUST** capture inside `BeginMode3D` using `Rlgl.GetMatrixModelview() * Rlgl.GetMatrixProjection()`
 - This matches what the batch computes for `mvp` (for identity model transforms)
 - Precomputing VP outside `BeginMode3D` or using `Matrix4x4.CreateLookAt * CreatePerspectiveFieldOfView` may produce different results due to raylib's internal matrix adjustments
+
+## Instancing opt-in for `beginEffect` shaders
+
+Instanced draws inside a `Draw3D.beginEffect`/`endEffect` scope are shaded by the user shader only when the shader opts in. The opt-in convention is backend-specific (each engine feeds per-instance data differently); the data is the same — a per-instance 4×4 world matrix.
+
+- **raylib:** the shader declares `in mat4 instanceTransform;`. The pipeline resolves that attribute once per shader (`GetShaderLocationAttrib`) and points the shader's `Locs[ShaderLocationIndex.MatrixModel]` slot at it for the duration of the instanced draw (restoring it afterward, so a non-instanced draw in the same scope still auto-uploads `matModel`). `matModel` is unused for instanced draws; `viewProj` is view-projection only.
+- **MonoGame:** the effect exposes a technique named `Instanced` whose vertex shader reads the per-instance matrix as four `float4` rows on `TEXCOORD1..4` (the `VertexInstanceWorld` layout, usage indices 1-4 to avoid the mesh's `TEXCOORD0` on stream 0). The pipeline binds the two-stream vertex layout (mesh on stream 0, instance rows on stream 1) and calls `DrawInstancedPrimitives` through the user effect.
+
+A shader/effect that doesn't declare the opt-in is unaffected: instanced draws fall back to the built-in PBR instanced path. Skinned + instanced draws are not supported (no per-instance bone palette).
+
+See `docs/shader-uniforms.md` → "Instancing (opt-in)" for the full contract and example shaders.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **3D:** instanced draws inside a `beginEffect`/`endEffect` scope are now shaded by your own shader/effect when it opts into instancing — raylib declares `in mat4 instanceTransform;`, MonoGame exposes an `Instanced` technique. Effects that don't opt in keep the previous PBR-instanced fallback. Skinned + instanced isn't supported (no per-instance bone palette). See the "Instancing (opt-in)" section of `docs/shader-uniforms.md`.
+
+### Fixed
+
+- **3D:** a custom `beginEffect`/`endEffect` shader/effect that opts into shadows now receives them correctly. The scene-upload path bound the shadow atlas under the wrong sampler name on MonoGame (`texture5` instead of `shadowAtlas` — the name `mgfxc` exposes samplers under), never uploaded the per-caster `shadowBiases`, and omitted the bias from the `ShadowResult` bundle entirely. Declare `sampler2D shadowAtlas : register(s5)` (MonoGame) / the `shadowAtlas`/`shadowBiases` uniforms (raylib) to opt in.
+
 ## [2.0.0-rc-001] - 2026-07-01
 
 ### Added

--- a/docs/graphics3d/instancing.md
+++ b/docs/graphics3d/instancing.md
@@ -121,6 +121,30 @@ CellGridRenderer3D.renderVolumeInstanced instancedCtx bounds model.World buffer
 
 The pipeline renders all instances of a mesh type in a single GPU draw call using the instanced shader.
 
+## Shading instances with a custom effect
+
+Instanced draws normally use the built-in PBR instanced shader. To shade them
+with your own effect — for a toon, water, fog, or other stylized look — wrap
+the instanced draw in a `Draw3D.beginEffect` / `endEffect` scope and have your
+shader opt into instancing.
+
+The opt-in is by declaration, and the declaration differs by backend because
+each engine feeds per-instance data differently:
+
+- **raylib:** declare `in mat4 instanceTransform;` (raylib streams the rows at
+  a per-instance rate). `viewProj` is view-projection only; `matModel` is not
+  set for instanced draws.
+- **MonoGame:** expose a technique named **`Instanced`** whose vertex shader
+  reads the per-instance world matrix as four `float4` rows on `TEXCOORD1..4`
+  (matching `ForwardPbr.fx`'s instanced input, or the minimal `Instanced.fx`).
+
+A shader that doesn't declare the opt-in is unaffected — its instanced draws
+fall back to the PBR instanced path. Skinned + instanced draws are not
+supported (no per-instance bone palette).
+
+See [Shader Uniform Reference](../shader-uniforms.html#instancing-opt-in) for
+the full per-backend input contract and minimal example shaders.
+
 ## Performance tips
 
 - **Key function** — Keep `getKey` cheap. It's called per cell per frame.

--- a/docs/migration-from-monogame.md
+++ b/docs/migration-from-monogame.md
@@ -846,7 +846,8 @@ to parse skeleton/clips at runtime).
 
 ### Shaders / effects
 
-Custom HLSL effects (`.fx` compiled by MGCB to `.mgfx`) load via
+Custom HLSL effects (`.fx` compiled by the MGCB content pipeline via
+`EffectImporter`/`EffectProcessor` to `.xnb`) load via
 `assets.Effect path` as before. Note that the 2D lit-sprite and 3D PBR/shadow
 shaders are now **bundled inside the `Mibo.MonoGame` assembly** — you no longer
 need to author/ship `Shaders/lighting`, `Shaders/shadowcaster`, `Effects/PBR`,

--- a/docs/shader-uniforms.md
+++ b/docs/shader-uniforms.md
@@ -22,8 +22,7 @@ How custom shading gets into the pipeline, per backend:
 
 | Escape hatch | raylib | MonoGame | Uniforms you receive |
 |---|---|---|---|
-| `Draw3D.beginEffect` / `endEffect` | ✓ (`Shader`) | ✓ (`Effect`) | Scene data **by name** — declare only what you use; absent ones are skipped |
-| `Draw3D.beginEffectWithInstanced` | ✓ | — | As above; routes `DrawMeshInstanced` through a second shader |
+| `Draw3D.beginEffect` / `endEffect` | ✓ (`Shader`) | ✓ (`Effect`) | Scene data **by name** — declare only what you use; absent ones are skipped. Instanced draws are shaded by your shader when it opts in (see [Instancing](#instancing-opt-in)). |
 | `Draw3D.drawMeshEffect` | — | ✓ | `World`/`View`/`Projection` only (via `IEffectMatrices`); you own lighting/material |
 | `Draw3D.drawImmediate` | ✓ | ✓ | None — the pipeline shader is bypassed; you get a `SceneContext` with raw device + gathered scene fields |
 
@@ -105,20 +104,95 @@ none of these renders unshadowed at no cost.
 | `shadowViewProjs[i]` | `mat4[]` / `float4x4[]` | Per-caster view-projection (default max 16 casters) |
 | `shadowUVOffsets[i]` | `vec4[]` / `float4[]` | Per-caster atlas region (xy=offset, zw=scale) |
 | `shadowTexelSize` | `float` (raylib) / `vec2`/`float2` (MonoGame) | `1.0 / atlasResolution` for PCF spread |
+| `shadowBiases[i]` | `float[]` | Per-caster receiver-side bias (prevents self-shadow acne; raylib adds an in-shader slope-scale term, MonoGame applies it directly) |
 | `pointLightShadowIdx[i]` | `int` | Per-point-light caster slot, `-1` = none |
 | `spotLightShadowIdx[i]` | `int` | Per-spot-light caster slot, `-1` = none |
-| `shadowAtlas` (raylib) / `texture5` (MonoGame) | `sampler2D` | The depth atlas |
+| `shadowAtlas` | `sampler2D` | The depth atlas (declared as `sampler2D shadowAtlas : register(s5)` on MonoGame) |
 
 > **Shadow sampler slot differs by backend.** raylib binds the atlas to
 > **slot 15** (and sets the `shadowAtlas` sampler uniform to 15). MonoGame binds
-> it to **slot 5** (PointClamp) and exposes it as the `texture5` sampler
-> parameter. Declare the matching sampler name for your backend.
+> it to **slot 5** (PointClamp) and exposes it through the effect's `shadowAtlas`
+> sampler parameter (mgfxc names the sampler after its HLSL declaration, not the
+> register slot — so declare `sampler2D shadowAtlas : register(s5)`, matching the
+> built-in `ForwardPbr.fx`). Both backends use the same uniform name: `shadowAtlas`.
 
 ### Skinning (only for skinned draws)
 
 | Uniform | Type | Source |
 |---|---|---|
 | `boneMatrices[128]` | `mat4[]` / `float4x4[]` | Bone palette (uploaded only when bones are supplied) |
+
+### Instancing (opt-in)
+
+A `Draw3D.drawMeshInstanced` inside a `beginEffect` scope is shaded by your
+shader when it declares the instancing input; otherwise it falls back to the
+built-in PBR instanced path. The opt-in convention differs by backend because
+each engine feeds per-instance data differently — raylib uses a single vertex
+attribute and sets the divisor itself, while MonoGame requires two explicit
+vertex streams. The data is the same in both cases: a per-instance 4×4 world
+matrix.
+
+`matModel` is **not** used for instanced draws (the per-instance transform *is*
+the model matrix); the pipeline uploads identity for it, so a shader that still
+declares `matModel` sees a benign value.
+
+**raylib (GLSL `#version 330`):** declare the per-instance attribute.
+
+```glsl
+in mat4 instanceTransform;   // the opt-in: raylib streams rows at a per-instance rate
+
+uniform mat4 viewProj;       // view * projection (matModel is NOT set for instanced draws)
+uniform vec3 cameraPos;      // plus whatever scene uniforms you consume
+
+void main() {
+  vec4 world = instanceTransform * vec4(vertexPosition, 1.0);
+  gl_Position = viewProj * world;
+  // ...
+}
+```
+
+**MonoGame (HLSL, SM 3.0/5.0):** expose a technique named **`Instanced`** whose
+vertex shader reads the per-instance matrix as four `float4` rows on
+`TEXCOORD1..4` (usage indices 1-4, to avoid colliding with the mesh's own
+`TEXCOORD0` on stream 0). This matches `ForwardPbr.fx`'s `VS_INPUT_INSTANCED`
+and the minimal `Instanced.fx`.
+
+```hlsl
+float4x4 viewProj;          // plus whatever scene uniforms you consume
+
+struct VS_INPUT_INSTANCED {
+  // Stream 0 (per-vertex mesh)
+  float3 Position : POSITION0;
+  float3 Normal   : NORMAL0;
+  float2 TexCoord : TEXCOORD0;
+  // Stream 1 (per-instance) — 4 rows composing a 4x4 world matrix
+  float4 Row0 : TEXCOORD1;
+  float4 Row1 : TEXCOORD2;
+  float4 Row2 : TEXCOORD3;
+  float4 Row3 : TEXCOORD4;
+};
+
+VS_OUTPUT VS_Instanced(VS_INPUT_INSTANCED input) {
+  VS_OUTPUT o;
+  float4x4 world = float4x4(input.Row0, input.Row1, input.Row2, input.Row3);
+  float4 wp = mul(float4(input.Position, 1.0), world);   // row-vector convention
+  o.Position = mul(wp, viewProj);
+  // ...
+  return o;
+}
+
+technique Instanced {   // the opt-in: the pipeline selects this technique for instanced draws
+  pass P0 {
+    VertexShader = compile VS_SHADERMODEL VS_Instanced();
+    PixelShader  = compile PS_SHADERMODEL PS_Main();
+  }
+}
+```
+
+> **Skinned + instanced is not supported.** There is no per-instance bone
+> palette; an animated crowd requires a separate scheme (e.g. a texture or
+> buffer of bone matrices indexed per instance). Until such a path exists, keep
+> animated models on non-instanced draws.
 
 ## `drawMeshEffect` (MonoGame only)
 

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -42,9 +42,9 @@ The shader language depends on your backend — this is the main place the two b
 
 | | raylib | MonoGame |
 |---|---|---|
-| Language | GLSL (`#version 330`) | HLSL (`.fx`, compiled to `.mgfx`) |
-| Loading | `Raylib.LoadShader` / `LoadShaderFromMemory` (GLSL strings/files) | `ShaderLoader.loadEffect gd name` (embedded compiled `.mgfx`) |
-| Content pipeline | None — plain `.fs`/`.vs` files or strings | The MonoGame content pipeline compiles `.fx` → `.mgfx` for DX11 (`.dx.mgfx`) and OpenGL (`.ogl.mgfx`) |
+| Language | GLSL (`#version 330`) | HLSL (`.fx`, compiled to `.xnb`) |
+| Loading | `Raylib.LoadShader` / `LoadShaderFromMemory` (GLSL strings/files) | The content pipeline: add the `.fx` to your `.mgcb`, then `assets.Effect(name)` |
+| Content pipeline | None — plain `.fs`/`.vs` files or strings | The MonoGame content pipeline compiles `.fx` → `.xnb` for DX11 and OpenGL |
 | Params | `Raylib.SetShaderValue` / `SetShaderValueMatrix` | Set parameters on the `Effect` object directly (`effect.Parameters.[name].SetValue(...)`) |
 
 ## Built-in shaders
@@ -82,17 +82,26 @@ void main() {
 let myShader = Raylib.LoadShaderFromMemory(null, fragCode)
 ```
 
-**MonoGame** — author an HLSL `.fx`, compile it to `.mgfx` (via the 2MGFX tool / content pipeline for both DX11 and OGL), then load it. For shaders embedded as resources, use `ShaderLoader.loadEffect`; for your own compiled `.mgfx` files, load the bytes and construct an `Effect` from the `GraphicsDevice`:
+**MonoGame** — author an HLSL `.fx` and build it through the **content pipeline** (the same pipeline that compiles your models/textures). Add the `.fx` to your `.mgcb` with the `EffectImporter` / `EffectProcessor`, which compiles it to a `.xnb` for both DirectX 11 and OpenGL, then load it like any other content asset:
+
+```
+#begin Toon.fx
+/importer:EffectImporter
+/processor:EffectProcessor
+/build:Toon.fx;Toon
+```
 
 ```fsharp
 open Microsoft.Xna.Framework.Graphics
 
-// Load a compiled effect from bytes (embed it or read it from disk)
-let effect = new Effect(gd, effectBytes)
-
-// Set a uniform
-effect.Parameters.["tint"].SetValue(Microsoft.Xna.Framework.Vector4(1f, 1f, 1f, 1f))
+// Loaded through the content pipeline, like a model or texture.
+let toonEffect = assets.Effect("Toon")
 ```
+
+> Effects are content: author `.fx`, add them to the `.mgcb`, and load via
+> `assets.Effect`. The framework's `ShaderLoader.loadEffect` is an internal path
+> for the built-in shaders it embeds as resources — your game effects go through
+> the content pipeline.
 
 ## Setting parameters
 
@@ -137,7 +146,7 @@ How you opt in with your own shading depends on the backend:
 **raylib (3D)** — `Draw3D.drawImmediate` runs raw rlgl/raylib calls (the pipeline's shader is bypassed for those draws). For a full custom pipeline, implement `IRenderPipeline3D`.
 
 **MonoGame (3D)** — two opt-in paths (no raylib equivalent):
-- `Draw3D.beginEffect effect` / `Draw3D.endEffect` — a **shading scope**: draws inside are shaded by your `Effect`, which *inherits* the scene data the pipeline gathered (camera matrices, lights, the shadow pass output, material, bones, frame time). Your effect only needs to declare the uniforms it consumes (e.g. `dirLightDir`, `boneMatrices`, `shadowViewProjs`, `time`, `texture5`); absent uniforms are skipped. Ideal for toon/cel/wireframe without re-implementing the gather.
+- `Draw3D.beginEffect effect` / `Draw3D.endEffect` — a **shading scope**: draws inside are shaded by your `Effect`, which *inherits* the scene data the pipeline gathered (camera matrices, lights, the shadow pass output, material, bones, frame time). Your effect only needs to declare the uniforms it consumes (e.g. `dirLightDir`, `boneMatrices`, `shadowViewProjs`, `shadowAtlas`, `time`); absent uniforms are skipped. Ideal for toon/cel/wireframe without re-implementing the gather.
 - `Draw3D.drawMeshEffect meshPart transform effect` — a fully user-owned effect (the pipeline sets only World/View/Projection; you own all lighting/material params).
 
 See [3D Rendering Overview](graphics3d/overview.html#escape-hatches) for examples.

--- a/src/Mibo.MonoGame/Graphics3D/Draw3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Draw3D.fs
@@ -293,12 +293,14 @@ module Draw3D =
   /// lights, the shadow pass output, material, bones, and the frame's elapsed <c>time</c>) is uploaded
   /// to the user effect by name via <see cref="T:Mibo.Elmish.Graphics3D.Pipelines.SceneUpload"/>: an
   /// effect that declares the matching uniforms (e.g. <c>dirLightDir</c>, <c>boneMatrices</c>,
-  /// <c>shadowViewProjs</c>, <c>texture5</c>, <c>time</c>) inherits and samples them; one that declares
+  /// <c>shadowViewProjs</c>, <c>shadowAtlas</c>, <c>time</c>) inherits and samples them; one that declares
   /// none of them is unaffected. So a toon/water scope can opt into shadows, skinned animation, and a
   /// shader animation clock simply by declaring those uniforms.
   /// <para>
-  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.drawInstanced"/> inside a scope falls back to the PBR
-  /// path — hardware instancing needs a per-instance vertex stream a generic inherited effect won't declare.
+  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.drawInstanced"/> inside a scope is shaded by the user
+  /// effect when it exposes an <c>Instanced</c> technique (the instancing opt-in); an effect that
+  /// doesn't falls back to the PBR instanced path. Skinned + instanced draws are not supported. See
+  /// <c>docs/graphics3d/instancing.md</c>.
   /// </para>
   /// </remarks>
   let inline beginEffect (effect: Effect) (buffer: RenderBuffer3D) =

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -106,6 +106,28 @@ type internal PbrResources() =
   // seen. A raw array (not ResizeArray) so we can pass it directly to CopyAbsoluteBoneTransformsTo.
   member val BoneTransforms = Array.zeroCreate<Matrix> 64 with get, set
 
+  /// <summary>User effects that have opted into instancing by exposing an <c>Instanced</c>
+  /// technique (the convention ForwardPbr.fx and Instanced.fx already use). Membership is probed
+  /// once per effect on first instanced draw inside a <c>beginEffect</c> scope; an effect that
+  /// doesn't expose the technique is absent and instanced draws fall back to the PBR instanced
+  /// path. See docs/graphics3d/instancing.md.</summary>
+  member val InstanceCapableEffects: System.Collections.Generic.HashSet<Effect> =
+    System.Collections.Generic.HashSet<Effect>() with get, set
+
+  /// <summary>True iff <paramref name="effect"/> has been seen to expose an <c>Instanced</c>
+  /// technique. Probes + memoizes on first lookup; returns false without probing again.</summary>
+  member this.IsInstanceCapable(effect: Effect) : bool =
+    if this.InstanceCapableEffects.Contains(effect) then
+      true
+    else
+      let capable =
+        not(obj.ReferenceEquals(effect.Techniques["Instanced"], null))
+
+      if capable then
+        this.InstanceCapableEffects.Add(effect) |> ignore
+
+      capable
+
 /// <summary>The extracted PBR draw handlers + the user-effect scope shading path.</summary>
 module internal PbrShading =
 
@@ -479,28 +501,29 @@ module internal PbrShading =
       mesh.Draw(gd, effect)
 
   /// <summary>
-  /// Handles <c>DrawInstanced</c>: native hardware instancing via two vertex streams (mesh + per-
-  /// instance VertexInstanceWorld rows). Prefers the PBR Instanced technique; falls back to minimal
-  /// Instanced.fx (flat albedo + 1 directional) when the PBR effect can't load.
+  /// Stages per-instance world matrices into the reusable <see cref="T:Mibo.Elmish.Graphics3D.VertexInstanceWorld"/>
+  /// buffer (growing it on demand), uploads them, and binds the two-stream vertex layout (mesh on
+  /// stream 0, per-instance rows on stream 1). Returns the clamped instance count (0 when there is
+  /// nothing to draw) and the instance vertex buffer. Shared by the PBR instanced path and the
+  /// user-effect instanced path so the two-stream bind lives in one place.
   /// </summary>
-  let drawInstanced
+  /// <remarks>Does not bind indices or draw — the caller selects its effect/technique, uploads
+  /// scene data, and issues <c>DrawInstancedPrimitives</c>.</remarks>
+  let stageInstanceData
     (
       gd: GraphicsDevice,
-      state: byref<ForwardState>,
-      frame: byref<ForwardFrame>,
       res: PbrResources,
       mesh: PrimitiveMesh,
       transforms: Matrix[],
-      material: Material3D,
       instanceCount: int
-    ) =
+    ) : struct (int * VertexBuffer) =
     // Clamp to the transforms array: an instanceCount larger than the buffer
     // would index out of range when staging per-instance world matrices.
     let instanceCount =
       min instanceCount (if isNull transforms then 0 else transforms.Length)
 
     if instanceCount <= 0 then
-      ()
+      struct (0, Unchecked.defaultof<VertexBuffer>)
     else
       if res.InstanceStaging.Length < instanceCount then
         res.InstanceStaging <-
@@ -546,6 +569,28 @@ module internal PbrShading =
         VertexBufferBinding(instVB, 0, 1)
       )
 
+      struct (instanceCount, instVB)
+
+  /// <summary>
+  /// Handles <c>DrawInstanced</c>: native hardware instancing via two vertex streams (mesh + per-
+  /// instance VertexInstanceWorld rows). Prefers the PBR Instanced technique; falls back to minimal
+  /// Instanced.fx (flat albedo + 1 directional) when the PBR effect can't load.
+  /// </summary>
+  let drawInstanced
+    (
+      gd: GraphicsDevice,
+      state: byref<ForwardState>,
+      frame: byref<ForwardFrame>,
+      res: PbrResources,
+      mesh: PrimitiveMesh,
+      transforms: Matrix[],
+      material: Material3D,
+      instanceCount: int
+    ) =
+    let struct (instanceCount, _instVB) =
+      stageInstanceData(gd, res, mesh, transforms, instanceCount)
+
+    if instanceCount > 0 then
       gd.Indices <- mesh.Indices
       let viewProj = state.View * state.Projection
 
@@ -656,8 +701,9 @@ module internal PbrShading =
   /// Shades a draw with a user-supplied <c>effect</c>: uploads the gathered scene data (matrices +
   /// material + lights + bones) via <see cref="M:Mibo.Elmish.Graphics3D.Pipelines.SceneUpload.uploadToEffect"/>
   /// (name-resolved; absent uniforms skipped), then draws through the effect's own CurrentTechnique.
-  /// The effect inherits scene DATA, not the PBR shader (v2 §3). DrawInstanced under a user scope
-  /// falls back to the PBR instanced path (instancing needs a vertex stream a generic effect won't declare).
+  /// The effect inherits scene DATA, not the PBR shader (v2 §3). DrawInstanced under a user scope is
+  /// shaded by the user effect when it exposes an <c>Instanced</c> technique (the instancing opt-in);
+  /// otherwise it falls back to the PBR instanced path. See docs/graphics3d/instancing.md.
   /// </summary>
   let shadeWithEffect
     (
@@ -929,7 +975,56 @@ module internal PbrShading =
             part.Effect <- saved
 
     | Command3D.DrawInstanced(mesh, transforms, material, count) ->
-      // Instancing under a user scope falls back to the PBR path (see remarks).
-      drawInstanced(gd, &state, &frame, res, mesh, transforms, material, count)
+      // Does the user effect opt into instancing? An effect exposing an `Instanced` technique
+      // (the convention ForwardPbr.fx and Instanced.fx already use) shades the instances directly;
+      // one that doesn't falls back to the PBR instanced path (see remarks).
+      if res.IsInstanceCapable(effect) then
+        let struct (instanceCount, _instVB) =
+          stageInstanceData(gd, res, mesh, transforms, count)
+
+        if instanceCount > 0 then
+          gd.Indices <- mesh.Indices
+
+          effect.CurrentTechnique <- effect.Techniques["Instanced"]
+
+          // matModel is identity: the per-instance world transform arrives on stream 1
+          // (VertexInstanceWorld rows), so a shader that still declares matModel sees a benign value.
+          SceneUpload.uploadToEffect(
+            gd,
+            effect,
+            state.View,
+            state.Projection,
+            camPos,
+            Matrix.Identity,
+            Matrix.Identity,
+            frame.Lights,
+            frame.Shadows,
+            ValueNone,
+            material,
+            frame.Time
+          )
+
+          for pass in effect.CurrentTechnique.Passes do
+            pass.Apply()
+
+            gd.DrawInstancedPrimitives(
+              PrimitiveType.TriangleList,
+              0,
+              0,
+              mesh.PrimitiveCount,
+              instanceCount
+            )
+      else
+        // Effect didn't opt in — fall back to the PBR instanced path (see remarks).
+        drawInstanced(
+          gd,
+          &state,
+          &frame,
+          res,
+          mesh,
+          transforms,
+          material,
+          count
+        )
 
     | _ -> ()

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -106,26 +106,27 @@ type internal PbrResources() =
   // seen. A raw array (not ResizeArray) so we can pass it directly to CopyAbsoluteBoneTransformsTo.
   member val BoneTransforms = Array.zeroCreate<Matrix> 64 with get, set
 
-  /// <summary>User effects that have opted into instancing by exposing an <c>Instanced</c>
-  /// technique (the convention ForwardPbr.fx and Instanced.fx already use). Membership is probed
-  /// once per effect on first instanced draw inside a <c>beginEffect</c> scope; an effect that
-  /// doesn't expose the technique is absent and instanced draws fall back to the PBR instanced
-  /// path. See docs/graphics3d/instancing.md.</summary>
-  member val InstanceCapableEffects: System.Collections.Generic.HashSet<Effect> =
-    System.Collections.Generic.HashSet<Effect>() with get, set
+  /// <summary>Per-effect memoization of the <c>Instanced</c>-technique probe (the convention
+  /// ForwardPbr.fx and Instanced.fx already use). Maps every effect seen on first instanced draw
+  /// inside a <c>beginEffect</c> scope to whether it exposes the technique, so neither outcome is
+  /// re-probed. An effect that doesn't expose it is absent and instanced draws fall back to the PBR
+  /// instanced path. See docs/graphics3d/instancing.md.</summary>
+  member val InstanceCapableEffects: System.Collections.Generic.Dictionary<
+    Effect,
+    bool
+   > = System.Collections.Generic.Dictionary<Effect, bool>() with get, set
 
   /// <summary>True iff <paramref name="effect"/> has been seen to expose an <c>Instanced</c>
-  /// technique. Probes + memoizes on first lookup; returns false without probing again.</summary>
+  /// technique. Probes + memoizes on first lookup (both outcomes); subsequent lookups are a
+  /// dictionary read, never a re-probe.</summary>
   member this.IsInstanceCapable(effect: Effect) : bool =
-    if this.InstanceCapableEffects.Contains(effect) then
-      true
-    else
+    match this.InstanceCapableEffects.TryGetValue(effect) with
+    | true, capable -> capable
+    | false, _ ->
       let capable =
         not(obj.ReferenceEquals(effect.Techniques["Instanced"], null))
 
-      if capable then
-        this.InstanceCapableEffects.Add(effect) |> ignore
-
+      this.InstanceCapableEffects[effect] <- capable
       capable
 
 /// <summary>The extracted PBR draw handlers + the user-effect scope shading path.</summary>

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs
@@ -41,11 +41,13 @@ open Mibo.Elmish.Graphics3D
 /// <para>
 /// <b>Shadows are opt-in by declaration.</b> A user effect that wants shadow sampling declares the
 /// shadow uniforms (<c>shadowViewProjs</c>, <c>shadowUVOffsets</c>, <c>shadowTexelSize</c>,
-/// <c>dirLightCastsShadows</c>, <c>pointLightShadowIdx</c>, <c>spotLightShadowIdx</c>) and a
-/// <c>texture5</c> sampler; when the frame's shadow pass produced an atlas, those uniforms are
-/// uploaded by name and the atlas is bound to sampler slot 5 (PointClamp). An effect that declares
-/// none of them renders unshadowed — no cost, no sampling. When the frame has no shadow-casting
-/// light, <c>dirLightCastsShadows</c> is set to 0 and nothing else shadow-related is uploaded.
+/// <c>shadowBiases</c>, <c>dirLightCastsShadows</c>, <c>pointLightShadowIdx</c>,
+/// <c>spotLightShadowIdx</c>) and a
+/// <c>shadowAtlas</c> sampler (declared as <c>sampler2D shadowAtlas : register(s5)</c>); when the
+/// frame's shadow pass produced an atlas, those uniforms are uploaded by name and the atlas is bound
+/// to the sampler at slot 5 (PointClamp). An effect that declares none of them renders unshadowed —
+/// no cost, no sampling. When the frame has no shadow-casting light,
+/// <c>dirLightCastsShadows</c> is set to 0 and nothing else shadow-related is uploaded.
 /// </para>
 /// </remarks>
 module SceneUpload =
@@ -96,8 +98,8 @@ module SceneUpload =
     if not(obj.ReferenceEquals(p, null)) then
       p.SetValue v
 
-  /// <summary>Binds the shadow atlas to a named sampler texture param (texture5 slot).</summary>
-  let inline private setTex5 (pp: EffectParameter) (tex: Texture2D) =
+  /// <summary>Binds the shadow atlas to the effect's named shadow sampler param.</summary>
+  let inline private setShadowAtlas (pp: EffectParameter) (tex: Texture2D) =
     if not(obj.ReferenceEquals(pp, null)) then
       pp.SetValue tex
 
@@ -315,10 +317,13 @@ module SceneUpload =
       setMatrixArray (p "shadowViewProjs") s.ViewProjs
       setVec4Array (p "shadowUVOffsets") s.UVOffsets
       setVec2 (p "shadowTexelSize") (Vector2(s.TexelSize, s.TexelSize))
-      // Bind the atlas to the effect's own sampler param (texture5) — like the material maps, the
-      // sampler is read from the effect's parameters at Apply(), not gd.Textures[]. Also set slot 5
-      // so an effect that samples the atlas via the fixed texture slot (not a named param) works.
-      setTex5 (p "texture5") s.Atlas
+      setFloatArray (p "shadowBiases") s.Biases
+      // Bind the atlas to the effect's shadow sampler param. The atlas sampler is named
+      // "shadowAtlas" in the convention ForwardPbr.fx uses (sampler2D shadowAtlas : register(s5))
+      // — NOT "texture5": mgfxc exposes the sampler under its HLSL name, so resolving "texture5"
+      // returns null. The slot-5 bind below is a fallback for effects that don't expose a named
+      // param (and makes the register(s5) in the shader pick it up regardless).
+      setShadowAtlas (p "shadowAtlas") s.Atlas
       gd.Textures[5] <- s.Atlas
       gd.SamplerStates[5] <- SamplerState.PointClamp
     | ValueNone -> setInt (p "dirLightCastsShadows") 0

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -941,6 +941,7 @@ module internal ShadowPass =
                 UVOffsets = res.UVOffsetsScratch
                 ActiveCasterCount = active
                 TexelSize = texel
+                Biases = res.BiasesScratch
                 DirLightCastsShadows = hasDirCaster
                 PointLightShadowIdx = res.PointShadowSlots
                 SpotLightShadowIdx = res.SpotShadowSlots

--- a/src/Mibo.MonoGame/Graphics3D/SceneContext.fs
+++ b/src/Mibo.MonoGame/Graphics3D/SceneContext.fs
@@ -97,6 +97,10 @@ type ShadowResult = {
   /// <summary><c>1.0f / atlasResolution</c> — for the <c>shadowTexelSize</c> PCF spread.</summary>
   TexelSize: float32
 
+  /// <summary>The per-caster receiver-side bias (<c>shadowBiases[]</c>), preventing self-shadow
+  /// acne when a surface both casts and receives (e.g. the instanced floor).</summary>
+  Biases: float32[]
+
   /// <summary>Whether the directional light casts shadows (the <c>dirLightCastsShadows</c> flag).</summary>
   DirLightCastsShadows: bool
 

--- a/src/Mibo.Raylib/Graphics3D/Draw3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/Draw3D.fs
@@ -213,8 +213,10 @@ module Draw3D =
   /// is unaffected. So a toon/water scope can opt into shadows, skinned animation, and a shader
   /// animation clock simply by declaring those uniforms.
   /// <para>
-  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.drawMeshInstanced"/> inside a scope falls back to the PBR
-  /// path — hardware instancing needs a per-instance vertex stream a generic inherited shader won't declare.
+  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.drawMeshInstanced"/> inside a scope is shaded by the
+  /// user shader when it declares <c>in mat4 instanceTransform;</c> (the instancing opt-in); a shader
+  /// that doesn't declare it falls back to the PBR instanced path. Skinned + instanced draws are not
+  /// supported. See <c>docs/graphics3d/instancing.md</c>.
   /// </para>
   /// </remarks>
   let inline beginEffect (shader: Shader) (buffer: RenderBuffer3D) =

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -1741,6 +1741,12 @@ type ForwardPipelineBase
   let mutable userEffectMaterial: Material = Unchecked.defaultof<Material>
   let mutable userEffectMaterialCreated = false
 
+  // Resolved `instanceTransform` attribute location per user shader Id, memoized on the first
+  // instanced draw inside a beginEffect/endEffect scope (-1 = the shader doesn't declare the
+  // attribute -> no opt-in -> instanced draws fall back to the PBR instanced path). Mirrors the
+  // MonoGame IsInstanceCapable memoization.
+  let mutable instanceAttrLocs: Dictionary<uint, int> = Dictionary<uint, int>()
+
   // Per-light shadow caster slot mapping (computed in runShadowPass, read in uploadLights).
   // Indexed by lights.PointLights/SpotLights buffer position; -1 = no shadow. Reallocated per
   // frame to match the live light counts.
@@ -1848,7 +1854,9 @@ type ForwardPipelineBase
 
   /// <summary>
   /// Default shading: PBR cached fast path (ValueNone) or name-resolved SceneUpload to the
-  /// user shader (ValueSome). DrawMeshInstanced under a user scope falls back to PBR.
+  /// user shader (ValueSome). DrawMeshInstanced under a user scope is shaded by the user shader
+  /// when it opts into instancing (<c>in mat4 instanceTransform;</c>); otherwise it falls back
+  /// to the PBR instanced path.
   /// </summary>
   default this.Shade(frame, activeEffect, currentCamera, draw) =
     match activeEffect with
@@ -1931,8 +1939,9 @@ type ForwardPipelineBase
   /// <summary>
   /// Shades a draw with a user-supplied shader via name-resolved SceneUpload. The shader inherits
   /// scene data (camera/lights/material/bones/time), NOT the PBR shader itself. DrawMeshInstanced
-  /// falls back to the PBR path (hardware instancing needs a per-instance vertex stream a generic
-  /// inherited shader won't declare).
+  /// under a user scope is shaded by the user shader when it opts into instancing
+  /// (<c>in mat4 instanceTransform;</c>); otherwise it falls back to the PBR instanced path. See
+  /// docs/graphics3d/instancing.md.
   /// </summary>
   member private _.shadeWithEffect
     (
@@ -2057,25 +2066,62 @@ type ForwardPipelineBase
       Raylib.DrawMesh(mesh, userEffectMaterial, transform)
 
     | Command3D.DrawMeshInstanced(mesh, transforms, material, instanceCount) ->
-      // Instancing under a user scope falls back to the PBR path (see remarks).
-      Raylib.EndShaderMode()
+      // Resolve (and memoize) the shader's `instanceTransform` attribute — the raylib opt-in for
+      // instancing under a user scope. A shader that declares it shades its own instances; one
+      // that doesn't falls back to the PBR instanced path.
+      let attrLoc =
+        match instanceAttrLocs.TryGetValue userShader.Id with
+        | true, loc -> loc
+        | false, _ ->
+          let loc =
+            Raylib.GetShaderLocationAttrib(userShader, "instanceTransform")
 
-      handleDrawMeshInstanced(
-        instancedShader,
-        &instanced,
-        frame.Lights,
-        maxPt,
-        maxSp,
-        frame.PointShadowSlots,
-        frame.SpotShadowSlots,
-        currentCamera,
-        mesh,
-        transforms,
-        material,
-        instanceCount
-      )
+          instanceAttrLocs[userShader.Id] <- loc
+          loc
 
-      Raylib.BeginShaderMode userShader
+      if attrLoc >= 0 then
+        // Opt-in: raylib streams the per-instance world matrix through the attribute the shader's
+        // Locs[MatrixModel] slot points at. Point that slot at `instanceTransform` for the duration
+        // of the draw (restoring it afterward so a non-instanced draw in the same scope still
+        // auto-uploads matModel). matModel is identity — the per-instance transform IS the model
+        // matrix; viewProj is view-projection only.
+        let matModelSlot = int ShaderLocationIndex.MatrixModel
+        let savedLoc = NativePtr.get userShader.Locs matModelSlot
+
+        NativePtr.set userShader.Locs matModelSlot attrLoc
+
+        try
+          upload Matrix4x4.Identity material ValueNone
+          populateMaps material
+
+          Raylib.DrawMeshInstanced(
+            mesh,
+            userEffectMaterial,
+            transforms,
+            instanceCount
+          )
+        finally
+          NativePtr.set userShader.Locs matModelSlot savedLoc
+      else
+        // No opt-in — fall back to the PBR instanced path (see remarks).
+        Raylib.EndShaderMode()
+
+        handleDrawMeshInstanced(
+          instancedShader,
+          &instanced,
+          frame.Lights,
+          maxPt,
+          maxSp,
+          frame.PointShadowSlots,
+          frame.SpotShadowSlots,
+          currentCamera,
+          mesh,
+          transforms,
+          material,
+          instanceCount
+        )
+
+        Raylib.BeginShaderMode userShader
 
     | _ -> ()
 
@@ -2249,6 +2295,7 @@ type ForwardPipelineBase
             UVOffsets = shadowAtlas.UVOffsets
             ActiveCasterCount = shadowAtlas.ActiveCasterCount
             TexelSize = 1.0f / float32 atlasCfg.Resolution
+            Biases = shadowAtlas.Biases
             DirLightCastsShadows =
               lights.DirLights.Count > 0 && lights.DirLights[0].CastsShadows
             PointLightShadowIdx = pointShadowSlots

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/SceneUpload.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/SceneUpload.fs
@@ -37,13 +37,13 @@ open Mibo.Elmish.Graphics3D
 /// (<c>albedoColor</c>, <c>texture0..4</c>, <c>roughness</c>/<c>metallic</c>/<c>emissionColor</c>/
 /// <c>opacity</c>/<c>tiling</c>/<c>useNormalMap</c>), lights (ambient + 1 directional + N point +
 /// M spot, including per-light shadow indices), shadows (the atlas + <c>shadowViewProjs[]</c>/
-/// <c>shadowUVOffsets[]</c>/<c>shadowTexelSize</c>/<c>dirLightCastsShadows</c>, when the frame has a
+/// <c>shadowUVOffsets[]</c>/<c>shadowBiases[]</c>/<c>dirLightCastsShadows</c>, when the frame has a
 /// <see cref="T:Mibo.Elmish.Graphics3D.Pipelines.ShadowResult"/>), and bones
 /// (<c>boneMatrices</c>, only when supplied).
 /// </para>
 /// <para>
 /// <b>Shadows are opt-in by declaration.</b> A user shader that wants shadow sampling declares the
-/// shadow uniforms (<c>shadowViewProjs[]</c>, <c>shadowUVOffsets[]</c>, <c>shadowTexelSize</c>,
+/// shadow uniforms (<c>shadowViewProjs[]</c>, <c>shadowUVOffsets[]</c>, <c>shadowBiases[]</c>,
 /// <c>dirLightCastsShadows</c>, <c>pointLightShadowIdx[]</c>, <c>spotLightShadowIdx[]</c>) and a
 /// <c>shadowAtlas</c> sampler; when the frame's shadow pass produced an atlas, those uniforms are
 /// uploaded by name and the atlas is bound to sampler slot 15. A shader that declares none of them
@@ -305,6 +305,9 @@ module SceneUpload =
 
         if i < s.UVOffsets.Length then
           setVec4 shader (loc shader $"shadowUVOffsets[%d{i}]") s.UVOffsets[i]
+
+        if i < s.Biases.Length then
+          setFloat shader (loc shader $"shadowBiases[%d{i}]") s.Biases[i]
 
       // Bind the atlas to texture slot 15 (the raylib convention the PBR path uses).
       if s.Atlas.Id <> 0u then

--- a/src/Mibo.Raylib/Graphics3D/SceneContext.fs
+++ b/src/Mibo.Raylib/Graphics3D/SceneContext.fs
@@ -101,6 +101,10 @@ type ShadowResult = {
   /// <summary><c>1.0f / atlasResolution</c> — for the <c>shadowTexelSize</c> PCF spread.</summary>
   TexelSize: float32
 
+  /// <summary>The per-caster receiver-side bias (<c>shadowBiases[]</c>), preventing self-shadow
+  /// acne when a surface both casts and receives (e.g. the instanced floor).</summary>
+  Biases: float32[]
+
   /// <summary>Whether the directional light casts shadows (the <c>dirLightCastsShadows</c> flag).</summary>
   DirLightCastsShadows: bool
 


### PR DESCRIPTION
## Summary

Instanced draws inside a `Draw3D.beginEffect`/`endEffect` scope are now shaded by the user's own shader/effect when it opts into instancing, instead of always falling back to the built-in PBR instanced path. Also fixes shadow sampling for the `beginEffect` scope and corrects the shader-loading guidance.

## What changed

### Instancing opt-in for `beginEffect` (Added)

Previously, `DrawMeshInstanced`/`DrawInstanced` inside a `beginEffect` scope always fell back to the PBR instanced path on both backends. Now the user shader/effect can opt in:

- **raylib** — declare `in mat4 instanceTransform;`. The pipeline resolves the attribute once per shader (`GetShaderLocationAttrib`), points the shader's `Locs[ShaderLocationIndex.MatrixModel]` slot at it for the duration of the instanced draw, and restores it afterward. `viewProj` is view-projection only; `matModel` is identity.
- **MonoGame** — expose a technique named `Instanced` reading the per-instance matrix as four `float4` rows on `TEXCOORD1..4` (the `VertexInstanceWorld` layout). The pipeline memoizes capability (`IsInstanceCapable`) and routes capable effects through the two-stream bind.

Effects that don't opt in are unaffected and keep the PBR-instanced fallback. Skinned + instanced is not supported.

### Shadow sampling for `beginEffect` (Fixed)

A user shader opting into shadows via `beginEffect` was broken in three ways, all now fixed:

1. `SceneUpload` (the `beginEffect` upload path) never uploaded `shadowBiases[]` — only the PBR pipeline's own uniform cache did. `ShadowResult` didn't even carry the field.
2. On MonoGame, `SceneUpload` bound the atlas under the wrong sampler name (`texture5`) — `mgfxc` exposes samplers under their HLSL name, so the bind silently no-op'd (it only worked by accident via the fixed slot-5 bind). Now resolves `shadowAtlas`, matching the built-in `ForwardPbr.fx`.
3. `shader-uniforms.md` documented the wrong MonoGame sampler name.

Both `ShadowResult` types gain a `Biases` field; both `SceneUpload` modules upload `shadowBiases` per caster.

### Docs

- `shaders.md` — replaced the precompiled-`Effect`/`new Effect(gd, bytes)`/`ShaderLoader.loadEffect` guidance with the content-pipeline path (MGCB `EffectImporter`/`EffectProcessor` → `assets.Effect`). MonoGame loads effects through the content pipeline like any other asset.
- `shader-uniforms.md` — added `shadowBiases` to the shadow table; corrected the sampler name to `shadowAtlas` on both backends.
- `instancing.md` — "Shading instances with a custom effect" section.
- `AGENTS.md` — instancing opt-in contract for contributors.
- `migration-from-monogame.md` — corrected `.mgfx` → content-pipeline `.xnb`.

## Validation

- Built `Mibo.Raylib` and `Mibo.MonoGame` clean (0 errors).
- `dotnet fantomas .` — all 149 files conform.
- Validated end-to-end in the samples (separate samples PR): a toon shader shades the instanced block pass through the opt-in path on both raylib (GLSL `in mat4 instanceTransform;`) and MonoGame (HLSL `Instanced` technique), with shadows sampling correctly (raylib uses the in-shader slope-scale bias via `dFdx`/`dFdy`; MonoGame uses the receiver-side `shadowBiases` + Y-flip, matching `ForwardPbr.fx`).

## Breaking changes

None. The instancing path is opt-in; effects that don't declare the opt-in keep the existing PBR-instanced fallback. `ShadowResult` gains a field, but it's only constructed internally.
