### PR TITLE
feat: 2D sampler control, MonoGame template restructure, docs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,18 @@
 
 - **3D:** instanced draws inside a `beginEffect`/`endEffect` scope are now shaded by your own shader/effect when it opts into instancing — raylib declares `in mat4 instanceTransform;`, MonoGame exposes an `Instanced` technique. Effects that don't opt in keep the previous PBR-instanced fallback. Skinned + instanced isn't supported (no per-instance bone palette). See the "Instancing (opt-in)" section of `docs/shader-uniforms.md`.
 
+- **MonoGame 2D:** `Draw.setSamplerState` sets the sprite-batch sampler state for subsequent sprites (e.g. `SamplerState.PointClamp`), mirroring `setBlend` — use it to stop tiles sampled from a gutterless spritesheet from bleeding at the edges. It flushes the batch on change and defaults to the previous behavior (`SamplerState.LinearClamp`). On raylib, use the new `Texture.filter` helper instead.
+- **Raylib:** a `Texture` helper module lets you configure a loaded texture's sampler in a pipe — `filter`, `wrap`, and `mipmaps` (e.g. `assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point`, or `|> Texture.wrap TextureWrap.Repeat`). These override the load-time trilinear+mipmaps default (needed for point-filtered tile atlases and repeating backgrounds). MonoGame controls sampling per draw via `Draw.setSamplerState` instead.
+
+### Changed
+
+- **Templates:** the MonoGame 2D and 3D templates now keep the shared library under `src/`, ship the MonoGame content pipeline (`Content/Content.mgcb`, built by each thin client via `MonoGame.Content.Builder.Task`), and expose `create()` as a ready-to-run `MonoGameProgram` with the content root already configured — the thin clients just construct `MiboGame` and run, instead of each wiring up `MonoGameProgram.ofProgram`.
+
 ### Fixed
 
 - **3D:** a custom `beginEffect`/`endEffect` shader/effect that opts into shadows now receives them correctly. The scene-upload path bound the shadow atlas under the wrong sampler name on MonoGame (`texture5` instead of `shadowAtlas` — the name `mgfxc` exposes samplers under), never uploaded the per-caster `shadowBiases`, and omitted the bias from the `ShadowResult` bundle entirely. Declare `sampler2D shadowAtlas : register(s5)` (MonoGame) / the `shadowAtlas`/`shadowBiases` uniforms (raylib) to opt in.
+
+- **Docs:** asset access in the program/assets/animation guides pointed at a non-existent `ctx.Assets` member — fixed to `GameContext.getService<IAssets> ctx`. The Core layout APIs (`CellGrid2D`/`LayeredGrid2D`) always take `System.Numerics.Vector2`, which collides with `Microsoft.Xna.Framework.Vector2` in MonoGame projects; the layout and camera guides now flag this and qualify the calls. The `SpriteState` reference now lists every field (`Rotation`/`Origin`/`NormalMap`), not just `Color`/`Layer`.
 
 ## [2.0.0-rc-001] - 2026-07-01
 

--- a/docs/animation.md
+++ b/docs/animation.md
@@ -220,12 +220,13 @@ let sprite = oldSprite |> AnimatedSprite.playByIndex walkIndex
 
 Mibo is format-agnostic: a `SpriteSheet` is simply a **Texture** plus a set of **Source Rectangles**.
 
-The concrete types are backend-native: `Texture2D`/`Rectangle` from `Raylib_cs` (raylib) or `Microsoft.Xna.Framework` (MonoGame). Load them via `ctx.Assets.Texture(...)`:
+The concrete types are backend-native: `Texture2D`/`Rectangle` from `Raylib_cs` (raylib) or `Microsoft.Xna.Framework` (MonoGame). Obtain them via the service registry — `GameContext.getService<IAssets> ctx` — then call its loaders:
 
 ```fsharp
 // Example: pseudo-code for a custom loader
 let loadHero (ctx: GameContext) =
-    let tex = ctx.Assets.Texture("hero_atlas")  // raylib: "hero_atlas.png"; MonoGame: "hero_atlas" (content name)
+    let assets = GameContext.getService<IAssets> ctx
+    let tex = assets.Texture("hero_atlas")  // raylib: "hero_atlas.png"; MonoGame: "hero_atlas" (content name)
     let frames = MyJsonParser.parse "hero_metadata.json"
     SpriteSheet.fromFrames tex (Vector2(32.f, 32.f)) frames
 ```

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -46,15 +46,16 @@ Access assets through the `GameContext`. The `path` convention differs by backen
 
 ```fsharp
 let init (ctx: GameContext): struct(Model * Cmd<Msg>) =
+  let assets = GameContext.getService<IAssets> ctx
   // raylib: paths are loose files on disk
-  let player = ctx.Assets.Texture("sprites/player.png")
-  let font = ctx.Assets.Font("fonts/ui.ttf")
-  let enemyModel = ctx.Assets.Model("models/enemy.glb")
+  let player = assets.Texture("sprites/player.png")
+  let font = assets.Font("fonts/ui.ttf")
+  let enemyModel = assets.Model("models/enemy.glb")
 
   // MonoGame: paths are content-pipeline asset names (no extension);
   // the .xnb must be built by the MonoGame content pipeline.
-  // let player = ctx.Assets.Texture("sprites/player")
-  // let font = ctx.Assets.Font("fonts/ui")
+  // let player = assets.Texture("sprites/player")
+  // let font = assets.Font("fonts/ui")
   ...
 ```
 
@@ -74,7 +75,25 @@ let init (ctx: GameContext): struct(Model * Cmd<Msg>) =
 > include the raw file in the output directory (e.g. `<CopyToOutputDirectory>` / `<Content>` in
 > the `.fsproj`).
 
-## Backend-neutral caching (`IAssetCache`)
+## Texture configuration (raylib)
+
+The raylib loader generates mipmaps and forces **trilinear** filtering on every texture at load time — good for 3D/PBR surfaces, but it makes tiles sampled from a gutterless spritesheet bleed at the edges. A texture's filter is a property of the texture itself (not the draw batch), so override it per texture with the `Texture` helper module:
+
+```fsharp
+let assets = GameContext.getService<IAssets> ctx
+// Point (nearest) filtering — stops adjacent tiles bleeding into each other.
+let atlas = assets.Texture("tiles.png") |> Texture.filter TextureFilter.Point
+```
+
+| Helper | Description |
+|--------|-------------|
+| `Texture.filter TextureFilter.Point tex` | Set the texture's filter (overrides the load-time trilinear default) |
+| `Texture.wrap TextureWrap.Repeat tex` | Set the wrap/addressing mode (Clamp/Repeat/MirrorClamp/MirrorRepeat) |
+| `Texture.mipmaps tex` | Generate mipmaps (the loader already does this on load) |
+
+Apply it once (e.g. in `init`) — not every frame — since it mutates the cached texture's sampler. (`TextureFilter` is `Raylib_cs.TextureFilter`: `Point`, `Bilinear`, `Trilinear`, `Aniso4x/8x/16x`; `TextureWrap` is `Raylib_cs.TextureWrap`: `Clamp`, `Repeat`, `MirrorClamp`, `MirrorRepeat`.) MonoGame controls sampling per draw via `Draw.setSamplerState` instead; see [2D Buffer & Commands](graphics2d/buffer-and-commands.html).
+
+
 
 The inherited `IAssetCache` members work on any backend and let portable code cache custom
 assets without referencing backend types:
@@ -101,7 +120,8 @@ let config = cache.GetOrCreate("gameConfig", fun () -> loadConfig())
 **Clearing caches:**
 
 ```fsharp
-ctx.Assets.Dispose()
+let assets = GameContext.getService<IAssets> ctx
+assets.Dispose()
 ```
 
 This unloads all GPU resources and clears all caches.

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -43,6 +43,8 @@ let camera = Camera2D.create (Vector2(400f, 300f)) 1.0f viewportSize
 - `zoom` — zoom factor (`1.0f` = no zoom)
 - `viewportSize` — screen size in pixels (used to compute the offset)
 
+> _**NOTE — vector types.**_ Each backend's `Camera2D.create`/`Camera3D` takes that backend's native vector type — raylib uses `System.Numerics`, MonoGame uses `Microsoft.Xna.Framework` — so make sure the matching namespace is `open`. (The `Vector3(...)` used by `Camera3D` follows the same rule.) Note that the Core layout APIs (`CellGrid2D`, `LayeredGrid2D`) always take `System.Numerics.Vector2` and must be explicitly qualified in MonoGame projects; see the note on the [2D Layout Engine](level-design/2d/core.html) page.
+
 ### Using in a view
 
 Wrap your world-space draw commands between `beginCamera` and `endCamera`. The `layer` parameter controls draw order — camera and content must share the same layer range.

--- a/docs/graphics2d/buffer-and-commands.md
+++ b/docs/graphics2d/buffer-and-commands.md
@@ -104,6 +104,7 @@ All commands live in two modules in `Mibo.Elmish.Graphics2D`:
 | | `Draw.clearScissor layer` | Disable scissor |
 | | `Draw.setLineWidth layer width` | Set line thickness |
 | | `Draw.setViewport layer (x, y, w, h)` | Set viewport |
+| | `Draw.setSamplerState layer sampler` | Set sprite sampler (MonoGame) |
 | **Clear** | `Draw.clear layer color` | Clear background |
 | **Immediate** | `Draw.drawImmediate layer action` | Escape hatch (see [Custom Commands](custom-commands.html)) |
 
@@ -133,9 +134,23 @@ buffer
 
 Blend mode, scissor rect, line width, and viewport are reset at the start of each frame.
 
+### Sampler state (MonoGame only)
+
+`Draw.setSamplerState layer sampler` sets the sampler used for subsequent sprites, modeled on `setBlend`. It applies to subsequent draws and flushes/restarts the sprite batch. This is **MonoGame-only** — `SamplerState` is `Microsoft.Xna.Framework.Graphics.SamplerState` (e.g. `SamplerState.PointClamp`, `SamplerState.LinearClamp`).
+
+```fsharp
+buffer
+|> Draw.setSamplerState 0<RenderLayer> SamplerState.PointClamp
+|> Draw.sprite (SpriteState.create (atlas, dest, src))
+```
+
+The sampler defaults to `SamplerState.LinearClamp` and is reset each frame, alongside blend mode, scissor, line width, and viewport.
+
+> **raylib** has no equivalent command — a texture's filter is a property of the texture, not the batch. Override the load-time default with the `Texture.filter` helper: `assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point` (apply once at load/init, not per frame). See [Assets](../assets.html).
+
 ## Text and sprite state types
 
-Sprite and text use state records. Use the `create` builders for quick setup:
+Sprite and text use state records. Use the `create` builders for quick setup. A `SpriteState` exposes the full field set: `Texture`, `Dest`, `Source`, `Origin`, `Rotation` (radians), `Color`, `Layer`, and `NormalMap` (for 2D lighting).
 
 ```fsharp
 // Sprite: texture + destination + source rect
@@ -143,6 +158,9 @@ let sprite = SpriteState.create(tex, Rectangle(100f, 100f, 32f, 32f), Rectangle(
 
 // Sprite with custom color
 let redSprite = { sprite with Color = Color.Red; Layer = 10<RenderLayer> }
+
+// SpriteState also exposes Rotation (radians), Origin (pivot, pixels), and NormalMap (2D lighting).
+let spinning = { sprite with Rotation = 0.785f } // ~45 degrees
 
 // Text: font + string + position
 let scoreText = TextState.create(font, "Score: 100", Vector2(10f, 10f))

--- a/docs/graphics2d/performance.md
+++ b/docs/graphics2d/performance.md
@@ -66,7 +66,7 @@ buffer |> Draw.drawImmediate 10<RenderLayer> (fun () ->
 
 ## 5. Minimize state-switching commands
 
-Commands like `setBlend`, `setScissor`, `beginCamera`, and `beginShader` flush the draw batch. Group draw calls that share state together:
+Commands like `setBlend`, `setSamplerState`, `setScissor`, `beginCamera`, and `beginShader` flush the draw batch. Group draw calls that share state together:
 
 ```fsharp
 // Good: one blend switch for all additive particles
@@ -80,6 +80,22 @@ buffer
 ## 6. Share textures and fonts
 
 The backend's internal batching is most efficient when consecutive draw calls use the same texture. Sort your commands by texture where practical (though the renderer sorts by layer, so consider arranging layers to keep same-texture draws together).
+
+## Tile-atlas bleeding
+
+Tiles sampled from a gutterless spritesheet (no padding between tiles) bleed at the edges under linear filtering, producing dark seams between abutting tiles.
+
+**MonoGame:** use `Draw.setSamplerState layer SamplerState.PointClamp` for the tile draws — point filtering reads exact texels, so there's no bleed. Note it flushes the batch, so group tile draws together. Alternatively, inset each tile's source rectangle by 1px.
+
+```fsharp
+// Point filtering stops adjacent tiles from bleeding into each other.
+buffer |> Draw.setSamplerState 0<RenderLayer> SamplerState.PointClamp
+
+for tile in visibleTiles do
+    buffer |> Draw.sprite (SpriteState.create (atlas, tile.Dest, tile.Src)) |> ignore
+```
+
+**raylib:** there is no per-draw sampler — a texture's filter is set on the texture itself. Use the `Texture.filter` helper once at load time (e.g. `assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point`), or inset source rectangles by 1px.
 
 ## 7. The buffer is allocation-free after warmup
 

--- a/docs/level-design/2d/core.md
+++ b/docs/level-design/2d/core.md
@@ -9,6 +9,13 @@ index: 21
 
 The Layout engine provides a tile-based level design system for 2D games. It lives in `Mibo.Layout`.
 
+> **`Vector2` namespace (MonoGame).** The Core layout APIs (`CellGrid2D`, `LayeredGrid2D`, and the 3D variants) always take `System.Numerics.Vector2`. MonoGame projects `open Microsoft.Xna.Framework`, so a bare `Vector2(...)` resolves to XNA's vector type and the Core layout calls fail to compile (`FS0193`). Qualify those calls explicitly:
+> ```fsharp
+> let grid =
+>     CellGrid2D.create 100 50 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
+> ```
+> Backend-specific APIs (each backend's `Camera2D.create`/`Camera3D`, `SpriteState`, `TextState`) use that backend's native vector type — raylib uses `System.Numerics`, MonoGame uses `Microsoft.Xna.Framework` — so bare `Vector2(...)` is fine there as long as the matching namespace is open.
+
 ## Core Concepts
 
 The system is built on three primitives:
@@ -26,7 +33,7 @@ open Mibo.Layout
 open System.Numerics
 
 // Create a 100x50 grid with 32x32 pixel cells
-let grid = CellGrid2D.create 100 50 (Vector2(32f, 32f)) Vector2.Zero
+let grid = CellGrid2D.create 100 50 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
 ```
 
 Each cell holds `'T voption` - either `ValueSome content` or `ValueNone` (empty). This struct-based option type has zero heap allocation per cell.
@@ -43,7 +50,7 @@ match CellGrid2D.get 5 3 grid with
 | ValueNone -> // empty
 
 // Get world position for a cell
-let worldPos = CellGrid2D.getWorldPos 5 3 grid  // Vector2(160f, 96f)
+let worldPos = CellGrid2D.getWorldPos 5 3 grid  // System.Numerics.Vector2(160f, 96f)
 ```
 
 ### Iteration
@@ -84,7 +91,7 @@ The `Layout` module provides a fluent DSL for placing content. All functions ret
 open Mibo.Layout
 
 let myGrid =
-    CellGrid2D.create 20 15 (Vector2(32f, 32f)) Vector2.Zero
+    CellGrid2D.create 20 15 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> Layout.run (fun section ->
         section
         |> Layout.fill 0 0 20 15 FloorTile      // Fill entire area
@@ -178,7 +185,7 @@ For multi-layer content (background, foreground, decorations), use `LayeredGrid2
 
 ```fsharp
 let level =
-    LayeredGrid2D.create 100 50 (Vector2(32f, 32f)) Vector2.Zero
+    LayeredGrid2D.create 100 50 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> LayeredLayout.layer 0 (fun section ->
         // Layer 0: Ground/Collision
         section |> Layout.fill 0 45 100 5 GroundTile

--- a/docs/level-design/2d/platformer.md
+++ b/docs/level-design/2d/platformer.md
@@ -23,7 +23,7 @@ Most platformer levels start with a foundation - ground, walls, and platforms:
 
 ```fsharp
 let basicLevel =
-    CellGrid2D.create 100 20 (Vector2(32f, 32f)) Vector2.Zero
+    CellGrid2D.create 100 20 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> Layout.run (fun section ->
         section
         // Ground floor
@@ -217,7 +217,7 @@ Use `LayeredGrid2D` for separate collision, decoration, and entity layers:
 
 ```fsharp
 let layeredPlatformer =
-    LayeredGrid2D.create 100 25 (Vector2(32f, 32f)) Vector2.Zero
+    LayeredGrid2D.create 100 25 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> LayeredLayout.layer 0 (fun section ->
         // Layer 0: Collision (walls, platforms, hazards)
         section
@@ -319,7 +319,7 @@ let levelSection section =
     |> Layout.section 83 5 (Layout.set 0 0 ChestTile)
 
 let level =
-    CellGrid2D.create 100 20 (Vector2(32f, 32f)) Vector2.Zero
+    CellGrid2D.create 100 20 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> Layout.run levelSection
 ```
 

--- a/docs/level-design/2d/topdown.md
+++ b/docs/level-design/2d/topdown.md
@@ -23,7 +23,7 @@ Every top-down level starts with rooms:
 
 ```fsharp
 let singleRoom =
-    CellGrid2D.create 20 15 (Vector2(32f, 32f)) Vector2.Zero
+    CellGrid2D.create 20 15 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> Layout.run (fun section ->
         section
             |> TopDown.room 12 8 FloorTile WallTile
@@ -298,7 +298,7 @@ let roguelikeFloor section =
     |> Layout.section 36 28 (Layout.set 0 0 StairsDownTile)
 
 let floor =
-    CellGrid2D.create 50 40 (Vector2(32f, 32f)) Vector2.Zero
+    CellGrid2D.create 50 40 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> Layout.run roguelikeFloor
 ```
 
@@ -308,7 +308,7 @@ Use `LayeredGrid2D` for separate structure, decoration, and entity layers:
 
 ```fsharp
 let layeredDungeon =
-    LayeredGrid2D.create 50 50 (Vector2(32f, 32f)) Vector2.Zero
+    LayeredGrid2D.create 50 50 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
     |> LayeredLayout.layer 0 (fun section ->
         // Layer 0: Structure (collision)
         section

--- a/docs/program.md
+++ b/docs/program.md
@@ -51,7 +51,14 @@ game.Run()
 ## Amenities & Services
 
 ### `withAssets`
-A placeholder for API consistency. Asset loading and caching are handled through the backend's `IAssets` (which extends the Core `IAssetCache`), so you access textures/fonts/etc. via `ctx.Assets` without explicit opt-in. Use `withAssetsBasePath` to configure a root path. The concrete asset *types* differ per backend (raylib vs XNA), but the `Get`/`GetOrCreate`/`Create` caching surface is backend-neutral through `IAssetCache`.
+A placeholder for API consistency. Asset loading and caching are handled through the backend's `IAssets` (which extends the Core `IAssetCache`), so assets are obtained from the service registry via `GameContext.getService<IAssets> ctx`. No explicit opt-in is needed:
+
+```fsharp
+let assets = GameContext.getService<IAssets> ctx
+let tex = assets.Texture("sprites/player")
+```
+
+Use `withAssetsBasePath` to configure a root path. The concrete asset *types* differ per backend (raylib vs XNA), but the `Get`/`GetOrCreate`/`Create` caching surface is backend-neutral through `IAssetCache`.
 
 ### `withInput`
 Registers the `IInput` service, enabling Keyboard, Mouse, Touch, Gamepad, and Gesture subscriptions.

--- a/src/Mibo.MonoGame/Graphics2D/Command2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Command2D.fs
@@ -281,6 +281,7 @@ type Command2D =
   | EndTarget of layer: int<RenderLayer>
   // Render State
   | SetBlend of blend: BlendMode * layer: int<RenderLayer>
+  | SetSamplerState of sampler: SamplerState * layer: int<RenderLayer>
   | SetScissor of
     scissorX: int *
     scissorY: int *
@@ -644,6 +645,10 @@ module Command2D =
   /// <summary>Sets the active blend mode. (layer) can be partially applied.</summary>
   let inline setBlend (layer: int<RenderLayer>) (mode: BlendMode) =
     Command2D.SetBlend(mode, layer)
+
+  /// <summary>Sets the sampler state for subsequent sprites. (layer) can be partially applied.</summary>
+  let inline setSamplerState (layer: int<RenderLayer>) (sampler: SamplerState) =
+    Command2D.SetSamplerState(sampler, layer)
 
   /// <summary>Enables a scissor rectangle. (layer) can be partially applied.</summary>
   let inline setScissor

--- a/src/Mibo.MonoGame/Graphics2D/Draw.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Draw.fs
@@ -443,6 +443,17 @@ module Draw =
     buffer.Add(Command2D.setBlend layer mode)
     buffer
 
+  /// <summary>Sets the sampler state (e.g. <c>SamplerState.PointClamp</c>) for subsequent
+  /// sprites — useful to stop tile-atlas bleeding. (layer) can be partially applied.
+  /// MonoGame only.</summary>
+  let inline setSamplerState
+    (layer: int<RenderLayer>)
+    (sampler: SamplerState)
+    (buffer: RenderBuffer2D)
+    =
+    buffer.Add(Command2D.setSamplerState layer sampler)
+    buffer
+
   /// <summary>Enables a scissor rectangle. (layer) can be partially applied.</summary>
   let inline setScissor
     (layer: int<RenderLayer>)

--- a/src/Mibo.MonoGame/Graphics2D/RenderBuffer2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/RenderBuffer2D.fs
@@ -69,6 +69,7 @@ type RenderBuffer2D
     | Command2D.BeginTarget(_, layer) -> layer
     | Command2D.EndTarget layer -> layer
     | Command2D.SetBlend(_, layer) -> layer
+    | Command2D.SetSamplerState(_, layer) -> layer
     | Command2D.SetScissor(_, _, _, _, layer) -> layer
     | Command2D.ClearScissor layer -> layer
     | Command2D.SetLineWidth(_, layer) -> layer

--- a/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
@@ -1507,8 +1507,9 @@ module private CommandHandlers =
         endAndRestart res &state
 
       | Command2D.SetSamplerState(sampler, _) ->
-        state.Sampler <- sampler
-        endAndRestart res &state
+        if state.Sampler <> sampler then
+          state.Sampler <- sampler
+          endAndRestart res &state
 
       | Command2D.SetScissor(x, y, w, h, _) ->
         flushBatches res

--- a/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
@@ -167,6 +167,7 @@ module private CommandHandlers =
     HasScissor: bool
     ScissorRect: Rectangle
     Blend: BlendMode
+    Sampler: SamplerState
     Shader: Effect voption
     HasRenderTarget: bool
     RenderTarget: RenderTarget2D voption
@@ -181,6 +182,7 @@ module private CommandHandlers =
     mutable HasScissor: bool
     mutable ScissorRect: Rectangle
     mutable Blend: BlendMode
+    mutable Sampler: SamplerState
     mutable Shader: Effect voption
     mutable HasRenderTarget: bool
     mutable RenderTarget: RenderTarget2D voption
@@ -227,13 +229,14 @@ module private CommandHandlers =
       sb: SpriteBatch,
       matrix: Matrix,
       blend: BlendMode,
+      sampler: SamplerState,
       rasterizer: RasterizerState,
       effect: Effect voption
     ) =
     sb.Begin(
       SpriteSortMode.Deferred,
       toBlendState blend,
-      SamplerState.LinearClamp,
+      sampler,
       DepthStencilState.None,
       rasterizer,
       (match effect with
@@ -265,7 +268,16 @@ module private CommandHandlers =
     =
     let matrix = currentMatrix &state
     let raster = currentRasterizer &state
-    beginSpriteBatch(res.SpriteBatch, matrix, state.Blend, raster, state.Shader)
+
+    beginSpriteBatch(
+      res.SpriteBatch,
+      matrix,
+      state.Blend,
+      state.Sampler,
+      raster,
+      state.Shader
+    )
+
     res.PrimitiveBatch.SetTransform(matrix)
     res.PrimitiveBatch.SetBlendState(toBlendState state.Blend)
     res.PrimitiveBatch.SetRasterizerState(raster)
@@ -289,6 +301,7 @@ module private CommandHandlers =
         HasScissor = state.HasScissor
         ScissorRect = state.ScissorRect
         Blend = state.Blend
+        Sampler = state.Sampler
         Shader = state.Shader
         HasRenderTarget = state.HasRenderTarget
         RenderTarget = state.RenderTarget
@@ -310,6 +323,7 @@ module private CommandHandlers =
       state.HasScissor <- frame.HasScissor
       state.ScissorRect <- frame.ScissorRect
       state.Blend <- frame.Blend
+      state.Sampler <- frame.Sampler
       state.Shader <- frame.Shader
       state.HasRenderTarget <- frame.HasRenderTarget
       state.RenderTarget <- frame.RenderTarget
@@ -1492,6 +1506,10 @@ module private CommandHandlers =
         state.Blend <- mode
         endAndRestart res &state
 
+      | Command2D.SetSamplerState(sampler, _) ->
+        state.Sampler <- sampler
+        endAndRestart res &state
+
       | Command2D.SetScissor(x, y, w, h, _) ->
         flushBatches res
         state.HasScissor <- true
@@ -1651,6 +1669,7 @@ type Renderer2D<'Model>
         sb,
         initialMatrix,
         BlendMode.NonPremultiplied,
+        SamplerState.LinearClamp,
         CommandHandlers.defaultRasterizer,
         ValueNone
       )
@@ -1664,6 +1683,7 @@ type Renderer2D<'Model>
         HasScissor = false
         ScissorRect = Rectangle.Empty
         Blend = BlendMode.NonPremultiplied
+        Sampler = SamplerState.LinearClamp
         Shader = ValueNone
         HasRenderTarget = false
         RenderTarget = ValueNone

--- a/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
@@ -1503,8 +1503,9 @@ module private CommandHandlers =
 
       // Render State
       | Command2D.SetBlend(mode, _) ->
-        state.Blend <- mode
-        endAndRestart res &state
+        if state.Blend <> mode then
+          state.Blend <- mode
+          endAndRestart res &state
 
       | Command2D.SetSamplerState(sampler, _) ->
         if state.Sampler <> sampler then

--- a/src/Mibo.Raylib/Mibo.Raylib.fsproj
+++ b/src/Mibo.Raylib/Mibo.Raylib.fsproj
@@ -14,6 +14,7 @@
     <Compile Include="Animation.fs" />
     <Compile Include="Animation3D.fs" />
     <Compile Include="Assets.fs" />
+    <Compile Include="Texture.fs" />
     <Compile Include="Elmish.Program.fs" />
     <Compile Include="Elmish.Runtime.fs" />
     <Compile Include="DefaultShaders.fs" />

--- a/src/Mibo.Raylib/Texture.fs
+++ b/src/Mibo.Raylib/Texture.fs
@@ -1,0 +1,69 @@
+namespace Mibo.Elmish
+
+open Raylib_cs
+
+/// <summary>
+/// Pipe-friendly helpers for configuring a loaded <c>Texture2D</c>.
+/// </summary>
+/// <remarks>
+/// raylib's texture filter is a property of the texture itself, set with
+/// <c>Raylib.SetTextureFilter</c>. The Mibo loader (<c>IAssets.Texture</c>)
+/// generates mipmaps and forces <c>Trilinear</c> filtering on every texture at
+/// load time — good for 3D/PBR surfaces, but it makes tiles sampled from a
+/// gutterless spritesheet bleed at the edges. Use these helpers to override
+/// that per texture:
+/// <code>
+/// let assets = GameContext.getService&lt;IAssets&gt; ctx
+/// let atlas = assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point
+/// </code>
+/// Apply once (e.g. in <c>init</c>) — not every frame — since it mutates the
+/// cached texture's sampler.
+/// </remarks>
+module Texture =
+
+  /// <summary>
+  /// Sets the texture's filtering mode, overriding the load-time default
+  /// (mipmaps + <c>Trilinear</c>).
+  /// </summary>
+  /// <param name="filterMode">The raylib <c>TextureFilter</c> to apply.</param>
+  /// <param name="tex">The texture to configure (returned for piping).</param>
+  /// <remarks>
+  /// <c>Point</c> (nearest) filtering reads exact texels — use it on a tile
+  /// atlas to stop adjacent tiles from bleeding into each other. The texture
+  /// already has mipmaps generated on load; <c>Point</c>/<c>Bilinear</c> simply
+  /// ignore them.
+  /// </remarks>
+  let inline filter (filterMode: TextureFilter) (tex: Texture2D) =
+    Raylib.SetTextureFilter(tex, filterMode)
+    tex
+
+  /// <summary>
+  /// Sets the texture's wrap (addressing) mode — how sampling handles texture
+  /// coordinates outside the <c>[0, 1]</c> range.
+  /// </summary>
+  /// <param name="wrapMode">The raylib <c>TextureWrap</c> to apply
+  /// (<c>Clamp</c>, <c>Repeat</c>, <c>MirrorClamp</c>, <c>MirrorRepeat</c>).</param>
+  /// <param name="tex">The texture to configure (returned for piping).</param>
+  /// <remarks>
+  /// Use <c>Repeat</c>/<c>MirrorRepeat</c> for a tiling background; <c>Clamp</c>
+  /// stops edge texels from wrapping. Like <c>filter</c>, this is a per-texture
+  /// sampler property.
+  /// </remarks>
+  let inline wrap (wrapMode: TextureWrap) (tex: Texture2D) =
+    Raylib.SetTextureWrap(tex, wrapMode)
+    tex
+
+  /// <summary>
+  /// Generates mipmaps for the texture (the Mibo loader already does this on
+  /// load, so this is mainly useful for textures loaded outside the loader).
+  /// </summary>
+  /// <param name="tex">The texture; the updated struct (new mipmap count) is
+  /// returned for piping.</param>
+  /// <remarks>
+  /// raylib-cs mutates the texture byref and writes the mipmap count back into
+  /// the same struct, so the returned texture must be used.
+  /// </remarks>
+  let inline mipmaps(tex: Texture2D) =
+    let mutable t = tex
+    Raylib.GenTextureMipmaps(&t) |> ignore
+    t

--- a/src/Templates/Templates/MiboMono2D/AGENTS.md
+++ b/src/Templates/Templates/MiboMono2D/AGENTS.md
@@ -4,15 +4,20 @@ This is a **Mibo** game project. Mibo is an Elmish-based F# game framework.
 This template targets the **MonoGame** backend (`Mibo.MonoGame`, host `MiboGame`)
 and ships **two interchangeable thin clients** sharing one library:
 
-- `MiboMono2D/` — shared library (net10.0). All game logic, the view, and a
-  `create()` composition root that builds the `Program`. References
-  `Mibo.MonoGame` + `MonoGame.Framework.Native` (the compile-time,
-  backend-neutral types).
+- `src/` — shared library (net10.0): `Library.fs` (module `MiboMono2D`, all game
+  logic, the view, and a `create()` composition root that builds the
+  `MonoGameProgram`) + `MiboMono2D.fsproj`. References `Mibo.MonoGame` +
+  `MonoGame.Framework.Native` (the compile-time, backend-neutral types) and the
+  shared content pipeline.
+- `Content/` — shared MonoGame content pipeline (`Content.mgcb`). Each thin
+  client builds it via `MonoGame.Content.Builder.Task`, so the same assets are
+  available in both backends.
 - `DesktopGL/` — thin client. Adds `MonoGame.Framework.DesktopGL` (**OpenGL**),
-  calls `MiboMono2D.create()` and runs `MiboGame`.
+  references `../src/MiboMono2D.fsproj` and the shared content, calls
+  `MiboMono2D.create()` and runs `MiboGame`.
 - `WindowsDX/` — thin client (net10.0-windows). Adds
   `MonoGame.Framework.WindowsDX` (**DirectX**), `[<STAThread>]`,
-  `app.manifest`. Same three lines as DesktopGL.
+  `app.manifest`. Same wiring as DesktopGL.
 
 The starter draws a bouncing red rectangle — pure Model-View-Update with a
 `Tick`-driven view. Treat it as Level 0 on the
@@ -34,16 +39,26 @@ MonoGame's platform host packages (`...DesktopGL` and `...WindowsDX`) **cannot
 coexist in one project**. That is why there are three projects. Keep the split:
 
 - **Game logic, model, messages, `update`, the `view`, and `create()` live in
-  the shared library only.** They must stay backend-neutral (compile against
+  `src/` only.** They must stay backend-neutral (compile against
   `MonoGame.Framework.Native`). Never reference `DesktopGL` or `WindowsDX` from
   the shared lib.
-- **Thin clients stay thin.** They only call `MiboMono2D.create()`, convert with
-  `MonoGameProgram.ofProgram` (+ optional `withConfig`), and `new MiboGame<_,_>().Run()`.
-  Put no game logic in a client.
+- **Thin clients stay thin.** They just call `MiboMono2D.create()` (which already
+  returns a `MonoGameProgram` with the content root configured) and
+  `new MiboGame<_,_>().Run()` — they no longer call `MonoGameProgram.ofProgram`
+  themselves. Asset / `Content.RootDirectory` configuration is centralized in
+  `create()`. Put no game logic in a client.
 - Both clients build from the same shared source — **do not fork logic per
   backend.** If you need a backend-specific service (audio, animation),
   define an interface in the shared lib (or `Mibo.Core`) and implement it once,
   injecting it through an `Env`/composition-root record like `create()` does.
+
+## Content pipeline
+
+Add assets under `Content/` and reference them in `Content/Content.mgcb` (asset
+names have no extension). They build into each client's output directory and
+load at runtime via `GameContext.getService<IAssets> ctx`. You can edit the
+pipeline with `dotnet mgcb-editor` (run `dotnet tool restore` first to install
+it from `dotnet-tools.json`).
 
 ## Architecture you must follow: routed sub-systems
 

--- a/src/Templates/Templates/MiboMono2D/Content/Content.mgcb
+++ b/src/Templates/Templates/MiboMono2D/Content/Content.mgcb
@@ -1,0 +1,13 @@
+#----------------------------- Global Properties ----------------------------#
+
+/outputDir:bin/$(Platform)
+/intermediateDir:obj
+/platform:DesktopGL
+/config:
+/profile:HiDef
+/compress:False
+
+#-------------------------------- References --------------------------------#
+
+
+#---------------------------------- Content ---------------------------------#

--- a/src/Templates/Templates/MiboMono2D/DesktopGL/DesktopGL.fsproj
+++ b/src/Templates/Templates/MiboMono2D/DesktopGL/DesktopGL.fsproj
@@ -12,8 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MiboMono2D.fsproj" />
+    <ProjectReference Include="..\src\MiboMono2D.fsproj" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="..\Content\Content.mgcb">
+      <Link>Content\Content.mgcb</Link>
+    </MonoGameContentReference>
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Templates/MiboMono2D/DesktopGL/Program.fs
+++ b/src/Templates/Templates/MiboMono2D/DesktopGL/Program.fs
@@ -5,7 +5,7 @@ open MiboMono2D
 
 [<EntryPoint>]
 let main _ =
-  let mgProgram = MiboMono2D.create() |> MonoGameProgram.ofProgram
+  let mgProgram = MiboMono2D.create()
 
   use game = new MiboGame<Model, Msg>(mgProgram)
   game.Run()

--- a/src/Templates/Templates/MiboMono2D/WindowsDX/Program.fs
+++ b/src/Templates/Templates/MiboMono2D/WindowsDX/Program.fs
@@ -6,7 +6,7 @@ open MiboMono2D
 
 [<EntryPoint; STAThread>]
 let main _ =
-  let mgProgram = MiboMono2D.create() |> MonoGameProgram.ofProgram
+  let mgProgram = MiboMono2D.create()
 
   use game = new MiboGame<Model, Msg>(mgProgram)
   game.Run()

--- a/src/Templates/Templates/MiboMono2D/WindowsDX/WindowsDX.fsproj
+++ b/src/Templates/Templates/MiboMono2D/WindowsDX/WindowsDX.fsproj
@@ -16,8 +16,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MiboMono2D.fsproj" />
+    <ProjectReference Include="..\src\MiboMono2D.fsproj" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="..\Content\Content.mgcb">
+      <Link>Content\Content.mgcb</Link>
+    </MonoGameContentReference>
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Templates/MiboMono2D/dotnet-tools.json
+++ b/src/Templates/Templates/MiboMono2D/dotnet-tools.json
@@ -6,6 +6,31 @@
       "version": "7.0.5",
       "commands": ["fantomas"],
       "rollForward": false
+    },
+    "dotnet-mgcb": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
     }
   }
 }

--- a/src/Templates/Templates/MiboMono2D/src/Library.fs
+++ b/src/Templates/Templates/MiboMono2D/src/Library.fs
@@ -129,9 +129,10 @@ let view (_ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
 // Program
 // ─────────────────────────────────────────────────────────────
 
-/// Builds the full Mibo program. The thin client projects
-/// (DesktopGL, WindowsDX) call this and pass the result to MiboGame.
-let create() : Program<Model, Msg> =
+/// Builds the full Mibo MonoGame program with the content root configured for the
+/// MonoGame content pipeline. The thin client projects (DesktopGL, WindowsDX)
+/// pass this directly to MiboGame.
+let create() : MonoGameProgram<Model, Msg> =
   Program.mkProgram init update
   |> Program.withConfig(fun cfg -> {
     cfg with
@@ -145,3 +146,6 @@ let create() : Program<Model, Msg> =
     InputMapper.subscribeStatic inputMap InputChanged ctx)
   |> Program.withTick Tick
   |> Program.withRenderer(fun () -> Renderer2D.create view)
+  |> MonoGameProgram.ofProgram
+  |> MonoGameProgram.withConfig(fun (game, deviceManager) ->
+    game.Content.RootDirectory <- "Content")

--- a/src/Templates/Templates/MiboMono2D/src/MiboMono2D.fsproj
+++ b/src/Templates/Templates/MiboMono2D/src/MiboMono2D.fsproj
@@ -6,12 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Program.fs" />
+    <Compile Include="Library.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Mibo.MonoGame" Version="2.0.0-*" />
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.4.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="../Content/Content.mgcb" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Templates/MiboMono3D/AGENTS.md
+++ b/src/Templates/Templates/MiboMono3D/AGENTS.md
@@ -4,15 +4,21 @@ This is a **Mibo** game project. Mibo is an Elmish-based F# game framework.
 This template targets the **MonoGame** backend (`Mibo.MonoGame`, host `MiboGame`)
 and ships **two interchangeable thin clients** sharing one library:
 
-- `MiboMono3D/` — shared library (net10.0). All game logic, the view, and a
-  `create()` composition root that builds the `Program`. References
+- `src/` — shared library (`Library.fs` + `MiboMono3D.fsproj`, net10.0). All
+  game logic, the view, and a `create()` composition root that builds the
+  `MonoGameProgram` (with the content root already configured). References
   `Mibo.MonoGame` + `MonoGame.Framework.Native` (the compile-time,
   backend-neutral types).
+- `Content/` — shared MonoGame content pipeline (`Content.mgcb`). Each thin
+  client builds it via `MonoGame.Content.Builder.Task`, so assets land in both
+  clients' output.
 - `DesktopGL/` — thin client. Adds `MonoGame.Framework.DesktopGL` (**OpenGL**),
-  calls `MiboMono3D.create()` and runs `MiboGame`.
+  references `../src/MiboMono3D.fsproj` and the shared content, calls
+  `MiboMono3D.create()` and runs `MiboGame`.
 - `WindowsDX/` — thin client (net10.0-windows). Adds
   `MonoGame.Framework.WindowsDX` (**DirectX**), `[<STAThread>]`,
-  `app.manifest`. Same three lines as DesktopGL.
+  `app.manifest`. References `../src/MiboMono3D.fsproj` and the shared content,
+  same three lines as DesktopGL.
 
 The starter draws a bouncing lit cube — pure Model-View-Update with a `Tick`-driven
 view. Treat it as Level 0 on the
@@ -32,16 +38,27 @@ MonoGame's platform host packages (`...DesktopGL` and `...WindowsDX`) **cannot
 coexist in one project**. That is why there are three projects. Keep the split:
 
 - **Game logic, model, messages, `update`, the `view`, and `create()` live in
-  the shared library only.** They must stay backend-neutral (compile against
-  `MonoGame.Framework.Native`). Never reference `DesktopGL` or `WindowsDX` from
-  the shared lib.
-- **Thin clients stay thin.** They only call `MiboMono3D.create()`, convert with
-  `MonoGameProgram.ofProgram` (+ optional `withConfig`), and `new MiboGame<_,_>().Run()`.
-  Put no game logic in a client.
+  the shared library (`src/`) only.** They must stay backend-neutral (compile
+  against `MonoGame.Framework.Native`). Never reference `DesktopGL` or
+  `WindowsDX` from the shared lib.
+- **Thin clients stay thin.** They only call `MiboMono3D.create()` — which
+  already returns a `MonoGameProgram` with the content root
+  (`Content.RootDirectory`) configured — and `new MiboGame<_,_>().Run()`. They
+  no longer call `MonoGameProgram.ofProgram` themselves. Put no game logic in a
+  client.
 - Both clients build from the same shared source — **do not fork logic per
   backend.** If you need a backend-specific service (audio, animation),
   define an interface in the shared lib (or `Mibo.Core`) and implement it once,
   injecting it through an `Env`/composition-root record like `create()` does.
+
+## Content pipeline
+
+Assets live under `Content/` and are listed in `Content/Content.mgcb`. Each thin
+client builds that pipeline via `MonoGame.Content.Builder.Task`, so the assets
+land in both clients' output directories and load at runtime through
+`GameContext.getService<IAssets> ctx` (asset names carry no file extension —
+e.g. load `Content/foo.png` as `"foo"`). To edit the pipeline visually, run
+`dotnet tool restore` then `dotnet mgcb-editor`.
 
 ## Architecture you must follow: routed sub-systems
 

--- a/src/Templates/Templates/MiboMono3D/Content/Content.mgcb
+++ b/src/Templates/Templates/MiboMono3D/Content/Content.mgcb
@@ -1,0 +1,14 @@
+
+#----------------------------- Global Properties ----------------------------#
+
+/outputDir:bin/$(Platform)
+/intermediateDir:obj
+/platform:DesktopGL
+/config:
+/profile:HiDef
+/compress:False
+
+#-------------------------------- References --------------------------------#
+
+
+#---------------------------------- Content ---------------------------------#

--- a/src/Templates/Templates/MiboMono3D/DesktopGL/DesktopGL.fsproj
+++ b/src/Templates/Templates/MiboMono3D/DesktopGL/DesktopGL.fsproj
@@ -12,8 +12,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MiboMono3D.fsproj" />
+    <ProjectReference Include="..\src\MiboMono3D.fsproj" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="..\Content\Content.mgcb">
+      <Link>Content\Content.mgcb</Link>
+    </MonoGameContentReference>
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Templates/MiboMono3D/DesktopGL/Program.fs
+++ b/src/Templates/Templates/MiboMono3D/DesktopGL/Program.fs
@@ -5,7 +5,7 @@ open MiboMono3D
 
 [<EntryPoint>]
 let main _ =
-  let mgProgram = MiboMono3D.create() |> MonoGameProgram.ofProgram
+  let mgProgram = MiboMono3D.create()
 
   use game = new MiboGame<Model, Msg>(mgProgram)
   game.Run()

--- a/src/Templates/Templates/MiboMono3D/WindowsDX/Program.fs
+++ b/src/Templates/Templates/MiboMono3D/WindowsDX/Program.fs
@@ -6,7 +6,7 @@ open MiboMono3D
 
 [<EntryPoint; STAThread>]
 let main _ =
-  let mgProgram = MiboMono3D.create() |> MonoGameProgram.ofProgram
+  let mgProgram = MiboMono3D.create()
 
   use game = new MiboGame<Model, Msg>(mgProgram)
   game.Run()

--- a/src/Templates/Templates/MiboMono3D/WindowsDX/WindowsDX.fsproj
+++ b/src/Templates/Templates/MiboMono3D/WindowsDX/WindowsDX.fsproj
@@ -16,8 +16,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\MiboMono3D.fsproj" />
+    <ProjectReference Include="..\src\MiboMono3D.fsproj" />
     <PackageReference Include="MonoGame.Framework.WindowsDX" Version="3.8.4.1" />
+    <PackageReference Include="MonoGame.Content.Builder.Task" Version="3.8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="..\Content\Content.mgcb">
+      <Link>Content\Content.mgcb</Link>
+    </MonoGameContentReference>
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Templates/MiboMono3D/dotnet-tools.json
+++ b/src/Templates/Templates/MiboMono3D/dotnet-tools.json
@@ -6,6 +6,31 @@
       "version": "7.0.5",
       "commands": ["fantomas"],
       "rollForward": false
+    },
+    "dotnet-mgcb": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor-linux": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor-windows": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
+    },
+    "dotnet-mgcb-editor-mac": {
+      "version": "3.8.4.1",
+      "commands": ["mgcb-editor"],
+      "rollForward": false
     }
   }
 }

--- a/src/Templates/Templates/MiboMono3D/src/Library.fs
+++ b/src/Templates/Templates/MiboMono3D/src/Library.fs
@@ -182,9 +182,10 @@ let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer3D) =
 // Program
 // ─────────────────────────────────────────────────────────────
 
-/// Builds the full Mibo program. The thin client projects
-/// (DesktopGL, WindowsDX) call this and pass the result to MiboGame.
-let create() : Program<Model, Msg> =
+/// Builds the full Mibo MonoGame program with the content root configured for the
+/// MonoGame content pipeline. The thin client projects (DesktopGL, WindowsDX)
+/// pass this directly to MiboGame.
+let create() : MonoGameProgram<Model, Msg> =
   Program.mkProgram init update
   |> Program.withConfig(fun cfg -> {
     cfg with
@@ -198,3 +199,6 @@ let create() : Program<Model, Msg> =
     InputMapper.subscribeStatic inputMap InputChanged ctx)
   |> Program.withTick Tick
   |> Program.withRenderer(fun () -> Renderer3D.create (ForwardPipeline()) view)
+  |> MonoGameProgram.ofProgram
+  |> MonoGameProgram.withConfig(fun (game, deviceManager) ->
+    game.Content.RootDirectory <- "Content")

--- a/src/Templates/Templates/MiboMono3D/src/MiboMono3D.fsproj
+++ b/src/Templates/Templates/MiboMono3D/src/MiboMono3D.fsproj
@@ -6,12 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Include="Program.fs" />
+    <Compile Include="Library.fs" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Mibo.MonoGame" Version="2.0.0-*" />
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.4.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MonoGameContentReference Include="../Content/Content.mgcb" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Three issues in one PR. Verified locally: `dotnet build` is green for both backends, the MonoGame templates instantiate via `dotnet new` with the new layout and build, and `dotnet fantomas .` is clean.

### #61 — Docs gaps
- Removed references to the non-existent `ctx.Assets` member across the `program`, `assets`, and `animation` docs — assets are obtained via `GameContext.getService<IAssets> ctx`.
- Flagged the `System.Numerics.Vector2` vs `Microsoft.Xna.Framework.Vector2` collision that breaks the Core layout APIs (`CellGrid2D`/`LayeredGrid2D`) in MonoGame projects, and qualified those calls in the layout + camera docs.
- Documented the full `SpriteState` field set (`Rotation`/`Origin`/`NormalMap`), not just `Color`/`Layer`.

### #62 — Tile-atlas sampler control
- **MonoGame:** new `Draw.setSamplerState layer sampler` (`Command2D.SetSamplerState`), threaded through the renderer exactly like `setBlend` — flushes/restarts the sprite batch on change, defaults to the previous behavior (`SamplerState.LinearClamp`). Use `SamplerState.PointClamp` to stop gutterless-atlas bleed.
- **raylib:** a new `Texture` helper module (`filter`/`wrap`/`mipmaps`), since a raylib texture's sampler is a property of the texture, not the batch: `assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point`. MonoGame has no per-texture sampler, so `setSamplerState` is its idiomatic place — no equivalent needed there.

### #63 — MonoGame template structure
Restructured the 2D and 3D MonoGame templates (modeled on a working reference project):
- Shared library moved into `src/` (`Library.fs` + `<Name>.fsproj`).
- Shipped the MonoGame content pipeline (`Content/Content.mgcb`, built by each thin client via `MonoGame.Content.Builder.Task`).
- `create()` now returns a `MonoGameProgram` with the content root already configured; the thin clients just construct `MiboGame` and run (no more per-client `MonoGameProgram.ofProgram`).
- `dotnet-tools.json` adds the MGCB tools; `AGENTS.md` updated to match.

### Docs / CHANGELOG
- Sampler control documented on both backends with cross-references; new "Tile-atlas bleeding" section in `graphics2d/performance.md`; the `Texture` DSL documented in `assets.md`.
- CHANGELOG entries under `[Unreleased]` (Added / Changed / Fixed).

## Verification
- `dotnet build src/Mibo.MonoGame` ✅
- `dotnet build src/Mibo.Raylib` ✅
- `dotnet new mibo-mg-2d` / `mibo-mg-3d` instantiate with the new `src/` + `Content/` layout and the DesktopGL client builds ✅
- `dotnet fantomas .` run (clean).

Closes #61, #62, #63.
