### PR TITLE
feat: model-aware scene-depth post-processing (raylib)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **3D:** model-aware post-processing — `Draw3D.postProcessWithDepth` exposes camera-POV scene depth to post-process passes (fog, depth-of-field, SSAO). The depth texture stores non-linear NDC z (`[0,1]`, 0=near, 1=far); linearize with the camera's near/far. raylib renders the scene into a custom framebuffer with a sampleable depth-texture attachment (no extra geometry pass); MonoGame re-renders opaque geometry into a dedicated R32F target. Use plain `Draw3D.postProcess` for color-only effects so the depth-production cost is skipped. See `docs/graphics3d/overview.md` → "Post-processing" and `docs/shaders.md` → "Post-process shaders" for the depth-texture contract and shader binding requirements.
+
 - **3D:** instanced draws inside a `beginEffect`/`endEffect` scope are now shaded by your own shader/effect when it opts into instancing — raylib declares `in mat4 instanceTransform;`, MonoGame exposes an `Instanced` technique. Effects that don't opt in keep the previous PBR-instanced fallback. Skinned + instanced isn't supported (no per-instance bone palette). See the "Instancing (opt-in)" section of `docs/shader-uniforms.md`.
 
 - **MonoGame 2D:** `Draw.setSamplerState` sets the sprite-batch sampler state for subsequent sprites (e.g. `SamplerState.PointClamp`), mirroring `setBlend` — use it to stop tiles sampled from a gutterless spritesheet from bleeding at the edges. It flushes the batch on change and defaults to the previous behavior (`SamplerState.LinearClamp`). On raylib, use the new `Texture.filter` helper instead.

--- a/docs/graphics3d/overview.md
+++ b/docs/graphics3d/overview.md
@@ -123,6 +123,107 @@ buffer
 |> Draw3D.drawModel skyboxModel skyboxTransform   // no shadows
 ```
 
+## Post-processing
+
+After the scene renders to an offscreen target, screen-space shader passes run in
+buffer order — each receives the previous pass's output as its source texture and
+draws a fullscreen quad. The last pass writes to the back-buffer; intermediate
+passes ping-pong through pooled render targets.
+
+Two entry points:
+
+| Function | Depth available? | When to use |
+|----------|-----------------|-------------|
+| `Draw3D.postProcess action` | No (`Context.Depth = ValueNone`) | Color-only effects: desaturation, vignette, tone mapping, blur |
+| `Draw3D.postProcessWithDepth action` | Yes (`Context.Depth = ValueSome`) | Distance effects: fog, depth-of-field, SSAO |
+
+Use plain `postProcess` when you don't sample depth — the pipeline skips the
+depth-production cost entirely. Emit passes conditionally from the view (e.g. only
+while a hit-flash is active).
+
+```fsharp
+// Color-only: desaturate the scene while a hit-flash is active
+if isHitFlash model then
+    buffer
+    |> Draw3D.postProcess (fun ctx ->
+        // ctx.Source is the scene render target (or the previous pass's output)
+        // Draw a fullscreen quad of it with your shader...
+        drawFullscreenQuad ctx.Source myShader)
+    |> Draw3D.drop
+```
+
+### Depth-aware post-processing
+
+`postProcessWithDepth` gives the action a `PostProcessContext3D` whose `Depth`
+field is a camera-POV depth texture. Sample it and linearize with the camera's
+near/far planes to get view-space distance:
+
+```fsharp
+buffer
+|> Draw3D.postProcessWithDepth (fun ctx ->
+    // ctx.Source — the scene color (Texture2D / RenderTarget2D)
+    // ctx.Depth — camera-POV depth (ValueSome Texture2D, NDC z in [0,1])
+    // ctx.Width, ctx.Height — dimensions
+    // Always handle the ValueNone case: it means depth wasn't produced this frame.
+    match ctx.Depth with
+    | ValueSome depthTex -> // bind depthTex, apply distance effect
+    | ValueNone ->          // no depth — draw the scene through unchanged
+    ())
+|> Draw3D.drop
+```
+
+### Depth texture contract
+
+The depth texture follows the same convention on both backends:
+
+| Property | Value |
+|----------|-------|
+| **Format** | Single-channel depth (NDC z) |
+| **Range** | `[0.0, 1.0]` — `0.0` = near plane, `1.0` = far plane |
+| **Distribution** | Non-linear (hyperbolic) — perspective-projected NDC z |
+| **Skybox / uncovered pixels** | `1.0` (far) — cleared before geometry renders |
+| **Linearization** | The effect's responsibility (see formula below) |
+
+To convert NDC z back to view-space distance, invert the perspective projection:
+
+```glsl
+// GLSL — linearize depth to positive view-space distance
+float z = depth * 2.0 - 1.0;   // remap [0,1] → NDC [-1,1]
+float dist = (2.0 * near * far) / (far + near - z * (far - near));
+```
+
+```hlsl
+// HLSL — equivalent for MonoGame
+float ndcZ = tex2D(DepthSampler, texCoord).r;
+float dist = (far * near) / (far - ndcZ * (far - near));
+```
+
+> _**NOTE — near/far source differs by backend.**_ raylib renders 3D with global
+> clip planes (`Rlgl.GetCullDistanceNear()` / `GetCullDistanceFar()`, defaults
+> `0.05`/`4000`), not per-camera near/far — query them at runtime and pass to your
+> shader. MonoGame uses the camera's `NearPlane`/`FarPlane`. The linearization
+> formula is the same; only the near/far *source* differs.
+
+### How the backends produce depth
+
+The depth texture is produced differently under the hood, but the contract above is
+identical:
+
+- **raylib:** the scene renders into a custom framebuffer whose depth attachment is
+  a sampleable texture (not a renderbuffer). OpenGL's depth buffer is directly
+  sampleable, so no extra geometry pass is needed — the depth you get is the same
+  depth buffer the forward pass wrote.
+- **MonoGame:** DirectX/OpenGL depth-stencil buffers are not directly sampleable as
+  textures in MonoGame's API, so the pipeline re-renders all opaque geometry into a
+  dedicated R32F color render target (cleared to white = far) via a depth-only
+  shader. This is an extra geometry pass, but produces the same NDC z values.
+
+### Post-process shader requirements
+
+For the contract your shader must satisfy (sampler names, texture binding, the
+`SetShaderValueTexture` caveat on raylib), see
+[Shaders → Post-process shaders](../shaders.html#post-process-shaders).
+
 ## Multi-camera rendering
 
 Use `Camera3DConfig` for split-screen, minimaps, or layered rendering:

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -202,6 +202,84 @@ let setShaderVec4 (shader: Shader) (loc: int) (value: Vector4) =
 - `SetShaderValueMatrix` takes `Matrix4x4` directly (not `void*`) — this works correctly without `fixed`.
 - `Rlgl.SetUniform` (raw rlgl) also requires `fixed + NativePtr.toVoidPtr`.
 
+## Post-process shaders
+
+Post-process passes (`Draw3D.postProcess` / `Draw3D.postProcessWithDepth`) run after
+the scene renders to an offscreen target. Your action receives a
+`PostProcessContext3D` and must draw a fullscreen quad of `ctx.Source`. See
+[3D Rendering → Post-processing](graphics3d/overview.html#post-processing) for the
+pipeline behavior and the depth-texture contract.
+
+### Scene color texture
+
+The scene color (`ctx.Source`) is always available:
+
+| Backend | Type | Binding |
+|---------|------|---------|
+| raylib | `RenderTexture2D` (use `.Texture` for the color) | Draw via `Raylib.DrawTexturePro` inside `BeginShaderMode` |
+| MonoGame | `RenderTarget2D` | Set as a texture parameter on your `Effect`, draw via the context's `Quad.Draw(effect)` |
+
+### Depth texture (depth-aware passes only)
+
+When you use `postProcessWithDepth`, `ctx.Depth` is `ValueSome texture` containing
+camera-POV NDC z (`[0,1]`, non-linear). Always handle the `ValueNone` case — it
+means depth wasn't produced this frame (bind a valid texture and pass through
+unchanged).
+
+**raylib — binding the depth sampler:**
+
+Raylib's 2D batch flush (triggered by `DrawTexturePro`) only re-binds textures
+registered through `SetShaderValueTexture`. Raw rlgl calls (`ActiveTextureSlot` +
+`EnableTexture`) set GL state but bypass that registry, so the sampler ends up
+unbound and reads `0`. **Always use `SetShaderValueTexture`:**
+
+```fsharp
+let depthLoc = Raylib.GetShaderLocation(shader, "texture1")  // your depth sampler
+
+Raylib.BeginShaderMode shader
+// ... set scalar uniforms ...
+Raylib.SetShaderValueTexture(shader, depthLoc, depthTexture)  // batch-safe binding
+Raylib.DrawTexturePro(ctx.Source.Texture, srcRect, dstRect, origin, 0f, Color.White)
+Raylib.EndShaderMode()
+```
+
+> _**NOTE — raylib auto-binds `texture1`.**_ Raylib maps the GLSL uniform name
+> `"texture1"` to its internal `SHADER_LOC_MAP_SPECULAR` slot during
+> `LoadShaderFromMemory`. Using `texture0` / `texture1` as your sampler names means
+> `GetShaderLocation` resolves them automatically — no manual location attribute
+> setup needed.
+
+**MonoGame — binding the depth sampler:**
+
+MonoGame has no equivalent batch-clobbering issue. Set the depth render target as a
+texture parameter on your `Effect`, just like the scene color:
+
+```fsharp
+effect.Parameters.["DepthTexture"].SetValue(ctx.Depth.Value)
+effect.Parameters.["SceneTexture"].SetValue(ctx.Source)
+ctx.Quad.Draw(effect)
+```
+
+### DisableRuntimeMarshalling caveat (raylib)
+
+The [`fixed + NativePtr.toVoidPtr`](#disableruntimemarshalling-and-setshadervalue-raylib-only)
+requirement applies to all scalar/vector uniforms in your post-process shader
+(`fogColor`, `fogNear`, etc.). One subtle trap: `Rlgl.GetCullDistanceNear` /
+`GetCullDistanceFar` return `double` (8 bytes), but `SetShaderValue` with
+`ShaderUniformDataType.Float` reads 4 bytes — convert to `float32` before passing:
+
+```fsharp
+// WRONG — uploads the first 4 bytes of a double as float32 (garbage)
+let mutable camN = Rlgl.GetCullDistanceNear()
+use p = fixed &camN
+Raylib.SetShaderValue(shader, loc, NativePtr.toVoidPtr p, ShaderUniformDataType.Float)
+
+// CORRECT — convert double → float32 first
+let mutable camN = float32 (Rlgl.GetCullDistanceNear())
+use p = fixed &camN
+Raylib.SetShaderValue(shader, loc, NativePtr.toVoidPtr p, ShaderUniformDataType.Float)
+```
+
 ## Where to Learn More
 
 - **2D lighting shaders**: See [2D Lighting & Shadows](graphics2d/lighting.html)

--- a/src/Mibo.MonoGame/Graphics3D/Command3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Command3D.fs
@@ -77,4 +77,15 @@ type Command3D =
   | BeginEffect of effect: Effect
   | EndEffect
   | DrawImmediate of action: (Pipelines.SceneContext -> unit)
+  /// <summary>
+  /// Requests a camera-POV linear-depth pre-pass this frame. When present (anywhere in the
+  /// buffer), the pipeline renders the opaque scene to an R32F target and exposes it as
+  /// <see cref="F:Mibo.Elmish.Graphics3D.PostProcessContext3D.Depth"/> to every
+  /// <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcess"/> action that frame. Emit it when a
+  /// post-process effect needs distance (fog, depth-of-field, SSAO); omit it for effects that
+  /// don't (e.g. a desaturation hit-flash) so the extra geometry pass is skipped. Depth is only
+  /// populated when at least one <c>EnableDepthPrePass</c> command is present; otherwise
+  /// <c>PostProcessContext3D.Depth</c> is <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>.
+  /// </summary>
+  | EnableDepthPrePass
   | PostProcess of ppAction: (PostProcessContext3D -> unit)

--- a/src/Mibo.MonoGame/Graphics3D/Command3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Command3D.fs
@@ -78,14 +78,16 @@ type Command3D =
   | EndEffect
   | DrawImmediate of action: (Pipelines.SceneContext -> unit)
   /// <summary>
-  /// Requests a camera-POV linear-depth pre-pass this frame. When present (anywhere in the
-  /// buffer), the pipeline renders the opaque scene to an R32F target and exposes it as
-  /// <see cref="F:Mibo.Elmish.Graphics3D.PostProcessContext3D.Depth"/> to every
-  /// <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcess"/> action that frame. Emit it when a
-  /// post-process effect needs distance (fog, depth-of-field, SSAO); omit it for effects that
-  /// don't (e.g. a desaturation hit-flash) so the extra geometry pass is skipped. Depth is only
-  /// populated when at least one <c>EnableDepthPrePass</c> command is present; otherwise
-  /// <c>PostProcessContext3D.Depth</c> is <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>.
+  /// A post-process action that reads only color (<c>PostProcessContext3D.Source</c>). Emits no
+  /// scene-depth production — use for color-only effects (desaturation, vignette, blur). Cheap:
+  /// costs only the scene render target + ping-pong, never a depth pass.
   /// </summary>
-  | EnableDepthPrePass
   | PostProcess of ppAction: (PostProcessContext3D -> unit)
+  /// <summary>
+  /// A post-process action that needs camera-POV scene depth (<c>PostProcessContext3D.Depth</c>) in
+  /// addition to color — fog, depth-of-field, SSAO. When at least one is present this frame, the
+  /// pipeline renders scene depth to an R32F target and exposes it via
+  /// <c>PostProcessContext3D.Depth</c>; use plain <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcess"/>
+  /// instead when an effect doesn't sample depth, so the depth pass is skipped entirely.
+  /// </summary>
+  | PostProcessWithDepth of ppAction: (PostProcessContext3D -> unit)

--- a/src/Mibo.MonoGame/Graphics3D/Draw3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Draw3D.fs
@@ -274,16 +274,6 @@ module Draw3D =
     buffer.Add Command3D.DisableShadows
     buffer
 
-  /// <summary>
-  /// Requests a camera-POV linear-depth pre-pass this frame so post-process actions can sample
-  /// <c>PostProcessContext3D.Depth</c> for distance effects (fog, depth-of-field, SSAO). Only emit
-  /// it on frames where a post-process needs depth — the depth pass re-renders the opaque scene,
-  /// so it is skipped entirely when no <c>enableDepthPrePass</c> is present.
-  /// </summary>
-  let inline enableDepthPrePass(buffer: RenderBuffer3D) =
-    buffer.Add Command3D.EnableDepthPrePass
-    buffer
-
   // ──────────────────────────────────────────────
   // Per-group shading scopes
   // ──────────────────────────────────────────────
@@ -373,19 +363,40 @@ module Draw3D =
     buffer
 
   /// <summary>
-  /// Enqueues a model-aware post-process pass. The action runs once, after the whole scene
-  /// renders to an offscreen target; it receives a <see cref="T:Mibo.Elmish.Graphics3D.PostProcessContext3D"/>
-  /// carrying the scene texture (+ optional depth), a fullscreen quad, and the device. The action
-  /// binds its effect, sets model-derived parameters, binds <c>Source</c> to the sampler, and calls
-  /// <c>Quad.Draw(effect)</c>. Emit it conditionally from the view based on game state. Chain
-  /// multiple passes — they ping-pong in buffer order, the last drawing to the back-buffer.
+  /// Enqueues a color-only post-process pass. The action runs once, after the whole scene renders
+  /// to an offscreen target; it receives a <see cref="T:Mibo.Elmish.Graphics3D.PostProcessContext3D"/>
+  /// carrying the scene texture, a fullscreen quad, and the device. <c>Context.Depth</c> is
+  /// <c>ValueNone</c> — no scene-depth pass runs. The action binds its effect, sets model-derived
+  /// parameters, binds <c>Source</c> to the sampler, and calls <c>Quad.Draw(effect)</c>. Emit it
+  /// conditionally from the view based on game state. Chain multiple passes — they ping-pong in
+  /// buffer order, the last drawing to the back-buffer.
+  ///
+  /// Use this for effects that don't sample depth (desaturation, vignette, blur) so the framework
+  /// skips depth production entirely. For distance effects (fog, depth-of-field, SSAO) use
+  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.postProcessWithDepth"/>.
   /// </summary>
-  /// <param name="action">Invoked once per frame with the post-process context.</param>
+  /// <param name="action">Invoked once per frame with the post-process context (Depth = ValueNone).</param>
   let inline postProcess
     ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
     (buffer: RenderBuffer3D)
     =
     buffer.Add(Command3D.PostProcess action)
+    buffer
+
+  /// <summary>
+  /// Enqueues a post-process pass that needs camera-POV scene depth. Same lifecycle as
+  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.postProcess"/> (runs once after the scene renders,
+  /// chains in buffer order), but when at least one such action is present the pipeline also renders
+  /// scene depth to an R32F target and exposes it via <c>Context.Depth</c>. Sample it (linearize with
+  /// the camera's near/far) for distance effects. Prefer plain <c>postProcess</c> for effects that
+  /// don't read depth, so the depth pass is skipped.
+  /// </summary>
+  /// <param name="action">Invoked once per frame with the post-process context (Depth populated).</param>
+  let inline postProcessWithDepth
+    ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
+    (buffer: RenderBuffer3D)
+    =
+    buffer.Add(Command3D.PostProcessWithDepth action)
     buffer
 
   /// <summary>Terminal function that discards the buffer, silencing the unused-value warning. Does nothing.</summary>

--- a/src/Mibo.MonoGame/Graphics3D/Draw3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Draw3D.fs
@@ -274,6 +274,16 @@ module Draw3D =
     buffer.Add Command3D.DisableShadows
     buffer
 
+  /// <summary>
+  /// Requests a camera-POV linear-depth pre-pass this frame so post-process actions can sample
+  /// <c>PostProcessContext3D.Depth</c> for distance effects (fog, depth-of-field, SSAO). Only emit
+  /// it on frames where a post-process needs depth — the depth pass re-renders the opaque scene,
+  /// so it is skipped entirely when no <c>enableDepthPrePass</c> is present.
+  /// </summary>
+  let inline enableDepthPrePass(buffer: RenderBuffer3D) =
+    buffer.Add Command3D.EnableDepthPrePass
+    buffer
+
   // ──────────────────────────────────────────────
   // Per-group shading scopes
   // ──────────────────────────────────────────────
@@ -282,7 +292,7 @@ module Draw3D =
   /// Opens a per-group shading scope: draws between this and <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.endEffect"/>
   /// are shaded by <paramref name="effect"/> instead of the default PBR effect. The effect inherits
   /// the gathered scene data (camera matrices, lights, material, bones) — <b>not</b> the PBR shader
-  /// itself (v2 spec §3): it need only declare the uniform subset it consumes, and absent uniforms
+  /// itself: it need only declare the uniform subset it consumes, and absent uniforms
   /// are skipped. This lets a toon/cel/wireframe effect reuse the scene's camera + lighting without
   /// re-implementing the gather. The scope closes at <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.endEffect"/>
   /// or automatically at the next <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.endCamera"/> (scopes do not

--- a/src/Mibo.MonoGame/Graphics3D/FullScreenQuad.fs
+++ b/src/Mibo.MonoGame/Graphics3D/FullScreenQuad.fs
@@ -52,13 +52,12 @@ type FullScreenQuad(gd: GraphicsDevice) =
     for pass in effect.CurrentTechnique.Passes do
       pass.Apply()
 
+      // Use the non-deprecated 4-arg overload: (primitiveType, baseVertex, startIndex, primitiveCount).
       gd.DrawIndexedPrimitives(
         PrimitiveType.TriangleList,
-        0,
-        0,
-        6, // index count -> 2 triangles
-        0,
-        2
+        0, // baseVertex
+        0, // startIndex
+        2 // primitiveCount -> 2 triangles (6 indices)
       )
 
   interface System.IDisposable with

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
@@ -995,7 +995,7 @@ type ForwardPipelineBase
                   h,
                   false,
                   SurfaceFormat.Single,
-                  DepthFormat.Depth24,
+                  DepthFormat.None,
                   0,
                   RenderTargetUsage.DiscardContents
                 )

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
@@ -995,7 +995,7 @@ type ForwardPipelineBase
                   h,
                   false,
                   SurfaceFormat.Single,
-                  DepthFormat.None,
+                  DepthFormat.Depth24,
                   0,
                   RenderTargetUsage.DiscardContents
                 )

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
@@ -200,6 +200,11 @@ type ForwardPipelineBase
   // Post-process: a fullscreen quad created against the device on the first post-process frame.
   let mutable fullScreenQuad: FullScreenQuad voption = ValueNone
 
+  // Camera-POV linear depth target (R32F) for post-process distance effects (fog/DOF/SSAO).
+  // Lazily created/resized against the back-buffer; recreated when the window resizes; disposed
+  // at shutdown. Only rendered when the view emits Command3D.EnableDepthPrePass this frame.
+  let mutable depthRT: RenderTarget2D voption = ValueNone
+
   let mutable billboardStaging: VertexPositionColorTexture[] =
     Array.zeroCreate<VertexPositionColorTexture> 256
   // Shared index pattern for N quads: [0,1,2, 0,2,3] offset by quad*4. Grown on demand.
@@ -585,8 +590,12 @@ type ForwardPipelineBase
   /// first (shadow uniforms upload to it).
   /// </summary>
   member private this.runShadowPass
-    (gd: GraphicsDevice, state: byref<ForwardState>, buffer: RenderBuffer3D)
-    =
+    (
+      gd: GraphicsDevice,
+      state: byref<ForwardState>,
+      buffer: RenderBuffer3D,
+      forceCollect: bool
+    ) =
     // Ensure the PBR effect is loaded BEFORE the pass uploads shadow uniforms to it.
     PbrShading.ensureEffect(gd, pbrRes) |> ignore
 
@@ -599,7 +608,42 @@ type ForwardPipelineBase
       pbrRes.Params
       buffer
       state.CurrentCamera
+      forceCollect
     |> fun r -> shadowRes.ShadowResult <- r // stash for the forward pass (Shade / user-effect scopes)
+
+  /// Renders the camera-POV linear depth (R32F) reusing the geometry the shadow pass already
+  /// collected. Creates/resizes the depth target against the back-buffer. Returns the target
+  /// (ValueNone if no camera set this frame, nothing was collected, or DepthShadow.fx unavailable).
+  member private this.runDepthPrePass
+    (gd: GraphicsDevice, w: int, h: int, viewProj: Matrix voption)
+    : RenderTarget2D voption =
+    match viewProj with
+    | ValueNone -> ValueNone
+    | ValueSome vp ->
+      match depthRT with
+      | ValueSome rt when rt.Width = w && rt.Height = h -> ()
+      | _ ->
+        (match depthRT with
+         | ValueSome rt -> rt.Dispose()
+         | ValueNone -> ())
+
+        depthRT <-
+          ValueSome(
+            new RenderTarget2D(
+              gd,
+              w,
+              h,
+              false,
+              SurfaceFormat.Single, // R32F — linear depth in .r
+              DepthFormat.None,
+              0,
+              RenderTargetUsage.DiscardContents
+            )
+          )
+
+      match depthRT with
+      | ValueSome rt -> ShadowPass.renderDepth gd shadowRes atlasCfg vp rt
+      | ValueNone -> ValueNone
 
   // ----------------------------------------------------------------
   // IRenderPipeline3D
@@ -682,6 +726,12 @@ type ForwardPipelineBase
         fullScreenQuad <- ValueNone
       | ValueNone -> ()
 
+      match depthRT with
+      | ValueSome rt ->
+        rt.Dispose()
+        depthRT <- ValueNone
+      | ValueNone -> ()
+
     member this.Execute(gameCtx, gameTime, buffer, rtPool) =
       let gd = MonoGameGameContext.getGraphicsDevice gameCtx
       // Total elapsed game time, in seconds — captured once per frame for the scene bundle so an
@@ -728,6 +778,8 @@ type ForwardPipelineBase
 
       // Pre-scan: lights, camera, and shadow commands (shadow origin / toggle) need to be
       // known before the shadow pass runs. Draw commands are handled in the forward pass.
+      let mutable depthRequested = false
+
       for i = 0 to buffer.Count - 1 do
         match buffer[i] with
         | Command3D.BeginCamera cam ->
@@ -752,15 +804,17 @@ type ForwardPipelineBase
         | Command3D.AddSpotLight s -> lights.SpotLights.Add s
         | Command3D.SetShadowOrigin origin ->
           shadowRes.Origin <- ValueSome origin
+        | Command3D.EnableDepthPrePass -> depthRequested <- true
         | Command3D.PostProcess action ->
           match ppActions with
           | ValueSome list -> list.Add action
           | ValueNone -> ()
         | _ -> ()
 
-      // Shadow pass (directional shadows only)
+      // Shadow pass. forceCollect lets the shadow pass gather opaque geometry even with no
+      // shadow-casting light, so the depth pre-pass below can reuse that single collection.
       if state.HasCamera then
-        this.runShadowPass(gd, &state, buffer)
+        this.runShadowPass(gd, &state, buffer, depthRequested)
 
       // Forward pass
       // Lights + shadow state are already gathered; the camera is re-established per block
@@ -801,6 +855,10 @@ type ForwardPipelineBase
         else
           ValueNone
 
+      // Stashes the last camera's correct-aspect view-projection during the forward pass, for the
+      // depth pre-pass (which runs after the loop, once HasCamera is reset). ValueNone if no camera.
+      let mutable depthViewProj: Matrix voption = ValueNone
+
       for i = 0 to buffer.Count - 1 do
         match buffer[i] with
         // ── Camera ──
@@ -822,6 +880,10 @@ type ForwardPipelineBase
 
           state.Projection <-
             perspectiveProjection cam (float32 vp.Width) (float32 vp.Height)
+
+          // Capture the correct-aspect view-projection for the depth pre-pass (post-process runs
+          // after this loop, once HasCamera has been reset by EndCamera — so stash the matrices now).
+          depthViewProj <- ValueSome(state.View * state.Projection)
 
           // New camera block: scopes don't persist across cameras.
           activeEffect <- ValueNone
@@ -848,6 +910,8 @@ type ForwardPipelineBase
               cfg.Camera
               (float32 vp.Width)
               (float32 vp.Height)
+
+          depthViewProj <- ValueSome(state.View * state.Projection)
 
           match cfg.ClearColor with
           | ValueSome c -> gd.Clear(ClearOptions.Target, c.ToVector4(), 1.0f, 0)
@@ -922,6 +986,10 @@ type ForwardPipelineBase
         | Command3D.EnableShadows
         | Command3D.DisableShadows -> ()
 
+        // Depth pre-pass is requested in the pre-scan and rendered before the post-process
+        // drain; nothing to do during the forward pass.
+        | Command3D.EnableDepthPrePass -> ()
+
         // Post-process actions were collected in the pre-scan and run after the scene
         // renders to an offscreen target; nothing to do during the forward pass.
         | Command3D.PostProcess _ -> ()
@@ -947,6 +1015,20 @@ type ForwardPipelineBase
             // Restore viewport; camera state is logical (matrices), nothing to restore on gd.
             gd.Viewport <- savedViewport
             state.HasCamera <- savedHasCamera
+
+      // Camera-POV depth for post-process distance effects (fog/DOF/SSAO), reusing the geometry the
+      // shadow pass already collected. Rendered only when the view requested depth AND post-process
+      // actions exist this frame — otherwise skipped entirely (no extra geometry pass).
+      let depthTarget: RenderTarget2D voption =
+        if depthRequested && usePostProcess then
+          this.runDepthPrePass(
+            gd,
+            gameCtx.WindowWidth,
+            gameCtx.WindowHeight,
+            depthViewProj
+          )
+        else
+          ValueNone
 
       // ── Post-process: ping-pong the scene through each action ──
       match sceneRT, ppActions with
@@ -989,7 +1071,7 @@ type ForwardPipelineBase
 
           let ppCtx: PostProcessContext3D = {
             Source = src
-            Depth = ValueNone
+            Depth = depthTarget
             Width = src.Width
             Height = src.Height
             Time = frameTime

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
@@ -200,10 +200,11 @@ type ForwardPipelineBase
   // Post-process: a fullscreen quad created against the device on the first post-process frame.
   let mutable fullScreenQuad: FullScreenQuad voption = ValueNone
 
-  // Camera-POV linear depth target (R32F) for post-process distance effects (fog/DOF/SSAO).
-  // Lazily created/resized against the back-buffer; recreated when the window resizes; disposed
-  // at shutdown. Only rendered when the view emits Command3D.EnableDepthPrePass this frame.
-  let mutable depthRT: RenderTarget2D voption = ValueNone
+  // Scene depth (R32F, NDC z in [0,1]) for post-process distance effects (fog/DOF/SSAO). Lazily
+  // created/resized, reused across frames, disposed at shutdown. Rendered by ShadowPass.renderSceneDepth
+  // reusing the geometry the shadow pass already collected — no second buffer scan. Only produced when
+  // the view emits PostProcessWithDepth actions; frames with only color-only PostProcess skip it.
+  let mutable sceneDepthRT: RenderTarget2D voption = ValueNone
 
   let mutable billboardStaging: VertexPositionColorTexture[] =
     Array.zeroCreate<VertexPositionColorTexture> 256
@@ -594,7 +595,7 @@ type ForwardPipelineBase
       gd: GraphicsDevice,
       state: byref<ForwardState>,
       buffer: RenderBuffer3D,
-      forceCollect: bool
+      needsDepth: bool
     ) =
     // Ensure the PBR effect is loaded BEFORE the pass uploads shadow uniforms to it.
     PbrShading.ensureEffect(gd, pbrRes) |> ignore
@@ -608,42 +609,8 @@ type ForwardPipelineBase
       pbrRes.Params
       buffer
       state.CurrentCamera
-      forceCollect
+      needsDepth
     |> fun r -> shadowRes.ShadowResult <- r // stash for the forward pass (Shade / user-effect scopes)
-
-  /// Renders the camera-POV linear depth (R32F) reusing the geometry the shadow pass already
-  /// collected. Creates/resizes the depth target against the back-buffer. Returns the target
-  /// (ValueNone if no camera set this frame, nothing was collected, or DepthShadow.fx unavailable).
-  member private this.runDepthPrePass
-    (gd: GraphicsDevice, w: int, h: int, viewProj: Matrix voption)
-    : RenderTarget2D voption =
-    match viewProj with
-    | ValueNone -> ValueNone
-    | ValueSome vp ->
-      match depthRT with
-      | ValueSome rt when rt.Width = w && rt.Height = h -> ()
-      | _ ->
-        (match depthRT with
-         | ValueSome rt -> rt.Dispose()
-         | ValueNone -> ())
-
-        depthRT <-
-          ValueSome(
-            new RenderTarget2D(
-              gd,
-              w,
-              h,
-              false,
-              SurfaceFormat.Single, // R32F — linear depth in .r
-              DepthFormat.None,
-              0,
-              RenderTargetUsage.DiscardContents
-            )
-          )
-
-      match depthRT with
-      | ValueSome rt -> ShadowPass.renderDepth gd shadowRes atlasCfg vp rt
-      | ValueNone -> ValueNone
 
   // ----------------------------------------------------------------
   // IRenderPipeline3D
@@ -726,10 +693,10 @@ type ForwardPipelineBase
         fullScreenQuad <- ValueNone
       | ValueNone -> ()
 
-      match depthRT with
+      match sceneDepthRT with
       | ValueSome rt ->
         rt.Dispose()
-        depthRT <- ValueNone
+        sceneDepthRT <- ValueNone
       | ValueNone -> ()
 
     member this.Execute(gameCtx, gameTime, buffer, rtPool) =
@@ -778,8 +745,6 @@ type ForwardPipelineBase
 
       // Pre-scan: lights, camera, and shadow commands (shadow origin / toggle) need to be
       // known before the shadow pass runs. Draw commands are handled in the forward pass.
-      let mutable depthRequested = false
-
       for i = 0 to buffer.Count - 1 do
         match buffer[i] with
         | Command3D.BeginCamera cam ->
@@ -804,17 +769,20 @@ type ForwardPipelineBase
         | Command3D.AddSpotLight s -> lights.SpotLights.Add s
         | Command3D.SetShadowOrigin origin ->
           shadowRes.Origin <- ValueSome origin
-        | Command3D.EnableDepthPrePass -> depthRequested <- true
-        | Command3D.PostProcess action ->
+        | Command3D.PostProcess action
+        | Command3D.PostProcessWithDepth action ->
           match ppActions with
           | ValueSome list -> list.Add action
           | ValueNone -> ()
         | _ -> ()
 
-      // Shadow pass. forceCollect lets the shadow pass gather opaque geometry even with no
-      // shadow-casting light, so the depth pre-pass below can reuse that single collection.
+      // Scene depth is needed when at least one PostProcessWithDepth action exists. Pass that to
+      // the shadow pass so it collects opaque geometry even without a shadow-casting light.
+      let needsDepth = buffer.DepthPostProcessCount > 0
+
+      // Shadow pass (also collects geometry for scene-depth when needsDepth is true)
       if state.HasCamera then
-        this.runShadowPass(gd, &state, buffer, depthRequested)
+        this.runShadowPass(gd, &state, buffer, needsDepth)
 
       // Forward pass
       // Lights + shadow state are already gathered; the camera is re-established per block
@@ -855,10 +823,6 @@ type ForwardPipelineBase
         else
           ValueNone
 
-      // Stashes the last camera's correct-aspect view-projection during the forward pass, for the
-      // depth pre-pass (which runs after the loop, once HasCamera is reset). ValueNone if no camera.
-      let mutable depthViewProj: Matrix voption = ValueNone
-
       for i = 0 to buffer.Count - 1 do
         match buffer[i] with
         // ── Camera ──
@@ -880,10 +844,6 @@ type ForwardPipelineBase
 
           state.Projection <-
             perspectiveProjection cam (float32 vp.Width) (float32 vp.Height)
-
-          // Capture the correct-aspect view-projection for the depth pre-pass (post-process runs
-          // after this loop, once HasCamera has been reset by EndCamera — so stash the matrices now).
-          depthViewProj <- ValueSome(state.View * state.Projection)
 
           // New camera block: scopes don't persist across cameras.
           activeEffect <- ValueNone
@@ -910,8 +870,6 @@ type ForwardPipelineBase
               cfg.Camera
               (float32 vp.Width)
               (float32 vp.Height)
-
-          depthViewProj <- ValueSome(state.View * state.Projection)
 
           match cfg.ClearColor with
           | ValueSome c -> gd.Clear(ClearOptions.Target, c.ToVector4(), 1.0f, 0)
@@ -986,13 +944,10 @@ type ForwardPipelineBase
         | Command3D.EnableShadows
         | Command3D.DisableShadows -> ()
 
-        // Depth pre-pass is requested in the pre-scan and rendered before the post-process
-        // drain; nothing to do during the forward pass.
-        | Command3D.EnableDepthPrePass -> ()
-
         // Post-process actions were collected in the pre-scan and run after the scene
         // renders to an offscreen target; nothing to do during the forward pass.
-        | Command3D.PostProcess _ -> ()
+        | Command3D.PostProcess _
+        | Command3D.PostProcessWithDepth _ -> ()
 
         // ── Escape hatch: full device control + the gathered scene data ──
         | Command3D.DrawImmediate action ->
@@ -1016,17 +971,50 @@ type ForwardPipelineBase
             gd.Viewport <- savedViewport
             state.HasCamera <- savedHasCamera
 
-      // Camera-POV depth for post-process distance effects (fog/DOF/SSAO), reusing the geometry the
-      // shadow pass already collected. Rendered only when the view requested depth AND post-process
-      // actions exist this frame — otherwise skipped entirely (no extra geometry pass).
-      let depthTarget: RenderTarget2D voption =
-        if depthRequested && usePostProcess then
-          this.runDepthPrePass(
-            gd,
-            gameCtx.WindowWidth,
-            gameCtx.WindowHeight,
-            depthViewProj
-          )
+      // ── Scene depth pre-pass (camera-POV, reusing collected geometry) ──
+      // Only runs when PostProcessWithDepth actions exist. The shadow pass already collected the
+      // opaque geometry; renderSceneDepth re-renders it from the camera VP into an R32F target.
+      let sceneDepth: RenderTarget2D voption =
+        if needsDepth && usePostProcess then
+          // Ensure the depth target matches the back-buffer size.
+          let w = gameCtx.WindowWidth
+          let h = gameCtx.WindowHeight
+
+          match sceneDepthRT with
+          | ValueSome rt when rt.Width = w && rt.Height = h -> ()
+          | _ ->
+            (match sceneDepthRT with
+             | ValueSome rt -> rt.Dispose()
+             | ValueNone -> ())
+
+            sceneDepthRT <-
+              ValueSome(
+                new RenderTarget2D(
+                  gd,
+                  w,
+                  h,
+                  false,
+                  SurfaceFormat.Single,
+                  DepthFormat.None,
+                  0,
+                  RenderTargetUsage.DiscardContents
+                )
+              )
+
+          // Reuse the camera VP the forward pass computed (correct viewport aspect). The forward
+          // pass captured it in state.View * state.Projection during BeginCamera.
+          match shadowRes.Effect, shadowRes.Params, sceneDepthRT with
+          | ValueSome eff, ValueSome prms, ValueSome rt ->
+            ShadowPass.renderSceneDepth
+              gd
+              shadowRes
+              eff
+              prms
+              (state.View * state.Projection)
+              rt
+
+            ValueSome rt
+          | _ -> ValueNone
         else
           ValueNone
 
@@ -1071,7 +1059,7 @@ type ForwardPipelineBase
 
           let ppCtx: PostProcessContext3D = {
             Source = src
-            Depth = depthTarget
+            Depth = sceneDepth
             Width = src.Width
             Height = src.Height
             Time = frameTime

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -819,7 +819,13 @@ module internal ShadowPass =
     gd.SetRenderTarget depthTarget
     // 1.0 = far: uncovered pixels (skybox, gaps) read as far so post-process fog treats them as
     // fully fogged rather than near. Clear as an explicit Vector4 so the R32F target gets .r=1.0.
-    gd.Clear(ClearOptions.Target, Color.White.ToVector4(), 1.0f, 0)
+    // Clear depth too — the RT has a Depth24 buffer for hardware depth testing during the pre-pass.
+    gd.Clear(
+      ClearOptions.Target ||| ClearOptions.DepthBuffer,
+      Color.White.ToVector4(),
+      1.0f,
+      0
+    )
 
     gd.RasterizerState <- RasterizerState.CullCounterClockwise
     gd.BlendState <- BlendState.Opaque
@@ -1092,6 +1098,19 @@ module internal ShadowPass =
       match pbrParams with
       | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
       | ValueNone -> ()
+
+      // Even without shadow casters, load the DepthShadow effect when needsDepth is true so
+      // renderSceneDepth can run (fog/DoF/SSOA in a shadowless scene). Without this the effect
+      // is never loaded and every postProcessWithDepth action silently receives Depth = None.
+      if needsDepth then
+        match res.Effect, res.Params with
+        | ValueSome _, ValueSome _ -> ()
+        | _ ->
+          match ShaderLoader.loadEffect gd "DepthShadow" with
+          | ValueSome e ->
+            res.Params <- ValueSome(buildShadowParams e)
+            res.Effect <- ValueSome e
+          | ValueNone -> ()
 
       ValueNone
     else

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -1093,19 +1093,6 @@ module internal ShadowPass =
       | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
       | ValueNone -> ()
 
-      // Even without shadow casters, load the DepthShadow effect so renderSceneDepth can run
-      // when needsDepth is true (fog/DoF/SSAO in a shadowless scene). Without this, the effect
-      // is never loaded and every postProcessWithDepth action silently receives Depth=None.
-      if needsDepth then
-        match res.Effect, res.Params with
-        | ValueSome _, ValueSome _ -> ()
-        | _ ->
-          match ShaderLoader.loadEffect gd "DepthShadow" with
-          | ValueSome e ->
-            res.Params <- ValueSome(buildShadowParams e)
-            res.Effect <- ValueSome e
-          | ValueNone -> ()
-
       ValueNone
     else
       res.Atlas.EnsureResources gd

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -28,6 +28,9 @@ type ShadowMeshDraw = {
   /// World-space bounds (mesh.Bounds transformed by Transform). Precomputed at collection
   /// time so the per-caster frustum cull in runShadowPass is a single ContainmentType check.
   WorldBounds: BoundingSphere
+  /// Whether this draw was emitted while shadows were enabled. The shadow pass renders only
+  /// draws with <c>CastsShadow = true</c>; the scene-depth pass renders all of them.
+  CastsShadow: bool
 }
 
 /// <summary>A skinned caster draw collected for the shadow pass (B12).</summary>
@@ -43,6 +46,8 @@ type ShadowSkinnedDraw = {
   Part: ModelMeshPart
   Transform: Matrix
   Bones: Matrix[]
+  /// Whether this draw was emitted while shadows were enabled (see ShadowMeshDraw).
+  CastsShadow: bool
 }
 
 /// <summary>A static <c>ModelMeshPart</c> caster collected for the shadow pass.</summary>
@@ -56,6 +61,8 @@ type ShadowSkinnedDraw = {
 type ShadowModelPartDraw = {
   Part: ModelMeshPart
   Transform: Matrix
+  /// Whether this draw was emitted while shadows were enabled (see ShadowMeshDraw).
+  CastsShadow: bool
 }
 
 /// <summary>An instanced caster draw collected for the shadow pass.</summary>
@@ -72,6 +79,8 @@ type ShadowInstancedDraw = {
   Mesh: PrimitiveMesh
   Transforms: Matrix[]
   InstanceCount: int
+  /// Whether this draw was emitted while shadows were enabled (see ShadowMeshDraw).
+  CastsShadow: bool
 }
 
 /// <summary>
@@ -170,9 +179,9 @@ type ShadowResources(atlasCfg: ShadowAtlasConfig, biasCfg: ShadowBiasConfig) =
   /// shadow-casting light exists or DepthShadow.fx is unavailable.</summary>
   member val ShadowResult: ShadowResult voption = ValueNone with get, set
 
-  /// <summary>Opaque-geometry counts from the last collection. Populated whenever the shadow pass
-  /// or a depth pre-pass collected geometry. The camera-POV depth pre-pass reuses the same
-  /// collected draws (see <c>ShadowPass.renderDepth</c>), so shadow + depth share one collection.</summary>
+  /// <summary>Opaque-geometry counts from the last unified collection. Populated whenever the
+  /// shadow pass or a scene-depth pass collected geometry. The scene-depth render reads the same
+  /// collected arrays (all entries), while the shadow render reads only <c>CastsShadow</c> entries.</summary>
   member val CollectedDrawCount = 0 with get, set
   member val CollectedSkinnedCount = 0 with get, set
   member val CollectedModelPartCount = 0 with get, set
@@ -341,15 +350,13 @@ module internal ShadowPass =
         )
 
   /// <summary>
-  /// Scans the command buffer once and collects every opaque caster draw (PrimitiveMesh, static
-  /// ModelMeshPart, skinned part, instanced mesh) into the pooled arrays on <paramref name="res"/>,
-  /// respecting <c>EnableShadows</c>/<c>DisableShadows</c>. Returns the four collected counts.
-  /// Shared by the shadow pass and the camera-POV depth pre-pass so neither re-scans the buffer.
+  /// Scans the command buffer once and collects every opaque draw into the pooled arrays on
+  /// <paramref name="res"/>, recording a <c>CastsShadow</c> flag per entry (snapshot of the
+  /// <c>EnableShadows</c>/<c>DisableShadows</c> state when the draw was emitted). Shared by the
+  /// shadow render (filters to <c>CastsShadow = true</c>) and the scene-depth render (all entries),
+  /// so shadow + depth never re-scan the buffer. Stashes the four counts on <paramref name="res"/>.
   /// </summary>
-  let collectCasters
-    (buffer: RenderBuffer3D)
-    (res: ShadowResources)
-    : struct (int * int * int * int) =
+  let collectGeometry (buffer: RenderBuffer3D) (res: ShadowResources) =
     let mutable castEnabled = true
     let mutable drawCount = 0
     let mutable skinnedCount = 0
@@ -364,7 +371,7 @@ module internal ShadowPass =
       match buffer[i] with
       | Command3D.EnableShadows -> castEnabled <- true
       | Command3D.DisableShadows -> castEnabled <- false
-      | Command3D.DrawPrimitive(mesh, transform, _) when castEnabled ->
+      | Command3D.DrawPrimitive(mesh, transform, _) ->
         if drawCount >= shadowDraws.Length then
           Array.Resize(&shadowDraws, shadowDraws.Length * 2)
           res.Draws <- shadowDraws
@@ -375,10 +382,11 @@ module internal ShadowPass =
           Mesh = mesh
           Transform = transform
           WorldBounds = worldBounds
+          CastsShadow = castEnabled
         }
 
         drawCount <- drawCount + 1
-      | Command3D.DrawAnimatedModel(model, transform, bones) when castEnabled ->
+      | Command3D.DrawAnimatedModel(model, transform, bones) ->
         for mesh in model.Meshes do
           for part in mesh.MeshParts do
             match part.Effect with
@@ -391,11 +399,12 @@ module internal ShadowPass =
                 Part = part
                 Transform = transform
                 Bones = bones
+                CastsShadow = castEnabled
               }
 
               skinnedCount <- skinnedCount + 1
             | _ -> ()
-      | Command3D.DrawModel(model, transform) when castEnabled ->
+      | Command3D.DrawModel(model, transform) ->
         for mesh in model.Meshes do
           for part in mesh.MeshParts do
             match part.Effect with
@@ -408,6 +417,7 @@ module internal ShadowPass =
                 Part = part
                 Transform = transform
                 Bones = Array.empty
+                CastsShadow = castEnabled
               }
 
               skinnedCount <- skinnedCount + 1
@@ -423,10 +433,11 @@ module internal ShadowPass =
               shadowModelPartDraws[modelPartCount] <- {
                 Part = part
                 Transform = transform
+                CastsShadow = castEnabled
               }
 
               modelPartCount <- modelPartCount + 1
-      | Command3D.DrawModelWith(model, transform, _) when castEnabled ->
+      | Command3D.DrawModelWith(model, transform, _) ->
         // Override material is irrelevant to depth; gather identically to DrawModel.
         for mesh in model.Meshes do
           for part in mesh.MeshParts do
@@ -440,6 +451,7 @@ module internal ShadowPass =
                 Part = part
                 Transform = transform
                 Bones = Array.empty
+                CastsShadow = castEnabled
               }
 
               skinnedCount <- skinnedCount + 1
@@ -455,12 +467,11 @@ module internal ShadowPass =
               shadowModelPartDraws[modelPartCount] <- {
                 Part = part
                 Transform = transform
+                CastsShadow = castEnabled
               }
 
               modelPartCount <- modelPartCount + 1
-      | Command3D.DrawAnimatedModelWith(model, transform, bones, _) when
-        castEnabled
-        ->
+      | Command3D.DrawAnimatedModelWith(model, transform, bones, _) ->
         // Mirror DrawAnimatedModel: SkinnedEffect parts only.
         for mesh in model.Meshes do
           for part in mesh.MeshParts do
@@ -474,17 +485,17 @@ module internal ShadowPass =
                 Part = part
                 Transform = transform
                 Bones = bones
+                CastsShadow = castEnabled
               }
 
               skinnedCount <- skinnedCount + 1
             | _ -> ()
       | Command3D.DrawInstanced(mesh, transforms, _material, instanceCount) when
-        castEnabled && instanceCount > 0
+        instanceCount > 0
         ->
-        // The world's instanced geometry (block grid, platforms, etc.) casts shadows too.
-        // Collected whole (one entry per emitted DrawInstanced); rendered via the
-        // DepthInstanced technique. No per-instance cull — the sample chunk-culls the
-        // source commands, so the emitted count is already bounded.
+        // The world's instanced geometry (block grid, platforms, etc.). Collected whole (one entry
+        // per emitted DrawInstanced). No per-instance cull — the sample chunk-culls the source
+        // commands, so the emitted count is already bounded.
         if instancedCount >= shadowInstancedDraws.Length then
           Array.Resize(&shadowInstancedDraws, shadowInstancedDraws.Length * 2)
           res.InstancedDraws <- shadowInstancedDraws
@@ -493,29 +504,544 @@ module internal ShadowPass =
           Mesh = mesh
           Transforms = transforms
           InstanceCount = instanceCount
+          CastsShadow = castEnabled
         }
 
         instancedCount <- instancedCount + 1
       | _ -> ()
 
-    struct (drawCount, skinnedCount, modelPartCount, instancedCount)
+    res.CollectedDrawCount <- drawCount
+    res.CollectedSkinnedCount <- skinnedCount
+    res.CollectedModelPartCount <- modelPartCount
+    res.CollectedInstancedCount <- instancedCount
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Per-draw-type render helpers
+  //
+  // Each renders a span of collected draws through DepthShadow.fx into the currently-bound
+  // render target. A shouldRender predicate decides per-entry inclusion:
+  //   shadow pass → CastsShadow && (frustum-visible for primitives)
+  //   scene-depth pass → always true (all opaque draws contribute depth)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  let renderPrimitiveSpan
+    (gd: GraphicsDevice)
+    (effect: Effect)
+    (shadowParams: ShadowEffectParams)
+    (viewProj: Matrix)
+    (draws: ShadowMeshDraw[])
+    (count: int)
+    (shouldRender: int -> bool)
+    =
+    for d = 0 to count - 1 do
+      if shouldRender d then
+        let draw = draws[d]
+        PbrUniforms.setMatrix shadowParams.MatModel draw.Transform
+        PbrUniforms.setMatrix shadowParams.ViewProj viewProj
+
+        for pass in effect.CurrentTechnique.Passes do
+          pass.Apply()
+          draw.Mesh.Draw(gd, effect)
+
+  let renderModelPartSpan
+    (gd: GraphicsDevice)
+    (effect: Effect)
+    (shadowParams: ShadowEffectParams)
+    (viewProj: Matrix)
+    (draws: ShadowModelPartDraw[])
+    (count: int)
+    (shouldRender: int -> bool)
+    =
+    for d = 0 to count - 1 do
+      if shouldRender d then
+        let draw = draws[d]
+        PbrUniforms.setMatrix shadowParams.MatModel draw.Transform
+        PbrUniforms.setMatrix shadowParams.ViewProj viewProj
+
+        let saved = draw.Part.Effect
+        draw.Part.Effect <- effect
+
+        try
+          drawPart(gd, draw.Part)
+        finally
+          draw.Part.Effect <- saved
+
+  let renderSkinnedSpan
+    (gd: GraphicsDevice)
+    (effect: Effect)
+    (shadowParams: ShadowEffectParams)
+    (viewProj: Matrix)
+    (boneScratch: Matrix[])
+    (draws: ShadowSkinnedDraw[])
+    (count: int)
+    (shouldRender: int -> bool)
+    =
+    effect.CurrentTechnique <- effect.Techniques["DepthSkinned"]
+
+    for d = 0 to count - 1 do
+      if shouldRender d then
+        let draw = draws[d]
+        PbrUniforms.setMatrix shadowParams.MatModel draw.Transform
+        PbrUniforms.setMatrix shadowParams.ViewProj viewProj
+
+        let boneCount = min draw.Bones.Length boneScratch.Length
+
+        for i = 0 to boneCount - 1 do
+          boneScratch[i] <- draw.Bones[i]
+
+        for i = boneCount to boneScratch.Length - 1 do
+          boneScratch[i] <- Matrix.Identity
+
+        PbrUniforms.setMatrixArray shadowParams.Bones boneScratch
+
+        let saved = draw.Part.Effect
+        draw.Part.Effect <- effect
+
+        try
+          drawPart(gd, draw.Part)
+        finally
+          draw.Part.Effect <- saved
+
+    effect.CurrentTechnique <- effect.Techniques["Depth"]
+
+  let renderInstancedSpan
+    (gd: GraphicsDevice)
+    (effect: Effect)
+    (shadowParams: ShadowEffectParams)
+    (viewProj: Matrix)
+    (res: ShadowResources)
+    (draws: ShadowInstancedDraw[])
+    (count: int)
+    (shouldRender: int -> bool)
+    =
+    effect.CurrentTechnique <- effect.Techniques["DepthInstanced"]
+    PbrUniforms.setMatrix shadowParams.MatModel Matrix.Identity
+
+    for d = 0 to count - 1 do
+      if shouldRender d then
+        let draw = draws[d]
+        let instanceCount = min draw.InstanceCount draw.Transforms.Length
+
+        if instanceCount > 0 then
+          if res.InstanceStaging.Length < instanceCount then
+            res.InstanceStaging <-
+              Array.zeroCreate<VertexInstanceWorld> instanceCount
+
+          for i = 0 to instanceCount - 1 do
+            res.InstanceStaging[i] <-
+              VertexInstanceWorld.Create draw.Transforms[i]
+
+          match res.InstanceVertexBuffer with
+          | ValueNone ->
+            let vb =
+              new VertexBuffer(
+                gd,
+                typeof<VertexInstanceWorld>,
+                instanceCount,
+                BufferUsage.WriteOnly
+              )
+
+            res.InstanceVertexBuffer <- ValueSome vb
+          | ValueSome vb when vb.VertexCount < instanceCount ->
+            vb.Dispose()
+
+            let vb' =
+              new VertexBuffer(
+                gd,
+                typeof<VertexInstanceWorld>,
+                instanceCount,
+                BufferUsage.WriteOnly
+              )
+
+            res.InstanceVertexBuffer <- ValueSome vb'
+          | _ -> ()
+
+          let instVB =
+            match res.InstanceVertexBuffer with
+            | ValueSome vb -> vb
+            | ValueNone -> Unchecked.defaultof<VertexBuffer> // unreachable
+
+          instVB.SetData(res.InstanceStaging, 0, instanceCount)
+
+          gd.SetVertexBuffers(
+            VertexBufferBinding(draw.Mesh.Vertices, 0, 0),
+            VertexBufferBinding(instVB, 0, 1)
+          )
+
+          gd.Indices <- draw.Mesh.Indices
+          PbrUniforms.setMatrix shadowParams.ViewProj viewProj
+
+          for pass in effect.CurrentTechnique.Passes do
+            pass.Apply()
+
+            gd.DrawInstancedPrimitives(
+              PrimitiveType.TriangleList,
+              0,
+              0,
+              draw.Mesh.PrimitiveCount,
+              instanceCount
+            )
+
+    effect.CurrentTechnique <- effect.Techniques["Depth"]
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // High-level passes
+  // ─────────────────────────────────────────────────────────────────────────────
 
   /// <summary>
-  /// Runs the shadow pass: collects dir + point + spot casters (B11 extends B10's dir-only), renders
-  /// depth to the atlas using <c>DepthShadow.fx</c> with <c>RasterizerState.SlopeScaleDepthBias</c>,
-  /// then uploads shadow uniforms to the PBR effect for forward-pass sampling. Per-light frustum
-  /// culling skips caster meshes outside each light's frustum (Layer 3 of the cost analysis).
+  /// Renders collected casters into the shadow atlas from each registered light's view-projection.
+  /// Filters to <c>CastsShadow = true</c> entries and frustum-culls per caster (primitives only;
+  /// skinned/model-part/instanced draw unconditionally as before). Saves/restores device state.
   /// </summary>
-  /// <param name="atlasCfg">Shadow atlas config (sizes/snap/distance).</param>
-  /// <param name="biasCfg">Shadow bias config (rasterizer polygon-offset).</param>
-  /// <param name="res">The pipeline's pooled shadow resources (atlas, effect, scratch, slots).</param>
-  /// <param name="lights">The frame's accumulated lights.</param>
-  /// <param name="pbrParams">The PBR effect params (shadow uniforms upload to its Shadow group).</param>
-  /// <param name="buffer">The command buffer (casters collected from it).</param>
-  /// <param name="activeCamera">The active camera (directional shadow origin).</param>
-  /// <param name="forceCollect">When true, collect opaque geometry even if there is no
-  /// shadow-casting light — so a camera-POV depth pre-pass can reuse it via
-  /// <c>renderDepth</c>. No-op otherwise.</param>
+  let renderAtlasCasters
+    (gd: GraphicsDevice)
+    (res: ShadowResources)
+    (biasCfg: ShadowBiasConfig)
+    (depthEffect: Effect)
+    (depthParams: ShadowEffectParams)
+    =
+    let shadowDraws = res.Draws
+    let skinnedDraws = res.SkinnedDraws
+    let instancedDraws = res.InstancedDraws
+    let modelPartDraws = res.ModelPartDraws
+    let drawCount = res.CollectedDrawCount
+    let skinnedCount = res.CollectedSkinnedCount
+    let modelPartCount = res.CollectedModelPartCount
+    let instancedCount = res.CollectedInstancedCount
+
+    if
+      drawCount = 0
+      && skinnedCount = 0
+      && instancedCount = 0
+      && modelPartCount = 0
+    then
+      ()
+    else
+      let prevViewport = gd.Viewport
+      let prevRaster = gd.RasterizerState
+      let prevBlend = gd.BlendState
+      let prevDepth = gd.DepthStencilState
+
+      gd.SetRenderTarget(res.Atlas.Fbo)
+
+      gd.Clear(
+        ClearOptions.Target ||| ClearOptions.DepthBuffer,
+        Color.White.ToVector4(),
+        1.0f,
+        0
+      )
+
+      if obj.ReferenceEquals(res.Raster, null) then
+        let sr = new RasterizerState()
+        sr.CullMode <- CullMode.CullCounterClockwiseFace
+        sr.DepthBias <- biasCfg.DirectionalBias
+        sr.SlopeScaleDepthBias <- biasCfg.SlopeScaleBias
+        res.Raster <- sr
+
+      gd.RasterizerState <- res.Raster
+      gd.BlendState <- BlendState.Opaque
+      gd.DepthStencilState <- DepthStencilState.Default
+      depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
+
+      let shadowFrustum = res.Frustum
+
+      for caster in res.Atlas.Casters do
+        if caster.Enabled then
+          let casterVP = res.Atlas.GetRegionViewProj caster.AtlasRegion
+          gd.Viewport <- res.Atlas.GetRegionViewport(caster.AtlasRegion)
+          shadowFrustum.Matrix <- casterVP
+
+          renderPrimitiveSpan
+            gd
+            depthEffect
+            depthParams
+            casterVP
+            shadowDraws
+            drawCount
+            (fun d ->
+              shadowDraws[d].CastsShadow
+              && Culling.isVisible shadowFrustum shadowDraws[d].WorldBounds)
+
+          renderModelPartSpan
+            gd
+            depthEffect
+            depthParams
+            casterVP
+            modelPartDraws
+            modelPartCount
+            (fun d -> modelPartDraws[d].CastsShadow)
+
+          renderSkinnedSpan
+            gd
+            depthEffect
+            depthParams
+            casterVP
+            res.BonePaletteScratch
+            skinnedDraws
+            skinnedCount
+            (fun d -> skinnedDraws[d].CastsShadow)
+
+          renderInstancedSpan
+            gd
+            depthEffect
+            depthParams
+            casterVP
+            res
+            instancedDraws
+            instancedCount
+            (fun d -> instancedDraws[d].CastsShadow)
+
+      gd.SetRenderTarget null
+      gd.Viewport <- prevViewport
+      gd.RasterizerState <- prevRaster
+      gd.BlendState <- prevBlend
+      gd.DepthStencilState <- prevDepth
+
+  /// <summary>
+  /// Renders ALL collected opaque geometry from a camera view-projection into an R32F depth target
+  /// (NDC z in [0,1], 1.0 = far). No frustum cull (the camera frustum already bounds the visible
+  /// scene), no <c>CastsShadow</c> filter — every opaque draw contributes to depth so post-process
+  /// distance effects (fog, DOF, SSAO) get correct per-pixel distance. Saves/restores device state.
+  /// </summary>
+  let renderSceneDepth
+    (gd: GraphicsDevice)
+    (res: ShadowResources)
+    (depthEffect: Effect)
+    (depthParams: ShadowEffectParams)
+    (viewProj: Matrix)
+    (depthTarget: RenderTarget2D)
+    =
+    let prevViewport = gd.Viewport
+    let prevRaster = gd.RasterizerState
+    let prevBlend = gd.BlendState
+    let prevDepth = gd.DepthStencilState
+
+    gd.SetRenderTarget depthTarget
+    // 1.0 = far: uncovered pixels (skybox, gaps) read as far so post-process fog treats them as
+    // fully fogged rather than near. Clear as an explicit Vector4 so the R32F target gets .r=1.0.
+    gd.Clear(ClearOptions.Target, Color.White.ToVector4(), 1.0f, 0)
+
+    gd.RasterizerState <- RasterizerState.CullCounterClockwise
+    gd.BlendState <- BlendState.Opaque
+    gd.DepthStencilState <- DepthStencilState.Default
+    depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
+
+    renderPrimitiveSpan
+      gd
+      depthEffect
+      depthParams
+      viewProj
+      res.Draws
+      res.CollectedDrawCount
+      (fun _ -> true)
+
+    renderModelPartSpan
+      gd
+      depthEffect
+      depthParams
+      viewProj
+      res.ModelPartDraws
+      res.CollectedModelPartCount
+      (fun _ -> true)
+
+    renderSkinnedSpan
+      gd
+      depthEffect
+      depthParams
+      viewProj
+      res.BonePaletteScratch
+      res.SkinnedDraws
+      res.CollectedSkinnedCount
+      (fun _ -> true)
+
+    renderInstancedSpan
+      gd
+      depthEffect
+      depthParams
+      viewProj
+      res
+      res.InstancedDraws
+      res.CollectedInstancedCount
+      (fun _ -> true)
+
+    gd.SetRenderTarget null
+    gd.Viewport <- prevViewport
+    gd.RasterizerState <- prevRaster
+    gd.BlendState <- prevBlend
+    gd.DepthStencilState <- prevDepth
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Shadow-specific helpers (caster registration + uniform upload)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Registers shadow-casting lights (dir → point → spot) into the atlas and returns the number
+  /// of casters that fit. The flat shader-array index == registration order (matches
+  /// <c>PrepareUniforms</c>). Returns 0 when the atlas is full or no caster registered.
+  /// </summary>
+  let registerCasters
+    (atlasCfg: ShadowAtlasConfig)
+    (res: ShadowResources)
+    (lights: LightBuffers)
+    (activeCamera: Camera3D)
+    : int =
+    res.Atlas.Clear()
+    let mutable casterSlot = 0
+
+    // Directional caster first (slot 0 by convention).
+    let hasDirCaster =
+      let mutable found = false
+
+      for i = 0 to lights.DirLights.Count - 1 do
+        if lights.DirLights[i].CastsShadows then
+          found <- true
+
+      found
+
+    if hasDirCaster then
+      let mutable dirIdx = 0
+
+      while not lights.DirLights[dirIdx].CastsShadows do
+        dirIdx <- dirIdx + 1
+
+      let dirLight = lights.DirLights[dirIdx]
+      let dir = Conversions.fromNumericsVector3 dirLight.Direction
+      let vp = buildDirectionalViewProj atlasCfg res.Origin dir activeCamera
+
+      match
+        res.Atlas.AddCaster(
+          ShadowCasterType.Directional,
+          Vector3.Zero,
+          dir,
+          Vector3.Zero,
+          true,
+          ValueNone
+        )
+      with
+      | ValueSome _ ->
+        res.Atlas.SetRegionViewProj(casterSlot, vp)
+        casterSlot <- casterSlot + 1
+      | ValueNone -> ()
+
+    // Point lights.
+    for i = 0 to lights.PointLights.Count - 1 do
+      let pt = lights.PointLights[i]
+
+      if pt.CastsShadows then
+        let ptPos = Conversions.fromNumericsVector3 pt.Position
+        let vp = buildPointViewProj(ptPos, pt.Radius)
+
+        match
+          res.Atlas.AddCaster(
+            ShadowCasterType.Point,
+            ptPos,
+            Vector3.Zero,
+            Vector3.Zero,
+            true,
+            pt.ShadowBias
+          )
+        with
+        | ValueSome _ ->
+          res.Atlas.SetRegionViewProj(casterSlot, vp)
+          res.PointShadowSlots[i] <- casterSlot
+          casterSlot <- casterSlot + 1
+        | ValueNone -> ()
+
+    // Spot lights.
+    for i = 0 to lights.SpotLights.Count - 1 do
+      let sp = lights.SpotLights[i]
+
+      if sp.CastsShadows then
+        let vp = buildSpotViewProj sp
+        let spPos = Conversions.fromNumericsVector3 sp.Position
+        let spDir = Conversions.fromNumericsVector3 sp.Direction
+
+        match
+          res.Atlas.AddCaster(
+            ShadowCasterType.Spot,
+            spPos,
+            spDir,
+            spPos + spDir,
+            true,
+            sp.ShadowBias
+          )
+        with
+        | ValueSome _ ->
+          res.Atlas.SetRegionViewProj(casterSlot, vp)
+          res.SpotShadowSlots[i] <- casterSlot
+          casterSlot <- casterSlot + 1
+        | ValueNone -> ()
+
+    casterSlot
+
+  /// <summary>
+  /// Copies shadow atlas data (view-projections, UV offsets, biases, texel size, atlas texture)
+  /// into the PBR effect's shadow uniform group so the forward pass can sample shadows.
+  /// </summary>
+  let uploadShadowUniforms
+    (gd: GraphicsDevice)
+    (res: ShadowResources)
+    (atlasCfg: ShadowAtlasConfig)
+    (pbrParams: PbrEffectParams voption)
+    (hasDirCaster: bool)
+    =
+    let active = res.Atlas.ActiveCasterCount
+    let maxC = atlasCfg.MaxCasters
+
+    if res.ViewProjsScratch.Length <> maxC then
+      res.ViewProjsScratch <- Array.zeroCreate<Matrix> maxC
+
+    if res.UVOffsetsScratch.Length <> maxC then
+      res.UVOffsetsScratch <- Array.zeroCreate<Vector4> maxC
+
+    if res.BiasesScratch.Length <> maxC then
+      res.BiasesScratch <- Array.zeroCreate<float32> maxC
+
+    Array.Clear(res.ViewProjsScratch, 0, maxC)
+    Array.Clear(res.UVOffsetsScratch, 0, maxC)
+    Array.Clear(res.BiasesScratch, 0, maxC)
+
+    if active > 0 then
+      let vpArr = res.Atlas.ViewProjs
+      let uvArr = res.Atlas.UVOffsets
+      let biasArr = res.Atlas.Biases
+
+      for i = 0 to active - 1 do
+        res.ViewProjsScratch[i] <- vpArr[i]
+        res.UVOffsetsScratch[i] <- uvArr[i]
+        res.BiasesScratch[i] <- biasArr[i]
+
+    let texel = 1.0f / float32 atlasCfg.Resolution
+
+    match pbrParams with
+    | ValueSome p ->
+      PbrUniforms.setInt
+        p.Shadow.DirLightCastsShadows
+        (if hasDirCaster then 1 else 0)
+
+      if active > 0 then
+        PbrUniforms.setMatrixArray p.Shadow.ShadowViewProjs res.ViewProjsScratch
+        PbrUniforms.setVec4Array p.Shadow.ShadowUVOffsets res.UVOffsetsScratch
+        PbrUniforms.setFloatArray p.Shadow.ShadowBiases res.BiasesScratch
+
+      PbrUniforms.setVec2 p.Shadow.ShadowTexelSize (Vector2(texel, texel))
+
+      if not(obj.ReferenceEquals(p.Shadow.ShadowAtlasTex, null)) then
+        p.Shadow.ShadowAtlasTex.SetValue(res.Atlas.Fbo)
+
+      gd.Textures[5] <- res.Atlas.Fbo
+      gd.SamplerStates[5] <- SamplerState.PointClamp
+    | ValueNone -> ()
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Orchestrator
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /// <summary>
+  /// Runs the shadow pass: scans lights, collects opaque geometry once (shared with scene-depth),
+  /// registers casters into the atlas, renders depth, and uploads shadow uniforms to the PBR
+  /// effect. When <paramref name="needsDepth"/> is true, geometry is collected even without a
+  /// shadow-casting light so <c>renderSceneDepth</c> can reuse it.
+  /// </summary>
   let run
     (gd: GraphicsDevice)
     (atlasCfg: ShadowAtlasConfig)
@@ -525,29 +1051,28 @@ module internal ShadowPass =
     (pbrParams: PbrEffectParams voption)
     (buffer: RenderBuffer3D)
     (activeCamera: Camera3D)
-    (forceCollect: bool)
+    (needsDepth: bool)
     : ShadowResult voption =
+    // ── Scan lights for casters ──
     let mutable hasDirCaster = false
+    let mutable hasPointCaster = false
+    let mutable hasSpotCaster = false
 
     for i = 0 to lights.DirLights.Count - 1 do
       if lights.DirLights[i].CastsShadows then
         hasDirCaster <- true
 
-    let mutable hasPointCaster = false
-
     for i = 0 to lights.PointLights.Count - 1 do
       if lights.PointLights[i].CastsShadows then
         hasPointCaster <- true
-
-    let mutable hasSpotCaster = false
 
     for i = 0 to lights.SpotLights.Count - 1 do
       if lights.SpotLights[i].CastsShadows then
         hasSpotCaster <- true
 
-    // Always init the per-light slot mappings (default -1 = no shadow). Even with no casters,
-    // the forward pass reads these to upload pointLightShadowIdx/spotLightShadowIdx. Reuse across
-    // frames (reallocate only if the light count grew).
+    let hasAnyCaster = hasDirCaster || hasPointCaster || hasSpotCaster
+
+    // ── Init per-light slot mappings (-1 = no shadow) ──
     if res.PointShadowSlots.Length < lights.PointLights.Count then
       res.PointShadowSlots <- Array.create<int> lights.PointLights.Count -1
     else
@@ -558,39 +1083,21 @@ module internal ShadowPass =
     else
       Array.Fill(res.SpotShadowSlots, -1)
 
-    let hasAnyCaster = hasDirCaster || hasPointCaster || hasSpotCaster
+    // ── Collect opaque geometry ONCE (shared by shadow render + scene-depth render) ──
+    if hasAnyCaster || needsDepth then
+      collectGeometry buffer res
 
-    let mutable result: ShadowResult voption = ValueNone
-
-    // Collect opaque geometry ONCE — the shadow pass (when a shadow-casting light exists) and the
-    // camera-POV depth pre-pass (forceCollect) share the same collected draws instead of each
-    // scanning the buffer. Stash the counts on res so renderDepth can iterate them.
-    let struct (drawCount, skinnedCount, modelPartCount, instancedCount) =
-      if hasAnyCaster || forceCollect then
-        collectCasters buffer res
-      else
-        struct (0, 0, 0, 0)
-
-    res.CollectedDrawCount <- drawCount
-    res.CollectedSkinnedCount <- skinnedCount
-    res.CollectedModelPartCount <- modelPartCount
-    res.CollectedInstancedCount <- instancedCount
-
-    // Read-only aliases over the (possibly grown) pooled arrays — the render loop below reads them.
-    let shadowDraws = res.Draws
-    let shadowSkinnedDraws = res.SkinnedDraws
-    let shadowInstancedDraws = res.InstancedDraws
-    let shadowModelPartDraws = res.ModelPartDraws
-
+    // ── Shadow pass (only when a shadow-casting light exists) ──
     if not hasAnyCaster then
       match pbrParams with
       | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
       | ValueNone -> ()
-    // No shadow-casting light → no result; scene renders unshadowed. (Geometry may still have
-    // been collected above when a depth pre-pass was requested.)
+
+      ValueNone
     else
       res.Atlas.EnsureResources gd
 
+      // Load DepthShadow effect on first use.
       match res.Effect, res.Params with
       | ValueSome _, ValueSome _ -> ()
       | _ ->
@@ -602,563 +1109,31 @@ module internal ShadowPass =
 
       match res.Effect, res.Params with
       | ValueSome depthEffect, ValueSome depthParams ->
-        res.Atlas.Clear()
-
-        // ── Register casters: dir first (slot 0), then point, then spot ──
-        // The flat shader-array index == registration order (matches PrepareUniforms).
-        let mutable casterSlot = 0
-
-        if hasDirCaster then
-          let mutable dirIdx = 0
-
-          while not lights.DirLights[dirIdx].CastsShadows do
-            dirIdx <- dirIdx + 1
-
-          let dirLight = lights.DirLights[dirIdx]
-          let dir = Conversions.fromNumericsVector3 dirLight.Direction
-
-          let vp = buildDirectionalViewProj atlasCfg res.Origin dir activeCamera
-
-          match
-            res.Atlas.AddCaster(
-              ShadowCasterType.Directional,
-              Vector3.Zero,
-              dir,
-              Vector3.Zero,
-              true,
-              ValueNone
-            )
-          with
-          | ValueSome _ ->
-            res.Atlas.SetRegionViewProj(casterSlot, vp)
-            casterSlot <- casterSlot + 1
-          | ValueNone -> ()
-
-        // Point lights (for loop, not Seq.iteri — avoids per-frame enumerator allocation).
-        for i = 0 to lights.PointLights.Count - 1 do
-          let pt = lights.PointLights[i]
-
-          if pt.CastsShadows then
-            let ptPos = Conversions.fromNumericsVector3 pt.Position
-            let vp = buildPointViewProj(ptPos, pt.Radius)
-
-            match
-              res.Atlas.AddCaster(
-                ShadowCasterType.Point,
-                ptPos,
-                Vector3.Zero,
-                Vector3.Zero,
-                true,
-                pt.ShadowBias
-              )
-            with
-            | ValueSome _ ->
-              res.Atlas.SetRegionViewProj(casterSlot, vp)
-              res.PointShadowSlots[i] <- casterSlot
-              casterSlot <- casterSlot + 1
-            | ValueNone -> ()
-
-        // Spot lights.
-        for i = 0 to lights.SpotLights.Count - 1 do
-          let sp = lights.SpotLights[i]
-
-          if sp.CastsShadows then
-            let vp = buildSpotViewProj sp
-
-            let spPos = Conversions.fromNumericsVector3 sp.Position
-            let spDir = Conversions.fromNumericsVector3 sp.Direction
-
-            match
-              res.Atlas.AddCaster(
-                ShadowCasterType.Spot,
-                spPos,
-                spDir,
-                spPos + spDir,
-                true,
-                sp.ShadowBias
-              )
-            with
-            | ValueSome _ ->
-              res.Atlas.SetRegionViewProj(casterSlot, vp)
-              res.SpotShadowSlots[i] <- casterSlot
-              casterSlot <- casterSlot + 1
-            | ValueNone -> ()
+        let casterSlot = registerCasters atlasCfg res lights activeCamera
 
         if casterSlot = 0 then
-          // Caster registration failed for every shadow light (atlas full). Effect params
-          // persist between frames in MonoGame, so DirLightCastsShadows (set to 1 on a
-          // previous successful frame) would leave the PBR shader sampling stale shadow
-          // matrices/UVs. Zero it explicitly so the scene renders unshadowed this frame.
+          // Atlas full — clear the flag so the PBR shader doesn't sample stale shadow data.
           match pbrParams with
           | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
           | ValueNone -> ()
-        else if
-          drawCount = 0
-          && skinnedCount = 0
-          && instancedCount = 0
-          && modelPartCount = 0
-        then
-          ()
+
+          ValueNone
         else
           res.Atlas.PrepareUniforms()
+          renderAtlasCasters gd res biasCfg depthEffect depthParams
+          uploadShadowUniforms gd res atlasCfg pbrParams hasDirCaster
 
-          // ── Render depth into the atlas ──
-          let prevViewport = gd.Viewport
-          let prevRaster = gd.RasterizerState
-          let prevBlend = gd.BlendState
-          let prevDepth = gd.DepthStencilState
-
-          gd.SetRenderTarget(res.Atlas.Fbo)
-          // Clear color (white = far = lit) AND depth (depth test enabled for hidden-surface removal).
-          gd.Clear(
-            ClearOptions.Target ||| ClearOptions.DepthBuffer,
-            Color.White.ToVector4(),
-            1.0f,
-            0
-          )
-
-          // Native polygon-offset bias. Cached (config-driven). For B11 the bias uses
-          // DirectionalBias as the base — per-type bias swap is deferred.
-          if obj.ReferenceEquals(res.Raster, null) then
-            let sr = new RasterizerState()
-            // Render front faces into the shadow map. The imported geometry (Kenney
-            // assets and typical MonoGame content) is clockwise-wound; keeping the
-            // front-facing sides writes the caster surfaces that are actually visible
-            // to the light. Back-face rendering was tried but produced identical
-            // self-shadowing results once receiver-side bias was added, so the
-            // simpler front-face path is kept.
-            sr.CullMode <- CullMode.CullCounterClockwiseFace
-            sr.DepthBias <- biasCfg.DirectionalBias
-            sr.SlopeScaleDepthBias <- biasCfg.SlopeScaleBias
-            res.Raster <- sr
-
-          gd.RasterizerState <- res.Raster
-          gd.BlendState <- BlendState.Opaque
-          gd.DepthStencilState <- DepthStencilState.Default
-          depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-          let shadowFrustum = res.Frustum
-          let bonePaletteScratch = res.BonePaletteScratch
-
-          for caster in res.Atlas.Casters do
-            if caster.Enabled then
-              let casterVP = res.Atlas.GetRegionViewProj caster.AtlasRegion
-              gd.Viewport <- res.Atlas.GetRegionViewport(caster.AtlasRegion)
-              // Per-light frustum cull: skip meshes the caster's frustum can't see. Update in-place.
-              shadowFrustum.Matrix <- casterVP
-
-              // ── Non-skinned casters (PrimitiveMesh, plain Depth technique) ──
-              for d = 0 to drawCount - 1 do
-                let draw = shadowDraws[d]
-
-                if Culling.isVisible shadowFrustum draw.WorldBounds then
-                  PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-                  PbrUniforms.setMatrix depthParams.ViewProj casterVP
-
-                  for pass in depthEffect.CurrentTechnique.Passes do
-                    pass.Apply()
-                    draw.Mesh.Draw(gd, depthEffect)
-
-              // ── Static ModelMeshPart casters (DrawModel/DrawModelWith, plain Depth technique) ──
-              if modelPartCount > 0 then
-                for d = 0 to modelPartCount - 1 do
-                  let draw = shadowModelPartDraws[d]
-                  PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-                  PbrUniforms.setMatrix depthParams.ViewProj casterVP
-
-                  let saved = draw.Part.Effect
-                  draw.Part.Effect <- depthEffect
-
-                  try
-                    drawPart(gd, draw.Part)
-                  finally
-                    draw.Part.Effect <- saved
-
-              // ── Skinned casters (B12: DepthSkinned technique, bone palette upload) ──
-              if skinnedCount > 0 then
-                depthEffect.CurrentTechnique <-
-                  depthEffect.Techniques["DepthSkinned"]
-
-                for d = 0 to skinnedCount - 1 do
-                  let draw = shadowSkinnedDraws[d]
-                  PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-                  PbrUniforms.setMatrix depthParams.ViewProj casterVP
-
-                  let boneCount =
-                    min draw.Bones.Length bonePaletteScratch.Length
-
-                  for i = 0 to boneCount - 1 do
-                    bonePaletteScratch[i] <- draw.Bones[i]
-
-                  for i = boneCount to bonePaletteScratch.Length - 1 do
-                    bonePaletteScratch[i] <- Matrix.Identity
-
-                  PbrUniforms.setMatrixArray
-                    depthParams.Bones
-                    bonePaletteScratch
-
-                  // drawPart applies part.Effect.CurrentTechnique.Passes, so DepthSkinned must be
-                  // bound on the part's own Effect slot — swap it for the depth effect around the draw.
-                  let saved = draw.Part.Effect
-                  draw.Part.Effect <- depthEffect
-
-                  try
-                    drawPart(gd, draw.Part)
-                  finally
-                    draw.Part.Effect <- saved
-
-                depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-
-              // ── Instanced casters: hardware instancing via two-stream vertex bind. ──
-              if instancedCount > 0 then
-                depthEffect.CurrentTechnique <-
-                  depthEffect.Techniques["DepthInstanced"]
-
-                // matModel is identity for instanced draws: the per-instance world transform
-                // is supplied as VertexInstanceWorld rows on stream 1.
-                PbrUniforms.setMatrix depthParams.MatModel Matrix.Identity
-
-                for d = 0 to instancedCount - 1 do
-                  let draw = shadowInstancedDraws[d]
-
-                  // Defensive: the source DrawInstanced command should always have a
-                  // transforms array matching instanceCount, but clamp to the available
-                  // data so a malformed command cannot read past the array.
-                  let instanceCount =
-                    min draw.InstanceCount draw.Transforms.Length
-
-                  if instanceCount > 0 then
-                    if res.InstanceStaging.Length < instanceCount then
-                      res.InstanceStaging <-
-                        Array.zeroCreate<VertexInstanceWorld> instanceCount
-
-                    for i = 0 to instanceCount - 1 do
-                      res.InstanceStaging[i] <-
-                        VertexInstanceWorld.Create draw.Transforms[i]
-
-                    match res.InstanceVertexBuffer with
-                    | ValueNone ->
-                      let vb =
-                        new VertexBuffer(
-                          gd,
-                          typeof<VertexInstanceWorld>,
-                          instanceCount,
-                          BufferUsage.WriteOnly
-                        )
-
-                      res.InstanceVertexBuffer <- ValueSome vb
-                    | ValueSome vb when vb.VertexCount < instanceCount ->
-                      vb.Dispose()
-
-                      let vb' =
-                        new VertexBuffer(
-                          gd,
-                          typeof<VertexInstanceWorld>,
-                          instanceCount,
-                          BufferUsage.WriteOnly
-                        )
-
-                      res.InstanceVertexBuffer <- ValueSome vb'
-                    | _ -> ()
-
-                    let instVB =
-                      match res.InstanceVertexBuffer with
-                      | ValueSome vb -> vb
-                      | ValueNone -> Unchecked.defaultof<VertexBuffer> // unreachable
-
-                    instVB.SetData(res.InstanceStaging, 0, instanceCount)
-
-                    gd.SetVertexBuffers(
-                      VertexBufferBinding(draw.Mesh.Vertices, 0, 0),
-                      VertexBufferBinding(instVB, 0, 1)
-                    )
-
-                    gd.Indices <- draw.Mesh.Indices
-
-                    PbrUniforms.setMatrix depthParams.ViewProj casterVP
-
-                    for pass in depthEffect.CurrentTechnique.Passes do
-                      pass.Apply()
-
-                      gd.DrawInstancedPrimitives(
-                        PrimitiveType.TriangleList,
-                        0,
-                        0,
-                        draw.Mesh.PrimitiveCount,
-                        instanceCount
-                      )
-
-                depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-
-          // ── Restore device state ──
-          (gd.SetRenderTarget null)
-          gd.Viewport <- prevViewport
-          gd.RasterizerState <- prevRaster
-          gd.BlendState <- prevBlend
-          gd.DepthStencilState <- prevDepth
-
-          // ── Upload shadow uniforms to the PBR effect ──
-          let active = res.Atlas.ActiveCasterCount
-          let maxC = atlasCfg.MaxCasters
-
-          if res.ViewProjsScratch.Length <> maxC then
-            res.ViewProjsScratch <- Array.zeroCreate<Matrix> maxC
-
-          if res.UVOffsetsScratch.Length <> maxC then
-            res.UVOffsetsScratch <- Array.zeroCreate<Vector4> maxC
-
-          if res.BiasesScratch.Length <> maxC then
-            res.BiasesScratch <- Array.zeroCreate<float32> maxC
-
-          Array.Clear(res.ViewProjsScratch, 0, maxC)
-          Array.Clear(res.UVOffsetsScratch, 0, maxC)
-          Array.Clear(res.BiasesScratch, 0, maxC)
-
-          if active > 0 then
-            let vpArr = res.Atlas.ViewProjs
-            let uvArr = res.Atlas.UVOffsets
-            let biasArr = res.Atlas.Biases
-
-            for i = 0 to active - 1 do
-              res.ViewProjsScratch[i] <- vpArr[i]
-              res.UVOffsetsScratch[i] <- uvArr[i]
-              res.BiasesScratch[i] <- biasArr[i]
-
-          let texel = 1.0f / float32 atlasCfg.Resolution
-
-          match pbrParams with
-          | ValueSome p ->
-            PbrUniforms.setInt
-              p.Shadow.DirLightCastsShadows
-              (if hasDirCaster then 1 else 0)
-
-            if active > 0 then
-              PbrUniforms.setMatrixArray
-                p.Shadow.ShadowViewProjs
-                res.ViewProjsScratch
-
-              PbrUniforms.setVec4Array
-                p.Shadow.ShadowUVOffsets
-                res.UVOffsetsScratch
-
-              PbrUniforms.setFloatArray p.Shadow.ShadowBiases res.BiasesScratch
-
-            PbrUniforms.setVec2 p.Shadow.ShadowTexelSize (Vector2(texel, texel))
-
-            if not(obj.ReferenceEquals(p.Shadow.ShadowAtlasTex, null)) then
-              p.Shadow.ShadowAtlasTex.SetValue(res.Atlas.Fbo)
-
-            gd.Textures[5] <- res.Atlas.Fbo
-            gd.SamplerStates[5] <- SamplerState.PointClamp
-          | ValueNone -> ()
-
-          result <-
-            ValueSome {
-              Atlas = res.Atlas.Fbo
-              ViewProjs = res.ViewProjsScratch
-              UVOffsets = res.UVOffsetsScratch
-              ActiveCasterCount = active
-              TexelSize = texel
-              Biases = res.BiasesScratch
-              DirLightCastsShadows = hasDirCaster
-              PointLightShadowIdx = res.PointShadowSlots
-              SpotLightShadowIdx = res.SpotShadowSlots
-            }
-      | _ -> () // DepthShadow.fx missing — render unshadowed (result stays ValueNone).
-
-    result
-
-  /// <summary>
-  /// Renders the opaque geometry already collected by <see cref="M:Mibo.Elmish.Graphics3D.Pipelines.ShadowPass.run"/>
-  /// (or <c>collectCasters</c>) from a camera view-projection into <paramref name="depthTarget"/> as
-  /// NDC depth (clip.z/clip.w in [0,1], 1.0 = far). Drives camera-POV distance effects (fog, DOF,
-  /// SSAO): linearize with the camera's near/far planes in the consuming shader. No per-light
-  /// frustum cull — the camera frustum already bounds the visible scene. Requires the DepthShadow
-  /// effect to be loadable; otherwise the target is left uncleared and <c>ValueNone</c> is returned.
-  /// </summary>
-  /// <returns><c>ValueSome depthTarget</c> if the pass ran, <c>ValueNone</c> if the DepthShadow
-  /// effect is unavailable or nothing was collected.</returns>
-  let renderDepth
-    (gd: GraphicsDevice)
-    (res: ShadowResources)
-    (atlasCfg: ShadowAtlasConfig)
-    (viewProj: Matrix)
-    (depthTarget: RenderTarget2D)
-    : RenderTarget2D voption =
-    let drawCount = res.CollectedDrawCount
-    let skinnedCount = res.CollectedSkinnedCount
-    let modelPartCount = res.CollectedModelPartCount
-    let instancedCount = res.CollectedInstancedCount
-
-    if
-      drawCount = 0
-      && skinnedCount = 0
-      && modelPartCount = 0
-      && instancedCount = 0
-    then
-      ValueNone
-    else
-      // Ensure the DepthShadow effect is loaded (shared with the shadow pass).
-      match res.Effect, res.Params with
-      | ValueSome _, ValueSome _ -> ()
+          ValueSome {
+            Atlas = res.Atlas.Fbo
+            ViewProjs = res.ViewProjsScratch
+            UVOffsets = res.UVOffsetsScratch
+            ActiveCasterCount = res.Atlas.ActiveCasterCount
+            TexelSize = 1.0f / float32 atlasCfg.Resolution
+            Biases = res.BiasesScratch
+            DirLightCastsShadows = hasDirCaster
+            PointLightShadowIdx = res.PointShadowSlots
+            SpotLightShadowIdx = res.SpotShadowSlots
+          }
       | _ ->
-        match ShaderLoader.loadEffect gd "DepthShadow" with
-        | ValueSome e ->
-          res.Params <- ValueSome(buildShadowParams e)
-          res.Effect <- ValueSome e
-        | ValueNone -> ()
-
-      match res.Effect, res.Params with
-      | ValueNone, _
-      | _, ValueNone -> ValueNone
-      | ValueSome depthEffect, ValueSome depthParams ->
-        let prevViewport = gd.Viewport
-        let prevRaster = gd.RasterizerState
-        let prevBlend = gd.BlendState
-        let prevDepth = gd.DepthStencilState
-
-        gd.SetRenderTarget depthTarget
-        // 1.0 = far (matches DepthShadow.fx's clip.z/clip.w). Clear as an explicit Vector4 so the
-        // R32F (SurfaceFormat.Single) target gets .r=1.0 reliably on both backends.
-        gd.Clear(ClearOptions.Target, Color.White.ToVector4(), 1.0f, 0)
-        gd.RasterizerState <- RasterizerState.CullCounterClockwise
-        gd.BlendState <- BlendState.Opaque
-        gd.DepthStencilState <- DepthStencilState.Default
-
-        depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-
-        // ── Non-skinned PrimitiveMesh ──
-        for d = 0 to drawCount - 1 do
-          let draw = res.Draws[d]
-          PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-          PbrUniforms.setMatrix depthParams.ViewProj viewProj
-
-          for pass in depthEffect.CurrentTechnique.Passes do
-            pass.Apply()
-            draw.Mesh.Draw(gd, depthEffect)
-
-        // ── Static ModelMeshPart (DrawModel/DrawModelWith) ──
-        if modelPartCount > 0 then
-          for d = 0 to modelPartCount - 1 do
-            let draw = res.ModelPartDraws[d]
-            PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-            PbrUniforms.setMatrix depthParams.ViewProj viewProj
-
-            let saved = draw.Part.Effect
-            draw.Part.Effect <- depthEffect
-
-            try
-              drawPart(gd, draw.Part)
-            finally
-              draw.Part.Effect <- saved
-
-        // ── Skinned (DepthSkinned technique, bone palette) ──
-        if skinnedCount > 0 then
-          depthEffect.CurrentTechnique <- depthEffect.Techniques["DepthSkinned"]
-          let bonePaletteScratch = res.BonePaletteScratch
-
-          for d = 0 to skinnedCount - 1 do
-            let draw = res.SkinnedDraws[d]
-            PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-            PbrUniforms.setMatrix depthParams.ViewProj viewProj
-
-            let boneCount = min draw.Bones.Length bonePaletteScratch.Length
-
-            for i = 0 to boneCount - 1 do
-              bonePaletteScratch[i] <- draw.Bones[i]
-
-            for i = boneCount to bonePaletteScratch.Length - 1 do
-              bonePaletteScratch[i] <- Matrix.Identity
-
-            PbrUniforms.setMatrixArray depthParams.Bones bonePaletteScratch
-
-            let saved = draw.Part.Effect
-            draw.Part.Effect <- depthEffect
-
-            try
-              drawPart(gd, draw.Part)
-            finally
-              draw.Part.Effect <- saved
-
-          depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-
-        // ── Instanced (DepthInstanced, two-stream vertex bind) ──
-        if instancedCount > 0 then
-          depthEffect.CurrentTechnique <-
-            depthEffect.Techniques["DepthInstanced"]
-
-          PbrUniforms.setMatrix depthParams.MatModel Matrix.Identity
-
-          for d = 0 to instancedCount - 1 do
-            let draw = res.InstancedDraws[d]
-            let instanceCount = min draw.InstanceCount draw.Transforms.Length
-
-            if instanceCount > 0 then
-              if res.InstanceStaging.Length < instanceCount then
-                res.InstanceStaging <-
-                  Array.zeroCreate<VertexInstanceWorld> instanceCount
-
-              for i = 0 to instanceCount - 1 do
-                res.InstanceStaging[i] <-
-                  VertexInstanceWorld.Create draw.Transforms[i]
-
-              match res.InstanceVertexBuffer with
-              | ValueNone ->
-                let vb =
-                  new VertexBuffer(
-                    gd,
-                    typeof<VertexInstanceWorld>,
-                    instanceCount,
-                    BufferUsage.WriteOnly
-                  )
-
-                res.InstanceVertexBuffer <- ValueSome vb
-              | ValueSome vb when vb.VertexCount < instanceCount ->
-                vb.Dispose()
-
-                let vb' =
-                  new VertexBuffer(
-                    gd,
-                    typeof<VertexInstanceWorld>,
-                    instanceCount,
-                    BufferUsage.WriteOnly
-                  )
-
-                res.InstanceVertexBuffer <- ValueSome vb'
-              | _ -> ()
-
-              let instVB =
-                match res.InstanceVertexBuffer with
-                | ValueSome vb -> vb
-                | ValueNone -> Unchecked.defaultof<VertexBuffer> // unreachable
-
-              instVB.SetData(res.InstanceStaging, 0, instanceCount)
-
-              gd.SetVertexBuffers(
-                VertexBufferBinding(draw.Mesh.Vertices, 0, 0),
-                VertexBufferBinding(instVB, 0, 1)
-              )
-
-              gd.Indices <- draw.Mesh.Indices
-
-              PbrUniforms.setMatrix depthParams.ViewProj viewProj
-
-              for pass in depthEffect.CurrentTechnique.Passes do
-                pass.Apply()
-
-                gd.DrawInstancedPrimitives(
-                  PrimitiveType.TriangleList,
-                  0,
-                  0,
-                  draw.Mesh.PrimitiveCount,
-                  instanceCount
-                )
-
-          depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-
-        gd.SetRenderTarget null
-        gd.Viewport <- prevViewport
-        gd.RasterizerState <- prevRaster
-        gd.BlendState <- prevBlend
-        gd.DepthStencilState <- prevDepth
-
-        ValueSome depthTarget
+        // DepthShadow.fx missing — render unshadowed.
+        ValueNone

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -170,6 +170,14 @@ type ShadowResources(atlasCfg: ShadowAtlasConfig, biasCfg: ShadowBiasConfig) =
   /// shadow-casting light exists or DepthShadow.fx is unavailable.</summary>
   member val ShadowResult: ShadowResult voption = ValueNone with get, set
 
+  /// <summary>Opaque-geometry counts from the last collection. Populated whenever the shadow pass
+  /// or a depth pre-pass collected geometry. The camera-POV depth pre-pass reuses the same
+  /// collected draws (see <c>ShadowPass.renderDepth</c>), so shadow + depth share one collection.</summary>
+  member val CollectedDrawCount = 0 with get, set
+  member val CollectedSkinnedCount = 0 with get, set
+  member val CollectedModelPartCount = 0 with get, set
+  member val CollectedInstancedCount = 0 with get, set
+
 /// <summary>The extracted shadow pass: caster geometry types, per-light ViewProj builders, and the pass body.</summary>
 module internal ShadowPass =
 
@@ -317,7 +325,7 @@ module internal ShadowPass =
     view * proj
 
   // ── drawPart: draw a single ModelMeshPart manually (part has no Draw() of its own). ──
-  let private drawPart(gd: GraphicsDevice, part: ModelMeshPart) =
+  let drawPart(gd: GraphicsDevice, part: ModelMeshPart) =
     if part.PrimitiveCount > 0 then
       gd.SetVertexBuffer(part.VertexBuffer)
       gd.Indices <- part.IndexBuffer
@@ -333,6 +341,166 @@ module internal ShadowPass =
         )
 
   /// <summary>
+  /// Scans the command buffer once and collects every opaque caster draw (PrimitiveMesh, static
+  /// ModelMeshPart, skinned part, instanced mesh) into the pooled arrays on <paramref name="res"/>,
+  /// respecting <c>EnableShadows</c>/<c>DisableShadows</c>. Returns the four collected counts.
+  /// Shared by the shadow pass and the camera-POV depth pre-pass so neither re-scans the buffer.
+  /// </summary>
+  let collectCasters
+    (buffer: RenderBuffer3D)
+    (res: ShadowResources)
+    : struct (int * int * int * int) =
+    let mutable castEnabled = true
+    let mutable drawCount = 0
+    let mutable skinnedCount = 0
+    let mutable instancedCount = 0
+    let mutable modelPartCount = 0
+    let mutable shadowDraws = res.Draws
+    let mutable shadowSkinnedDraws = res.SkinnedDraws
+    let mutable shadowInstancedDraws = res.InstancedDraws
+    let mutable shadowModelPartDraws = res.ModelPartDraws
+
+    for i = 0 to buffer.Count - 1 do
+      match buffer[i] with
+      | Command3D.EnableShadows -> castEnabled <- true
+      | Command3D.DisableShadows -> castEnabled <- false
+      | Command3D.DrawPrimitive(mesh, transform, _) when castEnabled ->
+        if drawCount >= shadowDraws.Length then
+          Array.Resize(&shadowDraws, shadowDraws.Length * 2)
+          res.Draws <- shadowDraws
+
+        let worldBounds = mesh.Bounds.Transform transform
+
+        shadowDraws[drawCount] <- {
+          Mesh = mesh
+          Transform = transform
+          WorldBounds = worldBounds
+        }
+
+        drawCount <- drawCount + 1
+      | Command3D.DrawAnimatedModel(model, transform, bones) when castEnabled ->
+        for mesh in model.Meshes do
+          for part in mesh.MeshParts do
+            match part.Effect with
+            | :? SkinnedEffect ->
+              if skinnedCount >= shadowSkinnedDraws.Length then
+                Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
+                res.SkinnedDraws <- shadowSkinnedDraws
+
+              shadowSkinnedDraws[skinnedCount] <- {
+                Part = part
+                Transform = transform
+                Bones = bones
+              }
+
+              skinnedCount <- skinnedCount + 1
+            | _ -> ()
+      | Command3D.DrawModel(model, transform) when castEnabled ->
+        for mesh in model.Meshes do
+          for part in mesh.MeshParts do
+            match part.Effect with
+            | :? SkinnedEffect ->
+              if skinnedCount >= shadowSkinnedDraws.Length then
+                Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
+                res.SkinnedDraws <- shadowSkinnedDraws
+
+              shadowSkinnedDraws[skinnedCount] <- {
+                Part = part
+                Transform = transform
+                Bones = Array.empty
+              }
+
+              skinnedCount <- skinnedCount + 1
+            | _ ->
+              if modelPartCount >= shadowModelPartDraws.Length then
+                Array.Resize(
+                  &shadowModelPartDraws,
+                  shadowModelPartDraws.Length * 2
+                )
+
+                res.ModelPartDraws <- shadowModelPartDraws
+
+              shadowModelPartDraws[modelPartCount] <- {
+                Part = part
+                Transform = transform
+              }
+
+              modelPartCount <- modelPartCount + 1
+      | Command3D.DrawModelWith(model, transform, _) when castEnabled ->
+        // Override material is irrelevant to depth; gather identically to DrawModel.
+        for mesh in model.Meshes do
+          for part in mesh.MeshParts do
+            match part.Effect with
+            | :? SkinnedEffect ->
+              if skinnedCount >= shadowSkinnedDraws.Length then
+                Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
+                res.SkinnedDraws <- shadowSkinnedDraws
+
+              shadowSkinnedDraws[skinnedCount] <- {
+                Part = part
+                Transform = transform
+                Bones = Array.empty
+              }
+
+              skinnedCount <- skinnedCount + 1
+            | _ ->
+              if modelPartCount >= shadowModelPartDraws.Length then
+                Array.Resize(
+                  &shadowModelPartDraws,
+                  shadowModelPartDraws.Length * 2
+                )
+
+                res.ModelPartDraws <- shadowModelPartDraws
+
+              shadowModelPartDraws[modelPartCount] <- {
+                Part = part
+                Transform = transform
+              }
+
+              modelPartCount <- modelPartCount + 1
+      | Command3D.DrawAnimatedModelWith(model, transform, bones, _) when
+        castEnabled
+        ->
+        // Mirror DrawAnimatedModel: SkinnedEffect parts only.
+        for mesh in model.Meshes do
+          for part in mesh.MeshParts do
+            match part.Effect with
+            | :? SkinnedEffect ->
+              if skinnedCount >= shadowSkinnedDraws.Length then
+                Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
+                res.SkinnedDraws <- shadowSkinnedDraws
+
+              shadowSkinnedDraws[skinnedCount] <- {
+                Part = part
+                Transform = transform
+                Bones = bones
+              }
+
+              skinnedCount <- skinnedCount + 1
+            | _ -> ()
+      | Command3D.DrawInstanced(mesh, transforms, _material, instanceCount) when
+        castEnabled && instanceCount > 0
+        ->
+        // The world's instanced geometry (block grid, platforms, etc.) casts shadows too.
+        // Collected whole (one entry per emitted DrawInstanced); rendered via the
+        // DepthInstanced technique. No per-instance cull — the sample chunk-culls the
+        // source commands, so the emitted count is already bounded.
+        if instancedCount >= shadowInstancedDraws.Length then
+          Array.Resize(&shadowInstancedDraws, shadowInstancedDraws.Length * 2)
+          res.InstancedDraws <- shadowInstancedDraws
+
+        shadowInstancedDraws[instancedCount] <- {
+          Mesh = mesh
+          Transforms = transforms
+          InstanceCount = instanceCount
+        }
+
+        instancedCount <- instancedCount + 1
+      | _ -> ()
+
+    struct (drawCount, skinnedCount, modelPartCount, instancedCount)
+
+  /// <summary>
   /// Runs the shadow pass: collects dir + point + spot casters (B11 extends B10's dir-only), renders
   /// depth to the atlas using <c>DepthShadow.fx</c> with <c>RasterizerState.SlopeScaleDepthBias</c>,
   /// then uploads shadow uniforms to the PBR effect for forward-pass sampling. Per-light frustum
@@ -345,6 +513,9 @@ module internal ShadowPass =
   /// <param name="pbrParams">The PBR effect params (shadow uniforms upload to its Shadow group).</param>
   /// <param name="buffer">The command buffer (casters collected from it).</param>
   /// <param name="activeCamera">The active camera (directional shadow origin).</param>
+  /// <param name="forceCollect">When true, collect opaque geometry even if there is no
+  /// shadow-casting light — so a camera-POV depth pre-pass can reuse it via
+  /// <c>renderDepth</c>. No-op otherwise.</param>
   let run
     (gd: GraphicsDevice)
     (atlasCfg: ShadowAtlasConfig)
@@ -354,6 +525,7 @@ module internal ShadowPass =
     (pbrParams: PbrEffectParams voption)
     (buffer: RenderBuffer3D)
     (activeCamera: Camera3D)
+    (forceCollect: bool)
     : ShadowResult voption =
     let mutable hasDirCaster = false
 
@@ -386,13 +558,36 @@ module internal ShadowPass =
     else
       Array.Fill(res.SpotShadowSlots, -1)
 
+    let hasAnyCaster = hasDirCaster || hasPointCaster || hasSpotCaster
+
     let mutable result: ShadowResult voption = ValueNone
 
-    if not(hasDirCaster || hasPointCaster || hasSpotCaster) then
+    // Collect opaque geometry ONCE — the shadow pass (when a shadow-casting light exists) and the
+    // camera-POV depth pre-pass (forceCollect) share the same collected draws instead of each
+    // scanning the buffer. Stash the counts on res so renderDepth can iterate them.
+    let struct (drawCount, skinnedCount, modelPartCount, instancedCount) =
+      if hasAnyCaster || forceCollect then
+        collectCasters buffer res
+      else
+        struct (0, 0, 0, 0)
+
+    res.CollectedDrawCount <- drawCount
+    res.CollectedSkinnedCount <- skinnedCount
+    res.CollectedModelPartCount <- modelPartCount
+    res.CollectedInstancedCount <- instancedCount
+
+    // Read-only aliases over the (possibly grown) pooled arrays — the render loop below reads them.
+    let shadowDraws = res.Draws
+    let shadowSkinnedDraws = res.SkinnedDraws
+    let shadowInstancedDraws = res.InstancedDraws
+    let shadowModelPartDraws = res.ModelPartDraws
+
+    if not hasAnyCaster then
       match pbrParams with
       | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
       | ValueNone -> ()
-    // No shadow-casting light → no result; scene renders unshadowed.
+    // No shadow-casting light → no result; scene renders unshadowed. (Geometry may still have
+    // been collected above when a depth pre-pass was requested.)
     else
       res.Atlas.EnsureResources gd
 
@@ -497,455 +692,473 @@ module internal ShadowPass =
           match pbrParams with
           | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
           | ValueNone -> ()
+        else if
+          drawCount = 0
+          && skinnedCount = 0
+          && instancedCount = 0
+          && modelPartCount = 0
+        then
+          ()
         else
-          // ── Collect caster meshes (PrimitiveMesh + skinned draws, gated by EnableShadows/DisableShadows) ──
-          let mutable castEnabled = true
-          let mutable drawCount = 0
-          let mutable skinnedCount = 0
-          let mutable instancedCount = 0
-          let mutable modelPartCount = 0
-          let mutable shadowDraws = res.Draws
-          let mutable shadowSkinnedDraws = res.SkinnedDraws
-          let mutable shadowInstancedDraws = res.InstancedDraws
-          let mutable shadowModelPartDraws = res.ModelPartDraws
+          res.Atlas.PrepareUniforms()
 
-          for i = 0 to buffer.Count - 1 do
-            match buffer[i] with
-            | Command3D.EnableShadows -> castEnabled <- true
-            | Command3D.DisableShadows -> castEnabled <- false
-            | Command3D.DrawPrimitive(mesh, transform, _) when castEnabled ->
-              if drawCount >= shadowDraws.Length then
-                Array.Resize(&shadowDraws, shadowDraws.Length * 2)
-                res.Draws <- shadowDraws
+          // ── Render depth into the atlas ──
+          let prevViewport = gd.Viewport
+          let prevRaster = gd.RasterizerState
+          let prevBlend = gd.BlendState
+          let prevDepth = gd.DepthStencilState
 
-              let worldBounds = mesh.Bounds.Transform transform
+          gd.SetRenderTarget(res.Atlas.Fbo)
+          // Clear color (white = far = lit) AND depth (depth test enabled for hidden-surface removal).
+          gd.Clear(
+            ClearOptions.Target ||| ClearOptions.DepthBuffer,
+            Color.White.ToVector4(),
+            1.0f,
+            0
+          )
 
-              shadowDraws[drawCount] <- {
-                Mesh = mesh
-                Transform = transform
-                WorldBounds = worldBounds
-              }
+          // Native polygon-offset bias. Cached (config-driven). For B11 the bias uses
+          // DirectionalBias as the base — per-type bias swap is deferred.
+          if obj.ReferenceEquals(res.Raster, null) then
+            let sr = new RasterizerState()
+            // Render front faces into the shadow map. The imported geometry (Kenney
+            // assets and typical MonoGame content) is clockwise-wound; keeping the
+            // front-facing sides writes the caster surfaces that are actually visible
+            // to the light. Back-face rendering was tried but produced identical
+            // self-shadowing results once receiver-side bias was added, so the
+            // simpler front-face path is kept.
+            sr.CullMode <- CullMode.CullCounterClockwiseFace
+            sr.DepthBias <- biasCfg.DirectionalBias
+            sr.SlopeScaleDepthBias <- biasCfg.SlopeScaleBias
+            res.Raster <- sr
 
-              drawCount <- drawCount + 1
-            | Command3D.DrawAnimatedModel(model, transform, bones) when
-              castEnabled
-              ->
-              for mesh in model.Meshes do
-                for part in mesh.MeshParts do
-                  match part.Effect with
-                  | :? SkinnedEffect ->
-                    if skinnedCount >= shadowSkinnedDraws.Length then
-                      Array.Resize(
-                        &shadowSkinnedDraws,
-                        shadowSkinnedDraws.Length * 2
-                      )
+          gd.RasterizerState <- res.Raster
+          gd.BlendState <- BlendState.Opaque
+          gd.DepthStencilState <- DepthStencilState.Default
+          depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
+          let shadowFrustum = res.Frustum
+          let bonePaletteScratch = res.BonePaletteScratch
 
-                      res.SkinnedDraws <- shadowSkinnedDraws
+          for caster in res.Atlas.Casters do
+            if caster.Enabled then
+              let casterVP = res.Atlas.GetRegionViewProj caster.AtlasRegion
+              gd.Viewport <- res.Atlas.GetRegionViewport(caster.AtlasRegion)
+              // Per-light frustum cull: skip meshes the caster's frustum can't see. Update in-place.
+              shadowFrustum.Matrix <- casterVP
 
-                    shadowSkinnedDraws[skinnedCount] <- {
-                      Part = part
-                      Transform = transform
-                      Bones = bones
-                    }
+              // ── Non-skinned casters (PrimitiveMesh, plain Depth technique) ──
+              for d = 0 to drawCount - 1 do
+                let draw = shadowDraws[d]
 
-                    skinnedCount <- skinnedCount + 1
-                  | _ -> ()
-            | Command3D.DrawModel(model, transform) when castEnabled ->
-              for mesh in model.Meshes do
-                for part in mesh.MeshParts do
-                  match part.Effect with
-                  | :? SkinnedEffect ->
-                    if skinnedCount >= shadowSkinnedDraws.Length then
-                      Array.Resize(
-                        &shadowSkinnedDraws,
-                        shadowSkinnedDraws.Length * 2
-                      )
+                if Culling.isVisible shadowFrustum draw.WorldBounds then
+                  PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+                  PbrUniforms.setMatrix depthParams.ViewProj casterVP
 
-                      res.SkinnedDraws <- shadowSkinnedDraws
+                  for pass in depthEffect.CurrentTechnique.Passes do
+                    pass.Apply()
+                    draw.Mesh.Draw(gd, depthEffect)
 
-                    shadowSkinnedDraws[skinnedCount] <- {
-                      Part = part
-                      Transform = transform
-                      Bones = Array.empty
-                    }
+              // ── Static ModelMeshPart casters (DrawModel/DrawModelWith, plain Depth technique) ──
+              if modelPartCount > 0 then
+                for d = 0 to modelPartCount - 1 do
+                  let draw = shadowModelPartDraws[d]
+                  PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+                  PbrUniforms.setMatrix depthParams.ViewProj casterVP
 
-                    skinnedCount <- skinnedCount + 1
-                  | _ ->
-                    if modelPartCount >= shadowModelPartDraws.Length then
-                      Array.Resize(
-                        &shadowModelPartDraws,
-                        shadowModelPartDraws.Length * 2
-                      )
+                  let saved = draw.Part.Effect
+                  draw.Part.Effect <- depthEffect
 
-                      res.ModelPartDraws <- shadowModelPartDraws
+                  try
+                    drawPart(gd, draw.Part)
+                  finally
+                    draw.Part.Effect <- saved
 
-                    shadowModelPartDraws[modelPartCount] <- {
-                      Part = part
-                      Transform = transform
-                    }
+              // ── Skinned casters (B12: DepthSkinned technique, bone palette upload) ──
+              if skinnedCount > 0 then
+                depthEffect.CurrentTechnique <-
+                  depthEffect.Techniques["DepthSkinned"]
 
-                    modelPartCount <- modelPartCount + 1
-            | Command3D.DrawModelWith(model, transform, _) when castEnabled ->
-              // Override material is irrelevant to depth; gather identically to DrawModel.
-              for mesh in model.Meshes do
-                for part in mesh.MeshParts do
-                  match part.Effect with
-                  | :? SkinnedEffect ->
-                    if skinnedCount >= shadowSkinnedDraws.Length then
-                      Array.Resize(
-                        &shadowSkinnedDraws,
-                        shadowSkinnedDraws.Length * 2
-                      )
+                for d = 0 to skinnedCount - 1 do
+                  let draw = shadowSkinnedDraws[d]
+                  PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+                  PbrUniforms.setMatrix depthParams.ViewProj casterVP
 
-                      res.SkinnedDraws <- shadowSkinnedDraws
+                  let boneCount =
+                    min draw.Bones.Length bonePaletteScratch.Length
 
-                    shadowSkinnedDraws[skinnedCount] <- {
-                      Part = part
-                      Transform = transform
-                      Bones = Array.empty
-                    }
+                  for i = 0 to boneCount - 1 do
+                    bonePaletteScratch[i] <- draw.Bones[i]
 
-                    skinnedCount <- skinnedCount + 1
-                  | _ ->
-                    if modelPartCount >= shadowModelPartDraws.Length then
-                      Array.Resize(
-                        &shadowModelPartDraws,
-                        shadowModelPartDraws.Length * 2
-                      )
+                  for i = boneCount to bonePaletteScratch.Length - 1 do
+                    bonePaletteScratch[i] <- Matrix.Identity
 
-                      res.ModelPartDraws <- shadowModelPartDraws
+                  PbrUniforms.setMatrixArray
+                    depthParams.Bones
+                    bonePaletteScratch
 
-                    shadowModelPartDraws[modelPartCount] <- {
-                      Part = part
-                      Transform = transform
-                    }
+                  // drawPart applies part.Effect.CurrentTechnique.Passes, so DepthSkinned must be
+                  // bound on the part's own Effect slot — swap it for the depth effect around the draw.
+                  let saved = draw.Part.Effect
+                  draw.Part.Effect <- depthEffect
 
-                    modelPartCount <- modelPartCount + 1
-            | Command3D.DrawAnimatedModelWith(model, transform, bones, _) when
-              castEnabled
-              ->
-              // Mirror DrawAnimatedModel: SkinnedEffect parts only.
-              for mesh in model.Meshes do
-                for part in mesh.MeshParts do
-                  match part.Effect with
-                  | :? SkinnedEffect ->
-                    if skinnedCount >= shadowSkinnedDraws.Length then
-                      Array.Resize(
-                        &shadowSkinnedDraws,
-                        shadowSkinnedDraws.Length * 2
-                      )
+                  try
+                    drawPart(gd, draw.Part)
+                  finally
+                    draw.Part.Effect <- saved
 
-                      res.SkinnedDraws <- shadowSkinnedDraws
+                depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
 
-                    shadowSkinnedDraws[skinnedCount] <- {
-                      Part = part
-                      Transform = transform
-                      Bones = bones
-                    }
+              // ── Instanced casters: hardware instancing via two-stream vertex bind. ──
+              if instancedCount > 0 then
+                depthEffect.CurrentTechnique <-
+                  depthEffect.Techniques["DepthInstanced"]
 
-                    skinnedCount <- skinnedCount + 1
-                  | _ -> ()
-            | Command3D.DrawInstanced(mesh, transforms, _material, instanceCount) when
-              castEnabled && instanceCount > 0
-              ->
-              // The world's instanced geometry (block grid, platforms, etc.) casts shadows too.
-              // Collected whole (one entry per emitted DrawInstanced); rendered via the
-              // DepthInstanced technique. No per-instance cull — the sample chunk-culls the
-              // source commands, so the emitted count is already bounded.
-              if instancedCount >= shadowInstancedDraws.Length then
-                Array.Resize(
-                  &shadowInstancedDraws,
-                  shadowInstancedDraws.Length * 2
-                )
+                // matModel is identity for instanced draws: the per-instance world transform
+                // is supplied as VertexInstanceWorld rows on stream 1.
+                PbrUniforms.setMatrix depthParams.MatModel Matrix.Identity
 
-                res.InstancedDraws <- shadowInstancedDraws
+                for d = 0 to instancedCount - 1 do
+                  let draw = shadowInstancedDraws[d]
 
-              shadowInstancedDraws[instancedCount] <- {
-                Mesh = mesh
-                Transforms = transforms
-                InstanceCount = instanceCount
-              }
+                  // Defensive: the source DrawInstanced command should always have a
+                  // transforms array matching instanceCount, but clamp to the available
+                  // data so a malformed command cannot read past the array.
+                  let instanceCount =
+                    min draw.InstanceCount draw.Transforms.Length
 
-              instancedCount <- instancedCount + 1
-            | _ -> ()
+                  if instanceCount > 0 then
+                    if res.InstanceStaging.Length < instanceCount then
+                      res.InstanceStaging <-
+                        Array.zeroCreate<VertexInstanceWorld> instanceCount
 
-          if
-            drawCount = 0
-            && skinnedCount = 0
-            && instancedCount = 0
-            && modelPartCount = 0
-          then
-            ()
-          else
-            res.Atlas.PrepareUniforms()
+                    for i = 0 to instanceCount - 1 do
+                      res.InstanceStaging[i] <-
+                        VertexInstanceWorld.Create draw.Transforms[i]
 
-            // ── Render depth into the atlas ──
-            let prevViewport = gd.Viewport
-            let prevRaster = gd.RasterizerState
-            let prevBlend = gd.BlendState
-            let prevDepth = gd.DepthStencilState
+                    match res.InstanceVertexBuffer with
+                    | ValueNone ->
+                      let vb =
+                        new VertexBuffer(
+                          gd,
+                          typeof<VertexInstanceWorld>,
+                          instanceCount,
+                          BufferUsage.WriteOnly
+                        )
 
-            gd.SetRenderTarget(res.Atlas.Fbo)
-            // Clear color (white = far = lit) AND depth (depth test enabled for hidden-surface removal).
-            gd.Clear(
-              ClearOptions.Target ||| ClearOptions.DepthBuffer,
-              Color.White.ToVector4(),
-              1.0f,
-              0
-            )
+                      res.InstanceVertexBuffer <- ValueSome vb
+                    | ValueSome vb when vb.VertexCount < instanceCount ->
+                      vb.Dispose()
 
-            // Native polygon-offset bias. Cached (config-driven). For B11 the bias uses
-            // DirectionalBias as the base — per-type bias swap is deferred.
-            if obj.ReferenceEquals(res.Raster, null) then
-              let sr = new RasterizerState()
-              // Render front faces into the shadow map. The imported geometry (Kenney
-              // assets and typical MonoGame content) is clockwise-wound; keeping the
-              // front-facing sides writes the caster surfaces that are actually visible
-              // to the light. Back-face rendering was tried but produced identical
-              // self-shadowing results once receiver-side bias was added, so the
-              // simpler front-face path is kept.
-              sr.CullMode <- CullMode.CullCounterClockwiseFace
-              sr.DepthBias <- biasCfg.DirectionalBias
-              sr.SlopeScaleDepthBias <- biasCfg.SlopeScaleBias
-              res.Raster <- sr
+                      let vb' =
+                        new VertexBuffer(
+                          gd,
+                          typeof<VertexInstanceWorld>,
+                          instanceCount,
+                          BufferUsage.WriteOnly
+                        )
 
-            gd.RasterizerState <- res.Raster
-            gd.BlendState <- BlendState.Opaque
-            gd.DepthStencilState <- DepthStencilState.Default
-            depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
-            let shadowFrustum = res.Frustum
-            let bonePaletteScratch = res.BonePaletteScratch
+                      res.InstanceVertexBuffer <- ValueSome vb'
+                    | _ -> ()
 
-            for caster in res.Atlas.Casters do
-              if caster.Enabled then
-                let casterVP = res.Atlas.GetRegionViewProj caster.AtlasRegion
-                gd.Viewport <- res.Atlas.GetRegionViewport(caster.AtlasRegion)
-                // Per-light frustum cull: skip meshes the caster's frustum can't see. Update in-place.
-                shadowFrustum.Matrix <- casterVP
+                    let instVB =
+                      match res.InstanceVertexBuffer with
+                      | ValueSome vb -> vb
+                      | ValueNone -> Unchecked.defaultof<VertexBuffer> // unreachable
 
-                // ── Non-skinned casters (PrimitiveMesh, plain Depth technique) ──
-                for d = 0 to drawCount - 1 do
-                  let draw = shadowDraws[d]
+                    instVB.SetData(res.InstanceStaging, 0, instanceCount)
 
-                  if Culling.isVisible shadowFrustum draw.WorldBounds then
-                    PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+                    gd.SetVertexBuffers(
+                      VertexBufferBinding(draw.Mesh.Vertices, 0, 0),
+                      VertexBufferBinding(instVB, 0, 1)
+                    )
+
+                    gd.Indices <- draw.Mesh.Indices
+
                     PbrUniforms.setMatrix depthParams.ViewProj casterVP
 
                     for pass in depthEffect.CurrentTechnique.Passes do
                       pass.Apply()
-                      draw.Mesh.Draw(gd, depthEffect)
 
-                // ── Static ModelMeshPart casters (DrawModel/DrawModelWith, plain Depth technique) ──
-                if modelPartCount > 0 then
-                  for d = 0 to modelPartCount - 1 do
-                    let draw = shadowModelPartDraws[d]
-                    PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-                    PbrUniforms.setMatrix depthParams.ViewProj casterVP
-
-                    let saved = draw.Part.Effect
-                    draw.Part.Effect <- depthEffect
-
-                    try
-                      drawPart(gd, draw.Part)
-                    finally
-                      draw.Part.Effect <- saved
-
-                // ── Skinned casters (B12: DepthSkinned technique, bone palette upload) ──
-                if skinnedCount > 0 then
-                  depthEffect.CurrentTechnique <-
-                    depthEffect.Techniques["DepthSkinned"]
-
-                  for d = 0 to skinnedCount - 1 do
-                    let draw = shadowSkinnedDraws[d]
-                    PbrUniforms.setMatrix depthParams.MatModel draw.Transform
-                    PbrUniforms.setMatrix depthParams.ViewProj casterVP
-
-                    let boneCount =
-                      min draw.Bones.Length bonePaletteScratch.Length
-
-                    for i = 0 to boneCount - 1 do
-                      bonePaletteScratch[i] <- draw.Bones[i]
-
-                    for i = boneCount to bonePaletteScratch.Length - 1 do
-                      bonePaletteScratch[i] <- Matrix.Identity
-
-                    PbrUniforms.setMatrixArray
-                      depthParams.Bones
-                      bonePaletteScratch
-
-                    // drawPart applies part.Effect.CurrentTechnique.Passes, so DepthSkinned must be
-                    // bound on the part's own Effect slot — swap it for the depth effect around the draw.
-                    let saved = draw.Part.Effect
-                    draw.Part.Effect <- depthEffect
-
-                    try
-                      drawPart(gd, draw.Part)
-                    finally
-                      draw.Part.Effect <- saved
-
-                  depthEffect.CurrentTechnique <-
-                    depthEffect.Techniques["Depth"]
-
-                // ── Instanced casters: hardware instancing via two-stream vertex bind. ──
-                if instancedCount > 0 then
-                  depthEffect.CurrentTechnique <-
-                    depthEffect.Techniques["DepthInstanced"]
-
-                  // matModel is identity for instanced draws: the per-instance world transform
-                  // is supplied as VertexInstanceWorld rows on stream 1.
-                  PbrUniforms.setMatrix depthParams.MatModel Matrix.Identity
-
-                  for d = 0 to instancedCount - 1 do
-                    let draw = shadowInstancedDraws[d]
-
-                    // Defensive: the source DrawInstanced command should always have a
-                    // transforms array matching instanceCount, but clamp to the available
-                    // data so a malformed command cannot read past the array.
-                    let instanceCount =
-                      min draw.InstanceCount draw.Transforms.Length
-
-                    if instanceCount > 0 then
-                      if res.InstanceStaging.Length < instanceCount then
-                        res.InstanceStaging <-
-                          Array.zeroCreate<VertexInstanceWorld> instanceCount
-
-                      for i = 0 to instanceCount - 1 do
-                        res.InstanceStaging[i] <-
-                          VertexInstanceWorld.Create draw.Transforms[i]
-
-                      match res.InstanceVertexBuffer with
-                      | ValueNone ->
-                        let vb =
-                          new VertexBuffer(
-                            gd,
-                            typeof<VertexInstanceWorld>,
-                            instanceCount,
-                            BufferUsage.WriteOnly
-                          )
-
-                        res.InstanceVertexBuffer <- ValueSome vb
-                      | ValueSome vb when vb.VertexCount < instanceCount ->
-                        vb.Dispose()
-
-                        let vb' =
-                          new VertexBuffer(
-                            gd,
-                            typeof<VertexInstanceWorld>,
-                            instanceCount,
-                            BufferUsage.WriteOnly
-                          )
-
-                        res.InstanceVertexBuffer <- ValueSome vb'
-                      | _ -> ()
-
-                      let instVB =
-                        match res.InstanceVertexBuffer with
-                        | ValueSome vb -> vb
-                        | ValueNone -> Unchecked.defaultof<VertexBuffer> // unreachable
-
-                      instVB.SetData(res.InstanceStaging, 0, instanceCount)
-
-                      gd.SetVertexBuffers(
-                        VertexBufferBinding(draw.Mesh.Vertices, 0, 0),
-                        VertexBufferBinding(instVB, 0, 1)
+                      gd.DrawInstancedPrimitives(
+                        PrimitiveType.TriangleList,
+                        0,
+                        0,
+                        draw.Mesh.PrimitiveCount,
+                        instanceCount
                       )
 
-                      gd.Indices <- draw.Mesh.Indices
+                depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
 
-                      PbrUniforms.setMatrix depthParams.ViewProj casterVP
+          // ── Restore device state ──
+          (gd.SetRenderTarget null)
+          gd.Viewport <- prevViewport
+          gd.RasterizerState <- prevRaster
+          gd.BlendState <- prevBlend
+          gd.DepthStencilState <- prevDepth
 
-                      for pass in depthEffect.CurrentTechnique.Passes do
-                        pass.Apply()
+          // ── Upload shadow uniforms to the PBR effect ──
+          let active = res.Atlas.ActiveCasterCount
+          let maxC = atlasCfg.MaxCasters
 
-                        gd.DrawInstancedPrimitives(
-                          PrimitiveType.TriangleList,
-                          0,
-                          0,
-                          draw.Mesh.PrimitiveCount,
-                          instanceCount
-                        )
+          if res.ViewProjsScratch.Length <> maxC then
+            res.ViewProjsScratch <- Array.zeroCreate<Matrix> maxC
 
-                  depthEffect.CurrentTechnique <-
-                    depthEffect.Techniques["Depth"]
+          if res.UVOffsetsScratch.Length <> maxC then
+            res.UVOffsetsScratch <- Array.zeroCreate<Vector4> maxC
 
-            // ── Restore device state ──
-            (gd.SetRenderTarget null)
-            gd.Viewport <- prevViewport
-            gd.RasterizerState <- prevRaster
-            gd.BlendState <- prevBlend
-            gd.DepthStencilState <- prevDepth
+          if res.BiasesScratch.Length <> maxC then
+            res.BiasesScratch <- Array.zeroCreate<float32> maxC
 
-            // ── Upload shadow uniforms to the PBR effect ──
-            let active = res.Atlas.ActiveCasterCount
-            let maxC = atlasCfg.MaxCasters
+          Array.Clear(res.ViewProjsScratch, 0, maxC)
+          Array.Clear(res.UVOffsetsScratch, 0, maxC)
+          Array.Clear(res.BiasesScratch, 0, maxC)
 
-            if res.ViewProjsScratch.Length <> maxC then
-              res.ViewProjsScratch <- Array.zeroCreate<Matrix> maxC
+          if active > 0 then
+            let vpArr = res.Atlas.ViewProjs
+            let uvArr = res.Atlas.UVOffsets
+            let biasArr = res.Atlas.Biases
 
-            if res.UVOffsetsScratch.Length <> maxC then
-              res.UVOffsetsScratch <- Array.zeroCreate<Vector4> maxC
+            for i = 0 to active - 1 do
+              res.ViewProjsScratch[i] <- vpArr[i]
+              res.UVOffsetsScratch[i] <- uvArr[i]
+              res.BiasesScratch[i] <- biasArr[i]
 
-            if res.BiasesScratch.Length <> maxC then
-              res.BiasesScratch <- Array.zeroCreate<float32> maxC
+          let texel = 1.0f / float32 atlasCfg.Resolution
 
-            Array.Clear(res.ViewProjsScratch, 0, maxC)
-            Array.Clear(res.UVOffsetsScratch, 0, maxC)
-            Array.Clear(res.BiasesScratch, 0, maxC)
+          match pbrParams with
+          | ValueSome p ->
+            PbrUniforms.setInt
+              p.Shadow.DirLightCastsShadows
+              (if hasDirCaster then 1 else 0)
 
             if active > 0 then
-              let vpArr = res.Atlas.ViewProjs
-              let uvArr = res.Atlas.UVOffsets
-              let biasArr = res.Atlas.Biases
+              PbrUniforms.setMatrixArray
+                p.Shadow.ShadowViewProjs
+                res.ViewProjsScratch
 
-              for i = 0 to active - 1 do
-                res.ViewProjsScratch[i] <- vpArr[i]
-                res.UVOffsetsScratch[i] <- uvArr[i]
-                res.BiasesScratch[i] <- biasArr[i]
+              PbrUniforms.setVec4Array
+                p.Shadow.ShadowUVOffsets
+                res.UVOffsetsScratch
 
-            let texel = 1.0f / float32 atlasCfg.Resolution
+              PbrUniforms.setFloatArray p.Shadow.ShadowBiases res.BiasesScratch
 
-            match pbrParams with
-            | ValueSome p ->
-              PbrUniforms.setInt
-                p.Shadow.DirLightCastsShadows
-                (if hasDirCaster then 1 else 0)
+            PbrUniforms.setVec2 p.Shadow.ShadowTexelSize (Vector2(texel, texel))
 
-              if active > 0 then
-                PbrUniforms.setMatrixArray
-                  p.Shadow.ShadowViewProjs
-                  res.ViewProjsScratch
+            if not(obj.ReferenceEquals(p.Shadow.ShadowAtlasTex, null)) then
+              p.Shadow.ShadowAtlasTex.SetValue(res.Atlas.Fbo)
 
-                PbrUniforms.setVec4Array
-                  p.Shadow.ShadowUVOffsets
-                  res.UVOffsetsScratch
+            gd.Textures[5] <- res.Atlas.Fbo
+            gd.SamplerStates[5] <- SamplerState.PointClamp
+          | ValueNone -> ()
 
-                PbrUniforms.setFloatArray
-                  p.Shadow.ShadowBiases
-                  res.BiasesScratch
-
-              PbrUniforms.setVec2
-                p.Shadow.ShadowTexelSize
-                (Vector2(texel, texel))
-
-              if not(obj.ReferenceEquals(p.Shadow.ShadowAtlasTex, null)) then
-                p.Shadow.ShadowAtlasTex.SetValue(res.Atlas.Fbo)
-
-              gd.Textures[5] <- res.Atlas.Fbo
-              gd.SamplerStates[5] <- SamplerState.PointClamp
-            | ValueNone -> ()
-
-            result <-
-              ValueSome {
-                Atlas = res.Atlas.Fbo
-                ViewProjs = res.ViewProjsScratch
-                UVOffsets = res.UVOffsetsScratch
-                ActiveCasterCount = active
-                TexelSize = texel
-                Biases = res.BiasesScratch
-                DirLightCastsShadows = hasDirCaster
-                PointLightShadowIdx = res.PointShadowSlots
-                SpotLightShadowIdx = res.SpotShadowSlots
-              }
+          result <-
+            ValueSome {
+              Atlas = res.Atlas.Fbo
+              ViewProjs = res.ViewProjsScratch
+              UVOffsets = res.UVOffsetsScratch
+              ActiveCasterCount = active
+              TexelSize = texel
+              Biases = res.BiasesScratch
+              DirLightCastsShadows = hasDirCaster
+              PointLightShadowIdx = res.PointShadowSlots
+              SpotLightShadowIdx = res.SpotShadowSlots
+            }
       | _ -> () // DepthShadow.fx missing — render unshadowed (result stays ValueNone).
 
     result
+
+  /// <summary>
+  /// Renders the opaque geometry already collected by <see cref="M:Mibo.Elmish.Graphics3D.Pipelines.ShadowPass.run"/>
+  /// (or <c>collectCasters</c>) from a camera view-projection into <paramref name="depthTarget"/> as
+  /// NDC depth (clip.z/clip.w in [0,1], 1.0 = far). Drives camera-POV distance effects (fog, DOF,
+  /// SSAO): linearize with the camera's near/far planes in the consuming shader. No per-light
+  /// frustum cull — the camera frustum already bounds the visible scene. Requires the DepthShadow
+  /// effect to be loadable; otherwise the target is left uncleared and <c>ValueNone</c> is returned.
+  /// </summary>
+  /// <returns><c>ValueSome depthTarget</c> if the pass ran, <c>ValueNone</c> if the DepthShadow
+  /// effect is unavailable or nothing was collected.</returns>
+  let renderDepth
+    (gd: GraphicsDevice)
+    (res: ShadowResources)
+    (atlasCfg: ShadowAtlasConfig)
+    (viewProj: Matrix)
+    (depthTarget: RenderTarget2D)
+    : RenderTarget2D voption =
+    let drawCount = res.CollectedDrawCount
+    let skinnedCount = res.CollectedSkinnedCount
+    let modelPartCount = res.CollectedModelPartCount
+    let instancedCount = res.CollectedInstancedCount
+
+    if
+      drawCount = 0
+      && skinnedCount = 0
+      && modelPartCount = 0
+      && instancedCount = 0
+    then
+      ValueNone
+    else
+      // Ensure the DepthShadow effect is loaded (shared with the shadow pass).
+      match res.Effect, res.Params with
+      | ValueSome _, ValueSome _ -> ()
+      | _ ->
+        match ShaderLoader.loadEffect gd "DepthShadow" with
+        | ValueSome e ->
+          res.Params <- ValueSome(buildShadowParams e)
+          res.Effect <- ValueSome e
+        | ValueNone -> ()
+
+      match res.Effect, res.Params with
+      | ValueNone, _
+      | _, ValueNone -> ValueNone
+      | ValueSome depthEffect, ValueSome depthParams ->
+        let prevViewport = gd.Viewport
+        let prevRaster = gd.RasterizerState
+        let prevBlend = gd.BlendState
+        let prevDepth = gd.DepthStencilState
+
+        gd.SetRenderTarget depthTarget
+        // 1.0 = far (matches DepthShadow.fx's clip.z/clip.w). Clear as an explicit Vector4 so the
+        // R32F (SurfaceFormat.Single) target gets .r=1.0 reliably on both backends.
+        gd.Clear(ClearOptions.Target, Color.White.ToVector4(), 1.0f, 0)
+        gd.RasterizerState <- RasterizerState.CullCounterClockwise
+        gd.BlendState <- BlendState.Opaque
+        gd.DepthStencilState <- DepthStencilState.Default
+
+        depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
+
+        // ── Non-skinned PrimitiveMesh ──
+        for d = 0 to drawCount - 1 do
+          let draw = res.Draws[d]
+          PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+          PbrUniforms.setMatrix depthParams.ViewProj viewProj
+
+          for pass in depthEffect.CurrentTechnique.Passes do
+            pass.Apply()
+            draw.Mesh.Draw(gd, depthEffect)
+
+        // ── Static ModelMeshPart (DrawModel/DrawModelWith) ──
+        if modelPartCount > 0 then
+          for d = 0 to modelPartCount - 1 do
+            let draw = res.ModelPartDraws[d]
+            PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+            PbrUniforms.setMatrix depthParams.ViewProj viewProj
+
+            let saved = draw.Part.Effect
+            draw.Part.Effect <- depthEffect
+
+            try
+              drawPart(gd, draw.Part)
+            finally
+              draw.Part.Effect <- saved
+
+        // ── Skinned (DepthSkinned technique, bone palette) ──
+        if skinnedCount > 0 then
+          depthEffect.CurrentTechnique <- depthEffect.Techniques["DepthSkinned"]
+          let bonePaletteScratch = res.BonePaletteScratch
+
+          for d = 0 to skinnedCount - 1 do
+            let draw = res.SkinnedDraws[d]
+            PbrUniforms.setMatrix depthParams.MatModel draw.Transform
+            PbrUniforms.setMatrix depthParams.ViewProj viewProj
+
+            let boneCount = min draw.Bones.Length bonePaletteScratch.Length
+
+            for i = 0 to boneCount - 1 do
+              bonePaletteScratch[i] <- draw.Bones[i]
+
+            for i = boneCount to bonePaletteScratch.Length - 1 do
+              bonePaletteScratch[i] <- Matrix.Identity
+
+            PbrUniforms.setMatrixArray depthParams.Bones bonePaletteScratch
+
+            let saved = draw.Part.Effect
+            draw.Part.Effect <- depthEffect
+
+            try
+              drawPart(gd, draw.Part)
+            finally
+              draw.Part.Effect <- saved
+
+          depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
+
+        // ── Instanced (DepthInstanced, two-stream vertex bind) ──
+        if instancedCount > 0 then
+          depthEffect.CurrentTechnique <-
+            depthEffect.Techniques["DepthInstanced"]
+
+          PbrUniforms.setMatrix depthParams.MatModel Matrix.Identity
+
+          for d = 0 to instancedCount - 1 do
+            let draw = res.InstancedDraws[d]
+            let instanceCount = min draw.InstanceCount draw.Transforms.Length
+
+            if instanceCount > 0 then
+              if res.InstanceStaging.Length < instanceCount then
+                res.InstanceStaging <-
+                  Array.zeroCreate<VertexInstanceWorld> instanceCount
+
+              for i = 0 to instanceCount - 1 do
+                res.InstanceStaging[i] <-
+                  VertexInstanceWorld.Create draw.Transforms[i]
+
+              match res.InstanceVertexBuffer with
+              | ValueNone ->
+                let vb =
+                  new VertexBuffer(
+                    gd,
+                    typeof<VertexInstanceWorld>,
+                    instanceCount,
+                    BufferUsage.WriteOnly
+                  )
+
+                res.InstanceVertexBuffer <- ValueSome vb
+              | ValueSome vb when vb.VertexCount < instanceCount ->
+                vb.Dispose()
+
+                let vb' =
+                  new VertexBuffer(
+                    gd,
+                    typeof<VertexInstanceWorld>,
+                    instanceCount,
+                    BufferUsage.WriteOnly
+                  )
+
+                res.InstanceVertexBuffer <- ValueSome vb'
+              | _ -> ()
+
+              let instVB =
+                match res.InstanceVertexBuffer with
+                | ValueSome vb -> vb
+                | ValueNone -> Unchecked.defaultof<VertexBuffer> // unreachable
+
+              instVB.SetData(res.InstanceStaging, 0, instanceCount)
+
+              gd.SetVertexBuffers(
+                VertexBufferBinding(draw.Mesh.Vertices, 0, 0),
+                VertexBufferBinding(instVB, 0, 1)
+              )
+
+              gd.Indices <- draw.Mesh.Indices
+
+              PbrUniforms.setMatrix depthParams.ViewProj viewProj
+
+              for pass in depthEffect.CurrentTechnique.Passes do
+                pass.Apply()
+
+                gd.DrawInstancedPrimitives(
+                  PrimitiveType.TriangleList,
+                  0,
+                  0,
+                  draw.Mesh.PrimitiveCount,
+                  instanceCount
+                )
+
+          depthEffect.CurrentTechnique <- depthEffect.Techniques["Depth"]
+
+        gd.SetRenderTarget null
+        gd.Viewport <- prevViewport
+        gd.RasterizerState <- prevRaster
+        gd.BlendState <- prevBlend
+        gd.DepthStencilState <- prevDepth
+
+        ValueSome depthTarget

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -1093,6 +1093,19 @@ module internal ShadowPass =
       | ValueSome p -> PbrUniforms.setInt p.Shadow.DirLightCastsShadows 0
       | ValueNone -> ()
 
+      // Even without shadow casters, load the DepthShadow effect so renderSceneDepth can run
+      // when needsDepth is true (fog/DoF/SSAO in a shadowless scene). Without this, the effect
+      // is never loaded and every postProcessWithDepth action silently receives Depth=None.
+      if needsDepth then
+        match res.Effect, res.Params with
+        | ValueSome _, ValueSome _ -> ()
+        | _ ->
+          match ShaderLoader.loadEffect gd "DepthShadow" with
+          | ValueSome e ->
+            res.Params <- ValueSome(buildShadowParams e)
+            res.Effect <- ValueSome e
+          | ValueNone -> ()
+
       ValueNone
     else
       res.Atlas.EnsureResources gd

--- a/src/Mibo.MonoGame/Graphics3D/PostProcessContext3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/PostProcessContext3D.fs
@@ -17,8 +17,10 @@ type PostProcessContext3D = {
   Source: RenderTarget2D
 
   /// <summary>
-  /// Camera-POV linear depth (R32F). <c>ValueNone</c> unless depth was opted in at pipeline
-  /// construction. Sample it for distance effects (fog, SSAO).
+  /// Camera-POV depth (NDC z in [0,1], written to an R32F target). Populated only when the view
+  /// emitted at least one <c>Command3D.EnableDepthPrePass</c> this frame; otherwise
+  /// <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>. Linearize with the camera's
+  /// near/far planes to get view-space distance (fog, depth-of-field, SSAO).
   /// </summary>
   Depth: RenderTarget2D voption
 

--- a/src/Mibo.MonoGame/Graphics3D/PostProcessContext3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/PostProcessContext3D.fs
@@ -17,10 +17,10 @@ type PostProcessContext3D = {
   Source: RenderTarget2D
 
   /// <summary>
-  /// Camera-POV depth (NDC z in [0,1], written to an R32F target). Populated only when the view
-  /// emitted at least one <c>Command3D.EnableDepthPrePass</c> this frame; otherwise
-  /// <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>. Linearize with the camera's
-  /// near/far planes to get view-space distance (fog, depth-of-field, SSAO).
+  /// Camera-POV depth (NDC z in [0,1], R32F target). Populated only when the view emitted at least
+  /// one <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcessWithDepth"/> action this frame; otherwise
+  /// <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>. Linearize with the camera's near/far
+  /// planes to get view-space distance (fog, depth-of-field, SSAO).
   /// </summary>
   Depth: RenderTarget2D voption
 

--- a/src/Mibo.MonoGame/Graphics3D/RenderBuffer3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/RenderBuffer3D.fs
@@ -28,6 +28,7 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
   let mutable count = 0
   let mutable clearCounter = 0
   let mutable postProcessCount = 0
+  let mutable depthPostProcessCount = 0
 
   let ensureCapacity(needed: int) =
     if count + needed > items.Length then
@@ -46,10 +47,19 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
   member _.Count = count
 
   /// <summary>
-  /// Number of <c>PostProcess</c> commands added since the last <c>Clear</c>. Lets a pipeline
-  /// skip the post-process drain (and its per-frame allocation) when the view emits none.
+  /// Number of <c>PostProcess</c>/<c>PostProcessWithDepth</c> commands added since the last
+  /// <c>Clear</c>. Lets a pipeline skip the post-process drain (and its per-frame allocation) when
+  /// the view emits none.
   /// </summary>
   member _.PostProcessCount = postProcessCount
+
+  /// <summary>
+  /// Number of <c>PostProcessWithDepth</c> commands added since the last <c>Clear</c>. When &gt; 0,
+  /// the pipeline produces a camera-POV depth target this frame so depth-needing effects (fog,
+  /// depth-of-field, SSAO) can sample <c>PostProcessContext3D.Depth</c>. Zero on frames with only
+  /// color-only <c>PostProcess</c> actions, so the depth pass is skipped entirely.
+  /// </summary>
+  member _.DepthPostProcessCount = depthPostProcessCount
 
   /// <summary>Gets the command at the specified index.</summary>
   member _.Item(i: int) = items[i]
@@ -61,6 +71,9 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
 
     match cmd with
     | Command3D.PostProcess _ -> postProcessCount <- postProcessCount + 1
+    | Command3D.PostProcessWithDepth _ ->
+      postProcessCount <- postProcessCount + 1
+      depthPostProcessCount <- depthPostProcessCount + 1
     | _ -> ()
 
     count <- count + 1
@@ -79,6 +92,7 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
   member _.Clear() =
     count <- 0
     postProcessCount <- 0
+    depthPostProcessCount <- 0
     // Periodically zero the backing array so stale managed refs (Model/Texture2D/Effect)
     // in slots above count don't keep unloaded assets alive indefinitely after a scene
     // shrinks or chunks evict. ~5s at 60fps; Array.Clear on structs is a cheap memset.

--- a/src/Mibo.Raylib/Graphics3D/Command3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/Command3D.fs
@@ -65,7 +65,20 @@ type Command3D =
   | BeginEffect of shader: Shader
   | EndEffect
   | DrawImmediate of action: (Pipelines.SceneContext -> unit)
+  /// <summary>
+  /// A post-process action that reads only color (<c>PostProcessContext3D.Source</c>). Emits no
+  /// scene-depth production — use for color-only effects (desaturation, vignette, blur). Cheap:
+  /// costs only the scene render target + ping-pong.
+  /// </summary>
   | PostProcess of ppAction: (PostProcessContext3D -> unit)
+  /// <summary>
+  /// A post-process action that needs camera-POV scene depth (<c>PostProcessContext3D.Depth</c>) in
+  /// addition to color — fog, depth-of-field, SSAO. The pipeline exposes the scene render target's
+  /// depth attachment (OpenGL's depth buffer is directly sampleable, so no extra geometry pass is
+  /// needed). Use plain <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcess"/> when an effect
+  /// doesn't sample depth.
+  /// </summary>
+  | PostProcessWithDepth of ppAction: (PostProcessContext3D -> unit)
 
 /// <summary>
 /// Factory functions that create <see cref="T:Mibo.Elmish.Graphics3D.Command3D"/> values

--- a/src/Mibo.Raylib/Graphics3D/Draw3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/Draw3D.fs
@@ -279,19 +279,39 @@ module Draw3D =
     buffer
 
   /// <summary>
-  /// Enqueues a model-aware post-process pass. The action runs once, after the whole scene
-  /// renders to an offscreen target; it receives a <see cref="T:Mibo.Elmish.Graphics3D.PostProcessContext3D"/>
-  /// with the scene texture (+ optional depth) and must draw a fullscreen quad of it.
-  /// Emit it conditionally from the view based on game state (e.g. only while a hit-flash is
-  /// active). Chain multiple passes — they ping-pong in buffer order, the last drawing to the
-  /// back-buffer.
+  /// Enqueues a color-only post-process pass. The action runs once, after the whole scene renders
+  /// to an offscreen target; it receives a <see cref="T:Mibo.Elmish.Graphics3D.PostProcessContext3D"/>
+  /// with the scene texture. <c>Context.Depth</c> is <c>ValueNone</c> — no scene depth is exposed.
+  /// The action must draw a fullscreen quad of <c>Source</c>. Emit it conditionally from the view
+  /// based on game state (e.g. only while a hit-flash is active). Chain multiple passes — they
+  /// ping-pong in buffer order, the last drawing to the back-buffer.
+  ///
+  /// Use this for effects that don't sample depth (desaturation, vignette, blur). For distance
+  /// effects (fog, depth-of-field, SSAO) use
+  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.postProcessWithDepth"/>.
   /// </summary>
-  /// <param name="action">Invoked once per frame with the post-process context.</param>
+  /// <param name="action">Invoked once per frame with the post-process context (Depth = ValueNone).</param>
   let inline postProcess
     ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
     (buffer: RenderBuffer3D)
     =
     buffer.Add(Command3D.postProcess action)
+    buffer
+
+  /// <summary>
+  /// Enqueues a post-process pass that needs camera-POV scene depth. Same lifecycle as
+  /// <see cref="M:Mibo.Elmish.Graphics3D.Draw3D.postProcess"/> (runs once after the scene renders,
+  /// chains in buffer order), but when at least one such action is present the pipeline exposes the
+  /// scene render target's depth attachment via <c>Context.Depth</c>. Sample it (linearize with the
+  /// camera's near/far) for distance effects. Prefer plain <c>postProcess</c> for effects that
+  /// don't read depth.
+  /// </summary>
+  /// <param name="action">Invoked once per frame with the post-process context (Depth populated).</param>
+  let inline postProcessWithDepth
+    ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
+    (buffer: RenderBuffer3D)
+    =
+    buffer.Add(Command3D.PostProcessWithDepth action)
     buffer
 
   /// <summary>Terminal function that discards the buffer, silencing the unused-value warning. Does nothing.</summary>

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -1432,7 +1432,8 @@ module internal PipelineFunctions =
           &mat,
           2
         )
-      | Command3D.PostProcess action ->
+      | Command3D.PostProcess action
+      | Command3D.PostProcessWithDepth action ->
         match ppActions with
         | ValueSome list -> list.Add action
         | ValueNone -> ()
@@ -1762,6 +1763,7 @@ type ForwardPipelineBase
     (sceneTarget: RenderTexture2D)
     (rtPool: IRenderTargetPool3D)
     (actions: ResizeArray<PostProcessContext3D -> unit>)
+    (depth: Texture2D voption)
     (frameTime: float32)
     =
     if actions.Count = 0 then
@@ -1788,7 +1790,7 @@ type ForwardPipelineBase
 
         let ppCtx: PostProcessContext3D = {
           Source = src
-          Depth = ValueNone
+          Depth = depth
           Width = w
           Height = h
           Time = frameTime
@@ -2536,7 +2538,8 @@ type ForwardPipelineBase
           | Command3D.DisableShadows -> ()
           // Post-process actions are collected above and run after the scene renders to
           // an offscreen target; nothing to do during the forward pass.
-          | Command3D.PostProcess _ -> ()
+          | Command3D.PostProcess _
+          | Command3D.PostProcessWithDepth _ -> ()
 
         // End remaining shader/camera state after dispatch
         if shaderActive then
@@ -2546,15 +2549,32 @@ type ForwardPipelineBase
           Raylib.EndMode3D()
 
       // Render the forward pass direct, or via a scene RT when post-process commands are present.
+      // When depth-needing actions exist (DepthPostProcessCount > 0), expose the scene RT's depth
+      // attachment to the post-process context — OpenGL's depth buffer is directly sampleable, so
+      // no separate geometry pre-pass is needed (unlike the MonoGame backend).
       match ppActions with
       | ValueNone -> dispatchForwardPass()
       | ValueSome actions ->
-        let sceneRT = rtPool.Acquire(gameCtx.WindowWidth, gameCtx.WindowHeight)
+        // Use a depth-sampleable RT (custom FBO with a depth texture) when post-process effects
+        // need to sample depth; otherwise a standard raylib RT (depth renderbuffer, cheaper).
+        let sceneRT =
+          if buffer.DepthPostProcessCount > 0 then
+            rtPool.AcquireWithDepth(gameCtx.WindowWidth, gameCtx.WindowHeight)
+          else
+            rtPool.Acquire(gameCtx.WindowWidth, gameCtx.WindowHeight)
+
         Raylib.BeginTextureMode sceneRT
         Raylib.ClearBackground Color.Black
         dispatchForwardPass()
         Raylib.EndTextureMode()
-        applyPostProcess gameCtx sceneRT rtPool actions frameTime
+
+        let depth: Texture2D voption =
+          if buffer.DepthPostProcessCount > 0 then
+            ValueSome sceneRT.Depth
+          else
+            ValueNone
+
+        applyPostProcess gameCtx sceneRT rtPool actions depth frameTime
 
       // Debug overlay (optional)
       if atlasCfg.ShowDebugOverlay then

--- a/src/Mibo.Raylib/Graphics3D/PostProcessContext3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/PostProcessContext3D.fs
@@ -17,8 +17,10 @@ type PostProcessContext3D = {
   Source: RenderTexture2D
 
   /// <summary>
-  /// Camera-POV linear depth (R32F). <c>ValueNone</c> unless depth was opted in at
-  /// pipeline construction. Sample it for distance effects (fog, SSAO).
+  /// Camera-POV depth (NDC z in [0,1]). Populated only when the view emitted at least one
+  /// <c>Command3D.EnableDepthPrePass</c> this frame; otherwise
+  /// <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>. Linearize with the camera's
+  /// near/far planes to get view-space distance (fog, depth-of-field, SSAO).
   /// </summary>
   Depth: Texture2D voption
 

--- a/src/Mibo.Raylib/Graphics3D/PostProcessContext3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/PostProcessContext3D.fs
@@ -18,7 +18,7 @@ type PostProcessContext3D = {
 
   /// <summary>
   /// Camera-POV depth (NDC z in [0,1]). Populated only when the view emitted at least one
-  /// <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcessWithDepth"/> action this frame; otherwise
+  /// <c>Command3D.EnableDepthPrePass</c> this frame; otherwise
   /// <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>. Linearize with the camera's
   /// near/far planes to get view-space distance (fog, depth-of-field, SSAO).
   /// </summary>

--- a/src/Mibo.Raylib/Graphics3D/PostProcessContext3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/PostProcessContext3D.fs
@@ -18,7 +18,7 @@ type PostProcessContext3D = {
 
   /// <summary>
   /// Camera-POV depth (NDC z in [0,1]). Populated only when the view emitted at least one
-  /// <c>Command3D.EnableDepthPrePass</c> this frame; otherwise
+  /// <see cref="F:Mibo.Elmish.Graphics3D.Command3D.PostProcessWithDepth"/> action this frame; otherwise
   /// <see cref="F:Microsoft.FSharp.Core.ValueOption`1.ValueNone"/>. Linearize with the camera's
   /// near/far planes to get view-space distance (fog, depth-of-field, SSAO).
   /// </summary>

--- a/src/Mibo.Raylib/Graphics3D/RenderBuffer3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderBuffer3D.fs
@@ -28,6 +28,7 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
   let mutable count = 0
   let mutable clearCounter = 0
   let mutable postProcessCount = 0
+  let mutable depthPostProcessCount = 0
 
   let ensureCapacity(needed: int) =
     if count + needed > items.Length then
@@ -43,10 +44,19 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
   member _.Count = count
 
   /// <summary>
-  /// Number of <c>PostProcess</c> commands added since the last <c>Clear</c>. Lets a pipeline
-  /// skip the post-process drain (and its per-frame allocation) when the view emits none.
+  /// Number of <c>PostProcess</c>/<c>PostProcessWithDepth</c> commands added since the last
+  /// <c>Clear</c>. Lets a pipeline skip the post-process drain (and its per-frame allocation) when
+  /// the view emits none.
   /// </summary>
   member _.PostProcessCount = postProcessCount
+
+  /// <summary>
+  /// Number of <c>PostProcessWithDepth</c> commands added since the last <c>Clear</c>. When &gt; 0,
+  /// the pipeline exposes the scene depth attachment to post-process actions via
+  /// <c>PostProcessContext3D.Depth</c>. Zero on frames with only color-only <c>PostProcess</c>
+  /// actions.
+  /// </summary>
+  member _.DepthPostProcessCount = depthPostProcessCount
 
   /// <summary>Gets the command at the specified index.</summary>
   member _.Item(i: int) = items[i]
@@ -58,6 +68,9 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
 
     match cmd with
     | Command3D.PostProcess _ -> postProcessCount <- postProcessCount + 1
+    | Command3D.PostProcessWithDepth _ ->
+      postProcessCount <- postProcessCount + 1
+      depthPostProcessCount <- depthPostProcessCount + 1
     | _ -> ()
 
     count <- count + 1
@@ -69,6 +82,7 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
   member _.Clear() =
     count <- 0
     postProcessCount <- 0
+    depthPostProcessCount <- 0
     clearCounter <- clearCounter + 1
 
     if clearCounter >= 300 then

--- a/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
@@ -50,6 +50,8 @@ type IRenderTargetPool3D =
 /// </remarks>
 type RenderTargetPool3D() =
 
+  let maxIdle = 2
+
   // ── Standard RTs (color texture + depth renderbuffer via raylib's LoadRenderTexture) ──
   let pool = Dictionary<struct (int * int), Queue<RenderTexture2D>>()
   let inUse = ResizeArray<RenderTexture2D>()
@@ -157,11 +159,16 @@ type RenderTargetPool3D() =
         let key = struct (rt.Texture.Width, rt.Texture.Height)
 
         match pool.TryGetValue(key) with
-        | true, queue -> queue.Enqueue(rt)
-        | false, _ ->
-          let queue = Queue<RenderTexture2D>()
-          queue.Enqueue(rt)
-          pool[key] <- queue
+        | true, queue when queue.Count < maxIdle -> queue.Enqueue(rt)
+        | _ ->
+          // Pool full for this dimension — unload instead of retaining.
+          match pool.TryGetValue(key) with
+          | true, queue when queue.Count >= maxIdle ->
+            Raylib.UnloadRenderTexture(rt)
+          | false, _ ->
+            let queue = Queue<RenderTexture2D>()
+            queue.Enqueue(rt)
+            pool[key] <- queue
 
       inUse.Clear()
 
@@ -169,11 +176,11 @@ type RenderTargetPool3D() =
         let key = struct (rt.Texture.Width, rt.Texture.Height)
 
         match depthPool.TryGetValue(key) with
-        | true, queue -> queue.Enqueue(rt)
-        | false, _ ->
-          let queue = Queue<RenderTexture2D>()
-          queue.Enqueue(rt)
-          depthPool[key] <- queue
+        | true, queue when queue.Count < maxIdle -> queue.Enqueue(rt)
+        | _ ->
+          Rlgl.UnloadTexture(rt.Texture.Id)
+          Rlgl.UnloadTexture(rt.Depth.Id)
+          Rlgl.UnloadFramebuffer(rt.Id)
 
       depthInUse.Clear()
 

--- a/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
@@ -50,6 +50,8 @@ type IRenderTargetPool3D =
 /// </remarks>
 type RenderTargetPool3D() =
 
+  let maxIdle = 2
+
   // ── Standard RTs (color texture + depth renderbuffer via raylib's LoadRenderTexture) ──
   let pool = Dictionary<struct (int * int), Queue<RenderTexture2D>>()
   let inUse = ResizeArray<RenderTexture2D>()
@@ -157,7 +159,8 @@ type RenderTargetPool3D() =
         let key = struct (rt.Texture.Width, rt.Texture.Height)
 
         match pool.TryGetValue(key) with
-        | true, queue -> queue.Enqueue(rt)
+        | true, queue when queue.Count < maxIdle -> queue.Enqueue(rt)
+        | true, _ -> Raylib.UnloadRenderTexture(rt)
         | false, _ ->
           let queue = Queue<RenderTexture2D>()
           queue.Enqueue(rt)
@@ -169,7 +172,11 @@ type RenderTargetPool3D() =
         let key = struct (rt.Texture.Width, rt.Texture.Height)
 
         match depthPool.TryGetValue(key) with
-        | true, queue -> queue.Enqueue(rt)
+        | true, queue when queue.Count < maxIdle -> queue.Enqueue(rt)
+        | true, _ ->
+          Rlgl.UnloadTexture(rt.Texture.Id)
+          Rlgl.UnloadTexture(rt.Depth.Id)
+          Rlgl.UnloadFramebuffer(rt.Id)
         | false, _ ->
           let queue = Queue<RenderTexture2D>()
           queue.Enqueue(rt)

--- a/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
@@ -1,6 +1,7 @@
 namespace Mibo.Elmish.Graphics3D
 
 open System.Collections.Generic
+open Microsoft.FSharp.NativeInterop
 open Raylib_cs
 
 /// <summary>
@@ -17,9 +18,21 @@ type IRenderTargetPool3D =
   /// <summary>
   /// Acquires a render texture matching the given dimensions.
   /// Reuses a previously released texture if available, otherwise creates a new one.
+  /// The depth attachment is a renderbuffer (not sampleable).
   /// </summary>
   /// <returns>A render texture with the specified width and height.</returns>
   abstract Acquire: width: int * height: int -> RenderTexture2D
+
+  /// <summary>
+  /// Acquires a render texture whose depth attachment is a sampleable <b>texture</b> (not a
+  /// renderbuffer). Use this for scene RTs when post-process effects need to sample depth
+  /// (fog, depth-of-field, SSAO). Reuses a previously released texture if available, otherwise
+  /// creates a new custom FBO (color texture + depth texture). More expensive to create than
+  /// <see cref="M:Mibo.Elmish.Graphics3D.IRenderTargetPool3D.Acquire"/>, so only request it when depth
+  /// sampling is actually needed.
+  /// </summary>
+  /// <returns>A render texture with a sampleable depth attachment.</returns>
+  abstract AcquireWithDepth: width: int * height: int -> RenderTexture2D
 
   /// <summary>
   /// Returns all currently held textures to the pool. Call once per frame
@@ -36,8 +49,81 @@ type IRenderTargetPool3D =
 /// Dispose the pool when the application shuts down to unload all pooled textures.
 /// </remarks>
 type RenderTargetPool3D() =
+
+  // ── Standard RTs (color texture + depth renderbuffer via raylib's LoadRenderTexture) ──
   let pool = Dictionary<struct (int * int), Queue<RenderTexture2D>>()
   let inUse = ResizeArray<RenderTexture2D>()
+
+  // ── Depth-sampleable RTs (custom rlgl FBO: color texture + depth texture) ──
+  // Separate pool so depth-needing frames don't pay the custom-FBO cost when they don't need it.
+  let depthPool = Dictionary<struct (int * int), Queue<RenderTexture2D>>()
+  let depthInUse = ResizeArray<RenderTexture2D>()
+
+  /// <summary>
+  /// Creates a custom FBO with a color texture + a sampleable depth texture (not renderbuffer).
+  /// raylib's <c>LoadRenderTexture</c> attaches depth as a renderbuffer, which can't be sampled
+  /// in a shader — this builds the FBO manually so the depth attachment is a real texture.
+  /// </summary>
+  static member private CreateDepthTextureRT
+    (width: int, height: int)
+    : RenderTexture2D =
+    let fboId = Rlgl.LoadFramebuffer()
+    Rlgl.EnableFramebuffer(fboId)
+
+    // Color texture (R8G8B8A8). Allocate a zeroed buffer and upload it once; raylib-cs's
+    // LoadTexture requires a non-null data pointer (DisableRuntimeMarshalling).
+    let colorBytes = Array.zeroCreate<byte>(width * height * 4)
+    use pcb = fixed &colorBytes[0]
+
+    let colorId =
+      Rlgl.LoadTexture(
+        NativePtr.toVoidPtr pcb,
+        width,
+        height,
+        PixelFormat.UncompressedR8G8B8A8,
+        1
+      )
+
+    // Depth texture (sampleable). false = texture, not renderbuffer.
+    let depthId = Rlgl.LoadTextureDepth(width, height, false)
+
+    Rlgl.FramebufferAttach(
+      fboId,
+      colorId,
+      FramebufferAttachType.ColorChannel0,
+      FramebufferAttachTextureType.Texture2D,
+      0
+    )
+
+    Rlgl.FramebufferAttach(
+      fboId,
+      depthId,
+      FramebufferAttachType.Depth,
+      FramebufferAttachTextureType.Texture2D,
+      0
+    )
+
+    Rlgl.DisableFramebuffer()
+
+    RenderTexture2D(
+      Id = fboId,
+      Texture =
+        Texture2D(
+          Id = colorId,
+          Width = width,
+          Height = height,
+          Mipmaps = 1,
+          Format = PixelFormat.UncompressedR8G8B8A8
+        ),
+      Depth =
+        Texture2D(
+          Id = depthId,
+          Width = width,
+          Height = height,
+          Mipmaps = 1,
+          Format = enum<PixelFormat> 19 // Depth24Unorm — matches ShadowAtlas.fs convention
+        )
+    )
 
   interface IRenderTargetPool3D with
     member _.Acquire(width, height) =
@@ -53,6 +139,19 @@ type RenderTargetPool3D() =
         inUse.Add(rt)
         rt
 
+    member _.AcquireWithDepth(width, height) =
+      let key = struct (width, height)
+
+      match depthPool.TryGetValue(key) with
+      | true, queue when queue.Count > 0 ->
+        let rt = queue.Dequeue()
+        depthInUse.Add(rt)
+        rt
+      | _ ->
+        let rt = RenderTargetPool3D.CreateDepthTextureRT(width, height)
+        depthInUse.Add(rt)
+        rt
+
     member _.ReleaseAll() =
       for rt in inUse do
         let key = struct (rt.Texture.Width, rt.Texture.Height)
@@ -65,6 +164,18 @@ type RenderTargetPool3D() =
           pool[key] <- queue
 
       inUse.Clear()
+
+      for rt in depthInUse do
+        let key = struct (rt.Texture.Width, rt.Texture.Height)
+
+        match depthPool.TryGetValue(key) with
+        | true, queue -> queue.Enqueue(rt)
+        | false, _ ->
+          let queue = Queue<RenderTexture2D>()
+          queue.Enqueue(rt)
+          depthPool[key] <- queue
+
+      depthInUse.Clear()
 
   interface System.IDisposable with
     member _.Dispose() =
@@ -80,3 +191,22 @@ type RenderTargetPool3D() =
         queue.Clear()
 
       pool.Clear()
+
+      // Depth-texture RTs use a custom FBO with separate texture resources — unload each
+      // (FBO + color texture + depth texture) individually, matching ShadowAtlas.Shutdown.
+      for rt in depthInUse do
+        Rlgl.UnloadTexture(rt.Texture.Id)
+        Rlgl.UnloadTexture(rt.Depth.Id)
+        Rlgl.UnloadFramebuffer(rt.Id)
+
+      depthInUse.Clear()
+
+      for KeyValue(_, queue) in depthPool do
+        for rt in queue do
+          Rlgl.UnloadTexture(rt.Texture.Id)
+          Rlgl.UnloadTexture(rt.Depth.Id)
+          Rlgl.UnloadFramebuffer(rt.Id)
+
+        queue.Clear()
+
+      depthPool.Clear()

--- a/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderTargetPool3D.fs
@@ -50,8 +50,6 @@ type IRenderTargetPool3D =
 /// </remarks>
 type RenderTargetPool3D() =
 
-  let maxIdle = 2
-
   // ── Standard RTs (color texture + depth renderbuffer via raylib's LoadRenderTexture) ──
   let pool = Dictionary<struct (int * int), Queue<RenderTexture2D>>()
   let inUse = ResizeArray<RenderTexture2D>()
@@ -159,16 +157,11 @@ type RenderTargetPool3D() =
         let key = struct (rt.Texture.Width, rt.Texture.Height)
 
         match pool.TryGetValue(key) with
-        | true, queue when queue.Count < maxIdle -> queue.Enqueue(rt)
-        | _ ->
-          // Pool full for this dimension — unload instead of retaining.
-          match pool.TryGetValue(key) with
-          | true, queue when queue.Count >= maxIdle ->
-            Raylib.UnloadRenderTexture(rt)
-          | false, _ ->
-            let queue = Queue<RenderTexture2D>()
-            queue.Enqueue(rt)
-            pool[key] <- queue
+        | true, queue -> queue.Enqueue(rt)
+        | false, _ ->
+          let queue = Queue<RenderTexture2D>()
+          queue.Enqueue(rt)
+          pool[key] <- queue
 
       inUse.Clear()
 
@@ -176,11 +169,11 @@ type RenderTargetPool3D() =
         let key = struct (rt.Texture.Width, rt.Texture.Height)
 
         match depthPool.TryGetValue(key) with
-        | true, queue when queue.Count < maxIdle -> queue.Enqueue(rt)
-        | _ ->
-          Rlgl.UnloadTexture(rt.Texture.Id)
-          Rlgl.UnloadTexture(rt.Depth.Id)
-          Rlgl.UnloadFramebuffer(rt.Id)
+        | true, queue -> queue.Enqueue(rt)
+        | false, _ ->
+          let queue = Queue<RenderTexture2D>()
+          queue.Enqueue(rt)
+          depthPool[key] <- queue
 
       depthInUse.Clear()
 


### PR DESCRIPTION
# Scene-depth post-processing (model-aware fog, DoF, SSAO)

## Summary

Adds camera-POV scene depth to the post-processing pipeline so distance-based screen-space effects (fog, depth-of-field, SSAO) can sample real geometry depth instead of operating color-only.

- **New API:** `Draw3D.postProcessWithDepth` — same lifecycle as `postProcess` (runs once after the scene, chains in buffer order), but exposes the scene's depth attachment via `Context.Depth`.
- **raylib:** renders the scene into a custom framebuffer with a sampleable depth-texture attachment (`RenderTargetPool3D.AcquireWithDepth`). OpenGL's depth buffer is directly sampleable, so no extra geometry pass is needed.
- **MonoGame:** re-renders all opaque geometry into a dedicated R32F color target (cleared to white = far) via the existing depth-only shader. DirectX/OpenGL depth-stencil buffers aren't directly sampleable in MonoGame's API, so this extra pass is required.
- **Depth contract:** non-linear NDC z, `[0,1]` (0=near, 1=far). Skybox/uncovered pixels read 1.0. The effect linearizes with the camera's near/far (raylib: global clip planes via `GetCullDistanceNear/Far`; MonoGame: per-camera `NearPlane`/`FarPlane`).

## Docs

- `docs/graphics3d/overview.md` — new "Post-processing" section with the depth-texture contract, linearization formulas, and per-backend depth-production notes.
- `docs/shaders.md` — new "Post-process shaders" section documenting sampler binding, the `SetShaderValueTexture` caveat (raylib batch flush), and the `double → float32` FFI trap on `GetCullDistanceNear/Far`.

## Validation

Built and validated against the FPS sample in [Mibo.Samples](https://github.com/AngelMunoz/Mibo.Samples) — distance fog now renders correctly on both backends (raylib + MonoGame DesktopGL/WindowsDX).
