### PR TITLE
fix: forward pipeline review fixes for v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Raylib 3D:** `cameraPos` was never uploaded to the forward/instanced PBR shaders when no shadow-casting light was active, silently breaking specular highlights and Fresnel on non-skinned draws. Camera position is now set per-draw on all shader variants, matching the MonoGame backend.
+- **MonoGame 3D:** light uniforms were re-uploaded on every draw call instead of once per frame. A `LightsDirty` flag (mirroring the raylib backend) now gates the upload, and the animated-model handler hoists the upload above the per-mesh loop.
+- **Raylib 3D:** instanced meshes used an identity normal matrix, producing incorrect normal-map lighting on rotated or non-uniformly scaled instances. The instanced vertex shader now computes the normal matrix per-vertex from `instanceTransform`.
+
+### Changed
+
+- **Raylib 3D:** the shadow-culling distance for point/spot lights (previously hardcoded at 50 units) is now configurable via `ShadowAtlasConfig.MaxShadowLightDistance` (default 50.0). Increase it for large-world games (RTS, open-world); decrease for tighter scenes.
+
 ## [2.0.0-rc-002] - 2026-07-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,20 @@
 
 ## [Unreleased]
 
+### Added
+
+- **3D:** point-light shadows are no longer fixed to look straight down. Set `PointLight3D.ShadowDirection` (or use the `withShadowDirection` builder) to aim the single-face shadow map toward your geometry — e.g. `Vector3.UnitX` for a wall sconce. Defaults to down (−Y) when unset.
+
 ### Fixed
 
-- **Raylib 3D:** `cameraPos` was never uploaded to the forward/instanced PBR shaders when no shadow-casting light was active, silently breaking specular highlights and Fresnel on non-skinned draws. Camera position is now set per-draw on all shader variants, matching the MonoGame backend.
-- **MonoGame 3D:** light uniforms were re-uploaded on every draw call instead of once per frame. A `LightsDirty` flag (mirroring the raylib backend) now gates the upload, and the animated-model handler hoists the upload above the per-mesh loop.
-- **Raylib 3D:** instanced meshes used an identity normal matrix, producing incorrect normal-map lighting on rotated or non-uniformly scaled instances. The instanced vertex shader now computes the normal matrix per-vertex from `instanceTransform`.
+- **Raylib 3D:** specular highlights and Fresnel effects rendered incorrectly on non-skinned meshes when no shadow-casting light was present.
+- **MonoGame 3D:** per-frame rendering overhead reduced — lighting data is now uploaded once per frame instead of once per draw call.
+- **Raylib 3D:** normal-mapped meshes now light correctly when consecutive draws share a material but differ in world transform (the normal matrix was previously cached per material instead of per draw).
+- **Raylib 3D:** normal-mapped instanced meshes now light correctly when individual instances are rotated or non-uniformly scaled.
 
 ### Changed
 
-- **Raylib 3D:** the shadow-culling distance for point/spot lights (previously hardcoded at 50 units) is now configurable via `ShadowAtlasConfig.MaxShadowLightDistance` (default 50.0). Increase it for large-world games (RTS, open-world); decrease for tighter scenes.
+- **Raylib 3D:** the maximum distance at which point/spot lights cast shadows is now configurable via `ShadowAtlasConfig.MaxShadowLightDistance` (default 50 world units). Increase it for large-world games (RTS, open-world); decrease for tighter scenes.
 
 ## [2.0.0-rc-002] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- **2D:** post-process effects can now read the scene's lighting data and camera transform. The post-process context exposes the active `LightContext2D` (point lights, directional lights, ambient, occluders) and the last `Camera2D` — so a post-process shader can bloom lit areas, apply light-tinted color grading, or anchor effects in world space.
+
 - **3D:** point-light shadows are no longer fixed to look straight down. Set `PointLight3D.ShadowDirection` (or use the `withShadowDirection` builder) to aim the single-face shadow map toward your geometry — e.g. `Vector3.UnitX` for a wall sconce. Defaults to down (−Y) when unset.
 
 ### Fixed

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -561,6 +561,48 @@ picking on raylib, you'll need a replacement. Use raylib's native
 (`Matrix4x4` unproject). For orbit-style cameras, build the
 `Raylib_cs.Camera3D` from spherical coordinates directly.
 
+---
+
+## Pre-release fixes (unreleased)
+
+These are fixes landing on the `fix/pipeline-review-v2` branch against the
+v2-rc codebase, before the stable v2 tag. They are **breaking only if you
+construct `PointLight3D` struct literals directly** (see below).
+
+### Point-light shadow direction
+
+Point-light shadows previously rendered a single face looking straight down
+(−Y), no matter where the light was or what geometry surrounded it. A wall
+sconce or a light placed at floor level cast shadows that missed everything.
+
+`PointLight3D` gains a `ShadowDirection: Vector3 voption` field:
+
+```fsharp
+// Ceiling light — default, looks down (no change needed)
+let ceiling = PointLight3D.create(pos, 10.0f) |> PointLight3D.withCastsShadows true
+
+// Wall sconce — aim the shadow map along +X
+let sconce =
+  PointLight3D.create(pos, 8.0f)
+  |> PointLight3D.withCastsShadows true
+  |> PointLight3D.withShadowDirection Vector3.UnitX
+```
+
+**Breaking:** if you construct `PointLight3D` via a struct literal
+(`{ Position = ...; ... }`), add `ShadowDirection = ValueNone`. If you use
+`PointLight3D.create` + builder functions, no change is needed.
+
+### Single directional-light shadow
+
+The forward PBR pipeline lights and shadows **only the first directional
+light**. The shader uses scalar (non-array) directional-light uniforms, so a
+second `AddDirectionalLight` with `CastsShadows = true` is silently ignored by
+the shader. This is now documented on `DirectionalLight3D.CastsShadows`.
+
+**No migration action** — the behavior is unchanged, just documented. If you
+need two directional lights, set `CastsShadows = false` on the secondary one
+and rely on it for fill lighting only.
+
 
 
 

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -7,13 +7,11 @@ index: 1
 
 # Migrating to Mibo v2
 
-> **Status: In progress.** This document tracks the work happening on the `v2`
-> branch to make Mibo backend-agnostic, and collects **every breaking change** a
-> user will face when moving from the current `1.3.0` (raylib-only) release to the
-> upcoming major version. It is updated as each phase lands — if a phase is not
-> listed here, it has not shipped yet.
->
-> If you are tracking `v2`, read this document first whenever you pull.
+This document collects **every breaking change** you will face when moving from
+the `1.3.0` (raylib-only) release to Mibo v2 — a backend-agnostic core with
+pluggable raylib and MonoGame backends. Work through the sections that match
+your code; each entry lists what changed, why, and exactly how to update your
+code.
 
 ## What v2 is
 
@@ -58,8 +56,7 @@ that leaks a backend enum/handle stay in the backend.**
 
 ## Breaking changes
 
-> Sections are added as the phase that introduces them lands. Each entry lists
-> what changed, why, and exactly how to update your code.
+Each entry below lists what changed, why, and exactly how to update your code.
 
 ### Phase 1a — `Mibo.Core` extraction
 
@@ -563,47 +560,111 @@ picking on raylib, you'll need a replacement. Use raylib's native
 
 ---
 
-## Pre-release fixes (unreleased)
+## Post-processing and shadow refinements
 
-These are fixes landing on the `fix/pipeline-review-v2` branch against the
-v2-rc codebase, before the stable v2 tag. They are **breaking only if you
-construct `PointLight3D` struct literals directly** (see below).
+### Post-processing is now command-driven (breaking)
 
-### Point-light shadow direction
+**Breaking (2D and 3D).** In 1.x, post-processing was configured once at
+renderer/pipeline construction and ran **every frame for the life of the
+renderer** — whether or not the effect was needed that frame:
 
-Point-light shadows previously rendered a single face looking straight down
-(−Y), no matter where the light was or what geometry surrounded it. A wall
-sconce or a light placed at floor level cast shadows that missed everything.
+- **2D:** `Renderer2DConfig.PostProcess: PostProcessPass[] voption`, where
+  `PostProcessPass = { Shader; OnSetup }`.
+- **3D:** `PostProcessConfig3D` / `PostProcessPass3D` (`{ Shader; OnSetup }`),
+  passed to the pipeline constructor.
 
-`PointLight3D` gains a `ShadowDirection: Vector3 voption` field:
+These config types have been removed. Post-processing is now **on-demand and
+model-aware**: the view emits a post-process command into the render buffer, and
+the action runs only when (and only on the frames) it is emitted — so a
+hit-flash, a pause vignette, or a cutscene grade costs nothing on the frames it
+isn't drawn.
 
 ```fsharp
-// Ceiling light — default, looks down (no change needed)
-let ceiling = PointLight3D.create(pos, 10.0f) |> PointLight3D.withCastsShadows true
+// 2D — v1, declared once, ran every frame whether needed or not
+let renderer =
+  Renderer2D.createWithConfig
+    { PostProcess =
+        ValueSome
+          [|
+            {
+              Shader = vignetteShader
+              OnSetup = ValueSome(fun shader ctx -> ...)
+            }
+          |]
+      ClearColor = ValueNone }
+    view
 
-// Wall sconce — aim the shadow map along +X
-let sconce =
-  PointLight3D.create(pos, 8.0f)
-  |> PointLight3D.withCastsShadows true
-  |> PointLight3D.withShadowDirection Vector3.UnitX
+// 2D — v2, emitted from the view, only on frames that need it
+let view ctx model (buffer: RenderBuffer2D) =
+  buffer
+  |> Draw.postProcess (fun ppCtx ->
+      // ppCtx.Source — the scene texture (or previous pass's output)
+      // ppCtx.Width, ppCtx.Height, ppCtx.Time — dimensions + frame time
+      drawFullscreenQuad ppCtx.Source vignetteShader)
 ```
 
-**Breaking:** if you construct `PointLight3D` via a struct literal
-(`{ Position = ...; ... }`), add `ShadowDirection = ValueNone`. If you use
-`PointLight3D.create` + builder functions, no change is needed.
+```fsharp
+// 3D — v1, declared once, ran every frame whether needed or not
+let pipeline =
+  ClusteredForwardPipeline(
+    postProcess = {
+      Passes =
+        ValueSome
+          [|
+            {
+              Shader = vignetteShader
+              OnSetup = ValueSome(fun shader ctx -> ...)
+            }
+          |]
+    }
+  )
 
-### Single directional-light shadow
+// 3D — v2, emitted from the view, only on frames that need it
+let view ctx model (buffer: RenderBuffer3D) =
+  buffer
+  |> Draw3D.postProcess (fun ppCtx ->
+      // ppCtx.Source — the scene texture (or previous pass's output)
+      // ppCtx.Width, ppCtx.Height, ppCtx.Time — dimensions + frame time
+      // ppCtx.Context — GameContext (resolve a shader via IAssets)
+      drawFullscreenQuad ppCtx.Source vignetteShader)
+  |> Draw3D.drop
+```
 
-The forward PBR pipeline lights and shadows **only the first directional
-light**. The shader uses scalar (non-array) directional-light uniforms, so a
-second `AddDirectionalLight` with `CastsShadows = true` is silently ignored by
-the shader. This is now documented on `DirectionalLight3D.CastsShadows`.
+Multiple passes chain in buffer order, ping-ponging through pooled render
+targets with the last pass drawing to the back-buffer. Resolve the shader inside
+the action (e.g. via `IAssets`) rather than capturing a renderer/pipeline-wide
+one — the action owns the draw.
+
+### Depth-aware post-processing (3D)
+
+A second command, `Draw3D.postProcessWithDepth`, gives the action a
+`PostProcessContext3D` whose `Depth` field is a camera-POV depth texture (NDC z
+in `[0,1]`) for distance effects like fog, depth-of-field, and SSAO. Use plain
+`Draw3D.postProcess` when you don't sample depth — the pipeline skips the
+depth-production cost entirely:
+
+```fsharp
+buffer
+|> Draw3D.postProcessWithDepth (fun ppCtx ->
+    match ppCtx.Depth with
+    | ValueSome depthTex -> // bind depthTex, apply the distance effect
+    | ValueNone ->          // no depth produced this frame — pass through
+    ())
+|> Draw3D.drop
+```
+
+The depth texture is produced differently per backend (raylib samples the
+forward pass's depth attachment directly; MonoGame re-renders opaque geometry
+into a dedicated R32F target), but the contract — single-channel NDC z, `0` =
+near, `1` = far, skybox/uncovered = `1.0` — is identical on both. See the
+[3D Rendering Overview](graphics3d/overview.html) for the linearization formula.
 
 ### 2D post-process context enrichment
 
-The `PostProcessContext2D` now exposes two additional fields that a post-process
-shader can read — lighting data and camera transform. No new command variants;
-the existing `Draw.postProcess` action closure just receives a richer context.
+The 2D `PostProcessContext2D` now exposes two fields a post-process shader can
+read: the active `LightContext2D` (point lights, directional lights, ambient,
+occluders) and the last active `Camera2D`. No new command variants — the
+existing `Draw.postProcess` action closure just receives a richer context:
 
 ```fsharp
 Draw.postProcess (fun ctx ->
@@ -618,19 +679,45 @@ Draw.postProcess (fun ctx ->
   ()) buffer
 ```
 
-**Multi-camera caveat:** `Camera` is the **last** `Camera2D` that was active
-during the scene render. Commands sort by layer (ascending) with deterministic
-insertion-order tie-breaking (the sort key encodes the insertion index), so
-"last" is well-defined. However, when multiple camera blocks exist in the same
-frame (e.g. main view + minimap), the scene RT contains all of them composited
-— a single camera reference can't reconstruct per-camera regions. Use
-`DrawImmediate` for per-camera post-processing if needed.
+**Multi-camera caveat:** `Camera` is the **last** `Camera2D` active during the
+scene render. When multiple camera blocks exist in the same frame (e.g. main
+view + minimap), the scene render target contains all of them composited — a
+single camera reference can't reconstruct per-camera regions. Use
+`DrawImmediate` for per-camera post-processing.
 
-**No depth in 2D:** Unlike the 3D pipeline's `postProcessWithDepth`, 2D
-rendering does not write to a depth buffer on either backend. There is no
-`PostProcessWithDepth` for 2D. If you need depth-like data for a 2D effect
-(fake DOF from layer ordering), render a custom R32F target via `DrawImmediate`
-and pass it through your post-process action's closure.
+**No depth in 2D:** 2D rendering does not write a depth buffer on either
+backend, so there is no `PostProcessWithDepth` for 2D. If you need depth-like
+data for a 2D effect (e.g. fake DOF from layer ordering), render a custom R32F
+target via `DrawImmediate` and pass it through your action's closure.
+
+### Point-light shadow direction
+
+Point-light shadows previously rendered a single face looking straight down
+(−Y), no matter where the light was or what geometry surrounded it.
+`PointLight3D` now has a `ShadowDirection: Vector3 voption` field so you can aim
+the shadow map toward your geometry:
+
+```fsharp
+// Ceiling light — default, looks down (no change needed)
+let ceiling = PointLight3D.create(pos, 10.0f) |> PointLight3D.withCastsShadows true
+
+// Wall sconce — aim the shadow map along +X
+let sconce =
+  PointLight3D.create(pos, 8.0f)
+  |> PointLight3D.withCastsShadows true
+  |> PointLight3D.withShadowDirection Vector3.UnitX
+```
+
+**Breaking (minor):** if you construct `PointLight3D` via a struct literal
+(`{ Position = ...; ... }`), add `ShadowDirection = ValueNone`. If you use
+`PointLight3D.create` + builder functions, no change is needed.
+
+### Single directional-light shadow
+
+The forward PBR pipeline lights and shadows **only the first directional
+light**. The shader uses scalar (non-array) directional-light uniforms, so a
+second `AddDirectionalLight` with `CastsShadows = true` is silently ignored by
+the shader. This is now documented on `DirectionalLight3D.CastsShadows`.
 
 
 

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -599,9 +599,38 @@ light**. The shader uses scalar (non-array) directional-light uniforms, so a
 second `AddDirectionalLight` with `CastsShadows = true` is silently ignored by
 the shader. This is now documented on `DirectionalLight3D.CastsShadows`.
 
-**No migration action** — the behavior is unchanged, just documented. If you
-need two directional lights, set `CastsShadows = false` on the secondary one
-and rely on it for fill lighting only.
+### 2D post-process context enrichment
+
+The `PostProcessContext2D` now exposes two additional fields that a post-process
+shader can read — lighting data and camera transform. No new command variants;
+the existing `Draw.postProcess` action closure just receives a richer context.
+
+```fsharp
+Draw.postProcess (fun ctx ->
+  // ctx.Lights — the active LightContext2D (ValueNone when no lit sprites were drawn).
+  //   Read ctx.Lights.Value.PointLights, .DirLights, .Ambient, .Occluders
+  //   to drive bloom thresholds, light-tinted grading, etc.
+
+  // ctx.Camera — the last active Camera2D (ValueNone when no BeginCamera block was used).
+  //   Use it to convert between screen UVs and world coordinates for world-anchored effects.
+
+  // ctx.Source, ctx.Width, ctx.Height, ctx.Time — unchanged
+  ()) buffer
+```
+
+**Multi-camera caveat:** `Camera` is the **last** `Camera2D` that was active
+during the scene render. Commands sort by layer (ascending) with deterministic
+insertion-order tie-breaking (the sort key encodes the insertion index), so
+"last" is well-defined. However, when multiple camera blocks exist in the same
+frame (e.g. main view + minimap), the scene RT contains all of them composited
+— a single camera reference can't reconstruct per-camera regions. Use
+`DrawImmediate` for per-camera post-processing if needed.
+
+**No depth in 2D:** Unlike the 3D pipeline's `postProcessWithDepth`, 2D
+rendering does not write to a depth buffer on either backend. There is no
+`PostProcessWithDepth` for 2D. If you need depth-like data for a 2D effect
+(fake DOF from layer ordering), render a custom R32F target via `DrawImmediate`
+and pass it through your post-process action's closure.
 
 
 

--- a/src/Mibo.Core/Graphics3D/Light3D.fs
+++ b/src/Mibo.Core/Graphics3D/Light3D.fs
@@ -109,13 +109,15 @@ type PointLight3D = {
   /// </remarks>
   CastsShadows: bool
   /// <summary>
-  /// Direction the single-face shadow map looks (should be normalized). When None, defaults to
+  /// Direction the single-face shadow map looks. When None, defaults to
   /// straight down (−Y) — the common case for ceiling-mounted lights.
   /// </summary>
   /// <remarks>
   /// <b>Pipeline-dependent:</b> Point-light shadows render a single face (not a 6-face cubemap).
   /// Set this to face toward the geometry that should receive shadows. For a wall sconce pointing
-  /// along +X, use <c>Vector3.UnitX</c>. Ignored by pipelines that don't support point-light shadows.
+  /// along +X, use <c>Vector3.UnitX</c>. Any non-zero direction is safe — the pipeline normalizes
+  /// internally and selects an up vector that isn't parallel to it. Ignored by pipelines that don't
+  /// support point-light shadows.
   /// </remarks>
   ShadowDirection: Vector3 voption
   /// <summary>

--- a/src/Mibo.Core/Graphics3D/Light3D.fs
+++ b/src/Mibo.Core/Graphics3D/Light3D.fs
@@ -51,9 +51,14 @@ type DirectionalLight3D = {
   /// Whether this directional light casts shadows.
   /// </summary>
   /// <remarks>
+  /// <b>Only the first shadow-casting directional light produces a shadow map.</b>
+  /// The forward PBR pipeline uses scalar (non-array) directional-light uniforms, so
+  /// only one directional light is lit and shadowed. Additional directional lights
+  /// are silently ignored by the shader. Set <c>CastsShadows = false</c> on extras.
+  /// <para>
   /// <b>Pipeline-dependent:</b> Not all rendering pipelines support shadow casting.
   /// Pipelines that don't support shadows will ignore this field.
-  /// Check your pipeline's documentation for shadow support details.
+  /// </para>
   /// </remarks>
   CastsShadows: bool
 }
@@ -104,6 +109,16 @@ type PointLight3D = {
   /// </remarks>
   CastsShadows: bool
   /// <summary>
+  /// Direction the single-face shadow map looks (should be normalized). When None, defaults to
+  /// straight down (−Y) — the common case for ceiling-mounted lights.
+  /// </summary>
+  /// <remarks>
+  /// <b>Pipeline-dependent:</b> Point-light shadows render a single face (not a 6-face cubemap).
+  /// Set this to face toward the geometry that should receive shadows. For a wall sconce pointing
+  /// along +X, use <c>Vector3.UnitX</c>. Ignored by pipelines that don't support point-light shadows.
+  /// </remarks>
+  ShadowDirection: Vector3 voption
+  /// <summary>
   /// Per-light shadow bias override. When None, uses the pipeline's global bias setting.
   /// </summary>
   /// <remarks>
@@ -125,6 +140,7 @@ module PointLight3D =
     Radius = radius
     Falloff = 2.0f
     CastsShadows = false
+    ShadowDirection = ValueNone
     ShadowBias = ValueNone
   }
 
@@ -140,6 +156,11 @@ module PointLight3D =
   let inline withCastsShadows (v: bool) (l: PointLight3D) = {
     l with
         CastsShadows = v
+  }
+
+  let inline withShadowDirection (v: Vector3) (l: PointLight3D) = {
+    l with
+        ShadowDirection = ValueSome v
   }
 
   let inline withShadowBias (v: float32) (l: PointLight3D) = {

--- a/src/Mibo.MonoGame/Graphics2D/PostProcessContext2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/PostProcessContext2D.fs
@@ -29,6 +29,23 @@ type PostProcessContext2D = {
   Quad: Mibo.Elmish.Graphics3D.FullScreenQuad
 
   /// <summary>
+  /// The active 2D light context (<c>ValueNone</c> when no lit sprites were drawn this frame).
+  /// Read <c>Lights.Value.PointLights</c>, <c>Lights.Value.DirLights</c>, <c>Lights.Value.Ambient</c>
+  /// to drive light-aware effects (bloom on lit areas, light-tinted color grading).
+  /// </summary>
+  Lights: Lighting.LightContext2D voption
+
+  /// <summary>
+  /// The last active camera during the scene render (<c>ValueNone</c> when no
+  /// <c>BeginCamera</c> block was used). Useful for anchoring post-process effects in world space
+  /// (world-aligned fog, distortion). When multiple camera blocks exist in the same frame this is
+  /// the <b>last</b> one — the scene RT contains all of them composited, so a single camera
+  /// reference can't reconstruct per-camera regions. Commands within a layer are executed in
+  /// insertion order (deterministic stable sort), so "last" is well-defined.
+  /// </summary>
+  Camera: Camera2D voption
+
+  /// <summary>
   /// Game services — e.g. <c>tryGetService&lt;IAssets&gt;</c> to resolve a compiled effect lazily
   /// (defers resolution to first frame, where the device/assets exist).
   /// </summary>

--- a/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Renderer2D.fs
@@ -50,6 +50,8 @@ module private PostProcessDrain =
     (ctx: GameContext)
     (gd: GraphicsDevice)
     (sceneTarget: RenderTarget2D)
+    (lights: Lighting.LightContext2D voption)
+    (camera: Camera2D voption)
     (rtPool: IRenderTargetPool)
     (quad: Mibo.Elmish.Graphics3D.FullScreenQuad)
     (actions: ResizeArray<PostProcessContext2D -> unit>)
@@ -62,9 +64,6 @@ module private PostProcessDrain =
     for i = 0 to actions.Count - 1 do
       let isLast = i = actions.Count - 1
 
-      // The last action draws to the back-buffer (null target); earlier actions ping-pong
-      // through pooled targets. The destination is set and (for intermediate targets) cleared
-      // BEFORE the action runs — the action samples `src`, not the destination.
       let dst: RenderTarget2D voption =
         if isLast then
           ValueNone
@@ -75,10 +74,7 @@ module private PostProcessDrain =
       | ValueSome target ->
         gd.SetRenderTarget(target)
         gd.Clear(ClearOptions.Target, Color.Black, 0.0f, 0)
-      | ValueNone ->
-        // Back-buffer on the last pass — don't clear it (matches the raylib 2D drain),
-        // so a noClear composite isn't wiped by the final post-process pass.
-        gd.SetRenderTarget(null)
+      | ValueNone -> gd.SetRenderTarget(null)
 
       let ppCtx: PostProcessContext2D = {
         Source = src
@@ -87,12 +83,13 @@ module private PostProcessDrain =
         Time = frameTime
         Device = gd
         Quad = quad
+        Lights = lights
+        Camera = camera
         Context = ctx
       }
 
       actions[i]ppCtx
 
-      // Advance the source to what we just rendered into, ready for the next pass.
       match dst with
       | ValueSome target -> src <- target
       | ValueNone -> ()
@@ -1677,9 +1674,17 @@ type Renderer2D<'Model>
         let ppActions =
           ResizeArray<PostProcessContext2D -> unit>(buffer.PostProcessCount)
 
+        let mutable lightCtx: Lighting.LightContext2D voption = ValueNone
+
         for i = 0 to buffer.Count - 1 do
           match buffer[i] with
           | Command2D.PostProcess a -> ppActions.Add a
+          | Command2D.LitSprite(ctx, _)
+          | Command2D.EndLighting(ctx, _)
+          | Command2D.EnableShadows(ctx, _)
+          | Command2D.DisableShadows(ctx, _) ->
+            if lightCtx.IsNone then
+              lightCtx <- ValueSome ctx
           | _ -> ()
 
         let pool = _rtPool.Value
@@ -1718,6 +1723,8 @@ type Renderer2D<'Model>
             ctx
             gd
             sceneRT
+            lightCtx
+            state.Camera
             pool
             quad
             ppActions

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
@@ -790,6 +790,7 @@ type ForwardPipelineBase
       // ValueNone → default PBR path; ValueSome e → shade with the user effect. Scopes do NOT
       // persist across cameras — a new camera block (BeginCamera/BeginCameraConfig) and EndCamera
       // both reset it, so a forgotten endEffect can't leak a user effect into the next view.
+      pbrRes.LightsDirty <- true
       let mutable activeEffect: Effect voption = ValueNone
 
       // Build the per-frame scene bundle once (lights, shared bone palette, per-light shadow slots,

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -98,6 +98,11 @@ type internal PbrResources() =
   /// <summary>MaterialKey short-circuit: whether the last draw's material is still current.</summary>
   member val HasLastMaterial = false with get, set
 
+  /// <summary>Whether light uniforms need re-uploading to the PBR effect. Set at frame start;
+  /// cleared after the first upload so subsequent draws in the same frame skip the cost
+  /// (lights are stable within a frame — gathered once in the pre-scan).</summary>
+  member val LightsDirty = true with get, set
+
   /// <summary>The last draw's MaterialKey (valid when HasLastMaterial).</summary>
   member val LastKey: MaterialKey =
     Unchecked.defaultof<MaterialKey> with get, set
@@ -292,12 +297,15 @@ module internal PbrShading =
         PbrUniforms.setMatrix p.Matrix.ViewProj viewProj
         PbrUniforms.setVec3 p.Matrix.CameraPos state.CurrentCamera.Position
 
-        PbrUniforms.uploadLights(
-          &p,
-          frame.Lights,
-          frame.PointShadowSlots,
-          frame.SpotShadowSlots
-        )
+        if res.LightsDirty then
+          PbrUniforms.uploadLights(
+            &p,
+            frame.Lights,
+            frame.PointShadowSlots,
+            frame.SpotShadowSlots
+          )
+
+          res.LightsDirty <- false
 
         let mutable partIndex = 0
 
@@ -367,6 +375,22 @@ module internal PbrShading =
         for i = palCount to bonePaletteScratch.Length - 1 do
           bonePaletteScratch[i] <- Matrix.Identity
 
+        // Frame-global uniforms don't depend on the mesh — set once per draw, not per mesh.
+        let viewProj = state.View * state.Projection
+
+        PbrUniforms.setMatrix p.Matrix.ViewProj viewProj
+        PbrUniforms.setVec3 p.Matrix.CameraPos state.CurrentCamera.Position
+
+        if res.LightsDirty then
+          PbrUniforms.uploadLights(
+            &p,
+            frame.Lights,
+            frame.PointShadowSlots,
+            frame.SpotShadowSlots
+          )
+
+          res.LightsDirty <- false
+
         let mutable partIndex = 0
 
         for mesh in model.Meshes do
@@ -376,20 +400,7 @@ module internal PbrShading =
           Matrix.Invert(&t, &inv) |> ignore
 
           PbrUniforms.setMatrix p.Matrix.MatModel world
-
-          PbrUniforms.setMatrix
-            p.Matrix.ViewProj
-            (state.View * state.Projection)
-
           PbrUniforms.setMatrix p.Matrix.NormalMatrix (Matrix.Transpose inv)
-          PbrUniforms.setVec3 p.Matrix.CameraPos state.CurrentCamera.Position
-
-          PbrUniforms.uploadLights(
-            &p,
-            frame.Lights,
-            frame.PointShadowSlots,
-            frame.SpotShadowSlots
-          )
 
           for part in mesh.MeshParts do
             let isSkinned =
@@ -463,12 +474,15 @@ module internal PbrShading =
           res.LastKey <- key
           res.HasLastMaterial <- true
 
-        PbrUniforms.uploadLights(
-          &p,
-          frame.Lights,
-          frame.PointShadowSlots,
-          frame.SpotShadowSlots
-        )
+        if res.LightsDirty then
+          PbrUniforms.uploadLights(
+            &p,
+            frame.Lights,
+            frame.PointShadowSlots,
+            frame.SpotShadowSlots
+          )
+
+          res.LightsDirty <- false
 
         mesh.Draw(gd, e)
       | _ -> ()
@@ -605,12 +619,15 @@ module internal PbrShading =
           PbrUniforms.uploadMaterial(&p, &material)
           PbrUniforms.bindTextures(&p, &material, whiteTex res)
 
-          PbrUniforms.uploadLights(
-            &p,
-            frame.Lights,
-            frame.PointShadowSlots,
-            frame.SpotShadowSlots
-          )
+          if res.LightsDirty then
+            PbrUniforms.uploadLights(
+              &p,
+              frame.Lights,
+              frame.PointShadowSlots,
+              frame.SpotShadowSlots
+            )
+
+            res.LightsDirty <- false
 
           for pass in e.CurrentTechnique.Passes do
             pass.Apply()

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -289,8 +289,16 @@ module internal ShadowPass =
   let buildPointViewProj
     (lightPos: Vector3, shadowDir: Vector3, lightRadius: float32)
     : Matrix =
-    let view =
-      Matrix.CreateLookAt(lightPos, lightPos + shadowDir, Vector3.UnitZ)
+    // Normalize so the parallel-up threshold check is accurate for non-unit
+    // inputs; fall back to the default on zero-length (avoids NaN from a
+    // degenerate forward in CreateLookAt).
+    let dir =
+      let len = shadowDir.Length()
+      if len > 0.0001f then shadowDir / len else -Vector3.UnitY
+
+    let safeUp = if abs dir.Y > 0.99f then Vector3.UnitZ else Vector3.UnitY
+
+    let view = Matrix.CreateLookAt(lightPos, lightPos + dir, safeUp)
     // Dynamic near plane: CreatePerspectiveFieldOfView throws if near <= 0.
     let nearPlane = max 0.0001f (min 0.1f (lightRadius * 0.5f))
 

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -283,13 +283,14 @@ module internal ShadowPass =
     view * proj
 
   /// <summary>
-  /// Builds a point light's shadow ViewProj — a downward-facing 90° perspective frustum
-  /// covering +Z. Used by the forward shader for point-light shadows. (B13 point-light
-  /// shadows are rendered as a single face into one atlas slot.)
+  /// Builds a point light's shadow ViewProj — a single-face 90° perspective frustum
+  /// covering the given shadow direction. Used by the forward shader for point-light shadows.
   /// </summary>
-  let buildPointViewProj(lightPos: Vector3, lightRadius: float32) : Matrix =
+  let buildPointViewProj
+    (lightPos: Vector3, shadowDir: Vector3, lightRadius: float32)
+    : Matrix =
     let view =
-      Matrix.CreateLookAt(lightPos, lightPos - Vector3.UnitY, Vector3.UnitZ)
+      Matrix.CreateLookAt(lightPos, lightPos + shadowDir, Vector3.UnitZ)
     // Dynamic near plane: CreatePerspectiveFieldOfView throws if near <= 0.
     let nearPlane = max 0.0001f (min 0.1f (lightRadius * 0.5f))
 
@@ -934,7 +935,15 @@ module internal ShadowPass =
 
       if pt.CastsShadows then
         let ptPos = Conversions.fromNumericsVector3 pt.Position
-        let vp = buildPointViewProj(ptPos, pt.Radius)
+
+        let shadowDir =
+          Conversions.fromNumericsVector3(
+            match pt.ShadowDirection with
+            | ValueSome d -> d
+            | ValueNone -> -System.Numerics.Vector3.UnitY
+          )
+
+        let vp = buildPointViewProj(ptPos, shadowDir, pt.Radius)
 
         match
           res.Atlas.AddCaster(

--- a/src/Mibo.Raylib/Graphics2D/PostProcessContext2D.fs
+++ b/src/Mibo.Raylib/Graphics2D/PostProcessContext2D.fs
@@ -23,6 +23,23 @@ type PostProcessContext2D = {
   Time: float32
 
   /// <summary>
+  /// The active 2D light context (<c>ValueNone</c> when no lit sprites were drawn this frame).
+  /// Read <c>Lights.Value.PointLights</c>, <c>Lights.Value.DirLights</c>, <c>Lights.Value.Ambient</c>
+  /// to drive light-aware effects (bloom on lit areas, light-tinted color grading).
+  /// </summary>
+  Lights: Lighting.LightContext2D voption
+
+  /// <summary>
+  /// The last active <c>Camera2D</c> during the scene render (<c>ValueNone</c> when no
+  /// <c>BeginCamera</c> block was used). Useful for anchoring post-process effects in world space
+  /// (world-aligned fog, distortion). When multiple camera blocks exist in the same frame this is
+  /// the <b>last</b> one — the scene RT contains all of them composited, so a single camera
+  /// reference can't reconstruct per-camera regions. Commands within a layer are executed in
+  /// insertion order (deterministic stable sort), so "last" is well-defined.
+  /// </summary>
+  Camera: Camera2D voption
+
+  /// <summary>
   /// Game services — e.g. <c>tryGetService&lt;IAssets&gt;</c> to resolve a shader lazily
   /// (defers resolution to first frame, where the device/assets exist).
   /// </summary>

--- a/src/Mibo.Raylib/Graphics2D/Renderer2D.fs
+++ b/src/Mibo.Raylib/Graphics2D/Renderer2D.fs
@@ -23,6 +23,8 @@ module private PostProcessDrain =
   let apply
     (ctx: GameContext)
     (sceneTarget: RenderTexture2D)
+    (lights: LightContext2D voption)
+    (camera: Camera2D voption)
     (rtPool: IRenderTargetPool)
     (actions: ResizeArray<PostProcessContext2D -> unit>)
     (frameTime: float32)
@@ -51,6 +53,8 @@ module private PostProcessDrain =
         Width = w
         Height = h
         Time = frameTime
+        Lights = lights
+        Camera = camera
         Context = ctx
       }
 
@@ -518,9 +522,17 @@ type Renderer2D<'Model>
         let ppActions =
           ResizeArray<PostProcessContext2D -> unit>(buffer.PostProcessCount)
 
+        let mutable lightCtx: LightContext2D voption = ValueNone
+
         for i = 0 to buffer.Count - 1 do
           match buffer[i] with
           | Command2D.PostProcess a -> ppActions.Add a
+          | Command2D.LitSprite(ctx, _)
+          | Command2D.EndLighting(ctx, _)
+          | Command2D.EnableShadows(ctx, _)
+          | Command2D.DisableShadows(ctx, _) ->
+            if lightCtx.IsNone then
+              lightCtx <- ValueSome ctx
           | _ -> ()
 
         let sceneRT = rtPool.Acquire(ctx.WindowWidth, ctx.WindowHeight)
@@ -536,6 +548,8 @@ type Renderer2D<'Model>
         PostProcessDrain.apply
           ctx
           sceneRT
+          lightCtx
+          state.Camera
           rtPool
           ppActions
           (float32 gameTime.TotalTime.TotalSeconds)

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -1584,13 +1584,23 @@ module internal PipelineFunctions =
               if distToCamera <= maxShadowDist then
                 match caster.Type with
                 | ShadowCasterType.Point ->
-                  let ptTarget = caster.LightPosition + caster.LightDirection
+                  let rawDir = caster.LightDirection
+                  let len = rawDir.Length()
+
+                  let shadowDir =
+                    if len > 0.0001f then rawDir / len else -Vector3.UnitY
+
+                  let safeUp =
+                    if abs shadowDir.Y > 0.99f then
+                      Vector3.UnitZ
+                    else
+                      Vector3.UnitY
 
                   let ptCamera =
                     Camera3D(
                       Position = caster.LightPosition,
-                      Target = ptTarget,
-                      Up = Vector3.UnitZ,
+                      Target = caster.LightPosition + shadowDir,
+                      Up = safeUp,
                       FovY = 90.0f,
                       Projection = CameraProjection.Perspective
                     )

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -1616,11 +1616,16 @@ module internal PipelineFunctions =
                   )
 
                 | ShadowCasterType.Spot ->
+                  let spotDir = caster.LightDirection
+                  let len = spotDir.Length()
+                  let dir = if len > 0.0001f then spotDir / len else -Vector3.UnitY
+                  let safeUp = if abs dir.Y > 0.99f then Vector3.UnitZ else Vector3.UnitY
+
                   let spotCamera =
                     Camera3D(
                       Position = caster.LightPosition,
-                      Target = caster.LightPosition + caster.LightDirection,
-                      Up = Vector3.UnitY,
+                      Target = caster.LightPosition + dir,
+                      Up = safeUp,
                       FovY = 90.0f,
                       Projection = CameraProjection.Perspective
                     )

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -466,11 +466,16 @@ module internal ShadowPassHelpers =
       let pt = lights.PointLights[i]
 
       if pt.CastsShadows then
+        let shadowDir =
+          match pt.ShadowDirection with
+          | ValueSome d -> d
+          | ValueNone -> -Vector3.UnitY
+
         match
           tryAdd
             ShadowCasterType.Point
             pt.Position
-            Vector3.Zero
+            shadowDir
             Vector3.Zero
             pt.ShadowBias
         with
@@ -815,12 +820,8 @@ module internal PipelineFunctions =
 
   /// Single parameterized material uniform setter replacing 3x duplication.
   let setMaterialUniforms
-    (
-      shader: Shader,
-      matLocs: inref<MaterialUniforms>,
-      mat3d: inref<Material3D>,
-      nm: Matrix4x4
-    ) =
+    (shader: Shader, matLocs: inref<MaterialUniforms>, mat3d: inref<Material3D>)
+    =
     setShaderVec4
       shader
       matLocs.AlbedoColor
@@ -843,7 +844,6 @@ module internal PipelineFunctions =
       | ValueNone -> 0
 
     setShaderInt shader matLocs.UseNormalMap useNormal
-    Raylib.SetShaderValueMatrix(shader, matLocs.NormalMatrix, nm)
 
   /// Single parameterized material cache lookup/creation replacing 3x duplication.
   let getOrCreate
@@ -1067,10 +1067,11 @@ module internal PipelineFunctions =
     setShaderInt shader variant.Locs.Shadow.Pass 0
 
     let nm = computeNormalMatrix transform
+    Raylib.SetShaderValueMatrix(shader, variant.Locs.Material.NormalMatrix, nm)
     let key = MaterialKey.fromMaterial3D &material
 
     if not variant.HasLastMaterial || key <> variant.LastMaterialKey then
-      setMaterialUniforms(shader, &variant.Locs.Material, &material, nm)
+      setMaterialUniforms(shader, &variant.Locs.Material, &material)
       variant.LastMaterialKey <- key
       variant.HasLastMaterial <- true
 
@@ -1112,6 +1113,7 @@ module internal PipelineFunctions =
     setShaderInt shader variant.Locs.Shadow.Pass 0
 
     let nm = computeNormalMatrix transform
+    Raylib.SetShaderValueMatrix(shader, variant.Locs.Material.NormalMatrix, nm)
 
     for mi = 0 to model.MeshCount - 1 do
       let mesh = NativePtr.get model.Meshes mi
@@ -1127,7 +1129,7 @@ module internal PipelineFunctions =
       let key = MaterialKey.fromMaterial3D &mat3d
 
       if not variant.HasLastMaterial || key <> variant.LastMaterialKey then
-        setMaterialUniforms(shader, &variant.Locs.Material, &mat3d, nm)
+        setMaterialUniforms(shader, &variant.Locs.Material, &mat3d)
         variant.LastMaterialKey <- key
         variant.HasLastMaterial <- true
 
@@ -1170,10 +1172,11 @@ module internal PipelineFunctions =
     setShaderVec3 shader variant.Locs.CameraPos currentCamera.Position
     setShaderInt shader variant.Locs.Shadow.Pass 0
     let nm = computeNormalMatrix transform
+    Raylib.SetShaderValueMatrix(shader, variant.Locs.Material.NormalMatrix, nm)
     let key = MaterialKey.fromMaterial3D &material
 
     if not variant.HasLastMaterial || key <> variant.LastMaterialKey then
-      setMaterialUniforms(shader, &variant.Locs.Material, &material, nm)
+      setMaterialUniforms(shader, &variant.Locs.Material, &material)
       variant.LastMaterialKey <- key
       variant.HasLastMaterial <- true
 
@@ -1219,12 +1222,7 @@ module internal PipelineFunctions =
     let key = MaterialKey.fromMaterial3D &material
 
     if not variant.HasLastMaterial || key <> variant.LastMaterialKey then
-      setMaterialUniforms(
-        shader,
-        &variant.Locs.Material,
-        &material,
-        Matrix4x4.Identity
-      )
+      setMaterialUniforms(shader, &variant.Locs.Material, &material)
 
       variant.LastMaterialKey <- key
       variant.HasLastMaterial <- true
@@ -1586,12 +1584,12 @@ module internal PipelineFunctions =
               if distToCamera <= maxShadowDist then
                 match caster.Type with
                 | ShadowCasterType.Point ->
-                  let downTarget = caster.LightPosition - Vector3.UnitY
+                  let ptTarget = caster.LightPosition + caster.LightDirection
 
                   let ptCamera =
                     Camera3D(
                       Position = caster.LightPosition,
-                      Target = downTarget,
+                      Target = ptTarget,
                       Up = Vector3.UnitZ,
                       FovY = 90.0f,
                       Projection = CameraProjection.Perspective

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -1043,6 +1043,7 @@ module internal PipelineFunctions =
       maxSp: int,
       pointShadowSlots: int[],
       spotShadowSlots: int[],
+      currentCamera: Camera3D,
       mesh: Mesh,
       transform: Matrix4x4,
       material: Material3D
@@ -1061,6 +1062,9 @@ module internal PipelineFunctions =
       )
 
       variant.LightsDirty <- false
+
+    setShaderVec3 shader variant.Locs.CameraPos currentCamera.Position
+    setShaderInt shader variant.Locs.Shadow.Pass 0
 
     let nm = computeNormalMatrix transform
     let key = MaterialKey.fromMaterial3D &material
@@ -1084,6 +1088,7 @@ module internal PipelineFunctions =
       maxSp: int,
       pointShadowSlots: int[],
       spotShadowSlots: int[],
+      currentCamera: Camera3D,
       model: Model,
       transform: Matrix4x4,
       matOverride: MaterialOverride voption
@@ -1102,6 +1107,9 @@ module internal PipelineFunctions =
       )
 
       variant.LightsDirty <- false
+
+    setShaderVec3 shader variant.Locs.CameraPos currentCamera.Position
+    setShaderInt shader variant.Locs.Shadow.Pass 0
 
     let nm = computeNormalMatrix transform
 
@@ -1571,7 +1579,9 @@ module internal PipelineFunctions =
               let distToCamera =
                 (lightPos - activeCamera.Position).LengthSquared()
 
-              let maxShadowDist = 2500.0f // 50^2
+              let maxShadowDist =
+                atlasCfg.MaxShadowLightDistance
+                * atlasCfg.MaxShadowLightDistance
 
               if distToCamera <= maxShadowDist then
                 match caster.Type with
@@ -1866,6 +1876,7 @@ type ForwardPipelineBase
           maxSp,
           frame.PointShadowSlots,
           frame.SpotShadowSlots,
+          currentCamera,
           mesh,
           transform,
           material
@@ -1879,6 +1890,7 @@ type ForwardPipelineBase
           maxSp,
           frame.PointShadowSlots,
           frame.SpotShadowSlots,
+          currentCamera,
           model,
           transform,
           ValueNone
@@ -1892,6 +1904,7 @@ type ForwardPipelineBase
           maxSp,
           frame.PointShadowSlots,
           frame.SpotShadowSlots,
+          currentCamera,
           model,
           transform,
           ValueSome matOverride
@@ -2401,6 +2414,7 @@ type ForwardPipelineBase
                     maxSp,
                     pointShadowSlots,
                     spotShadowSlots,
+                    currentCamera,
                     mesh,
                     transform,
                     material
@@ -2414,6 +2428,7 @@ type ForwardPipelineBase
                     maxSp,
                     pointShadowSlots,
                     spotShadowSlots,
+                    currentCamera,
                     model,
                     transform,
                     ValueNone
@@ -2427,6 +2442,7 @@ type ForwardPipelineBase
                     maxSp,
                     pointShadowSlots,
                     spotShadowSlots,
+                    currentCamera,
                     model,
                     transform,
                     ValueSome matOverride

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/Shaders.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/Shaders.fs
@@ -62,13 +62,13 @@ out vec3 fragNormal;
 out vec3 fragWorldPos;
 
 uniform mat4 mvp;
-uniform mat4 normalMatrix;
 
 void main()
 {
     fragTexCoord = vertexTexCoord;
     fragColor = vertexColor;
-    fragNormal = mat3(normalMatrix) * vertexNormal;
+    mat3 nMat = transpose(inverse(mat3(instanceTransform)));
+    fragNormal = normalize(nMat * vertexNormal);
     fragWorldPos = (instanceTransform * vec4(vertexPosition, 1.0)).xyz;
     gl_Position = mvp * instanceTransform * vec4(vertexPosition, 1.0);
 }

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ShadowAtlas.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ShadowAtlas.fs
@@ -38,7 +38,8 @@ type ShadowCasterData = {
   LightTarget: Vector3
   /// <summary>Index of first atlas region (0-based).</summary>
   AtlasRegion: int
-  /// <summary>Number of atlas regions used (1 for directional/spot, 6 for point).</summary>
+  /// <summary>Number of atlas regions used. Always 1 in the current implementation —
+  /// point lights render a single downward-facing shadow map, not a 6-face cubemap.</summary>
   RegionCount: int
   /// <summary>Whether this caster is currently casting shadows.</summary>
   Enabled: bool
@@ -121,6 +122,16 @@ type ShadowAtlasConfig = {
   /// Set to 0 to disable snapping. Typical range: 1.0-5.0 units.
   /// </remarks>
   GridSnapSize: float32
+
+  /// <summary>
+  /// Maximum distance from the camera at which point/spot lights cast shadows. Default: 50.
+  /// </summary>
+  /// <remarks>
+  /// <b>ForwardPbr-specific:</b> Lights beyond this distance are excluded from the shadow pass
+  /// for performance. Increase for open-world or RTS games with large scenes; decrease for
+  /// tighter, more shadow-dense scenes. Measured in world units (distance, not squared).
+  /// </remarks>
+  MaxShadowLightDistance: float32
 }
 
 /// <summary>Global shadow bias configuration.</summary>
@@ -145,6 +156,7 @@ module ShadowAtlasConfig =
     DirectionalLightDistance = ValueNone
     DirectionalLightSize = ValueNone
     GridSnapSize = 2.0f
+    MaxShadowLightDistance = 50.0f
   }
 
 module ShadowBiasConfig =


### PR DESCRIPTION
## Summary

Forward pipeline review fixes wrapping up the v2 release — 3D rendering correctness, configurable shadow distance, and 2D post-process lighting/camera access. No API removals.

## Changes

### Added
- **2D post-process context** now exposes the scene's `LightContext2D` (point lights, directional lights, ambient, occluders) and the last `Camera2D`, so post-process shaders can bloom lit areas, apply light-tinted grading, or anchor effects in world space.
- **3D point-light shadow direction** — `PointLight3D.ShadowDirection` (or `withShadowDirection` builder) aims the single-face shadow map toward geometry instead of being fixed straight down. Defaults to −Y when unset.

### Fixed
- **Raylib 3D:** specular highlights and Fresnel effects rendered incorrectly on non-skinned meshes when no shadow-casting light was present.
- **Raylib 3D:** normal-mapped meshes lit incorrectly when consecutive draws share a material but differ in world transform (normal matrix was cached per material instead of per draw).
- **Raylib 3D:** normal-mapped instanced meshes lit incorrectly when instances are rotated or non-uniformly scaled.
- **MonoGame 3D:** per-frame overhead reduced — lighting data uploaded once per frame instead of once per draw call.

### Changed
- **Raylib 3D:** `ShadowAtlasConfig.MaxShadowLightDistance` (default 50 units) caps how far point/spot lights cast shadows. Tunable for large-world vs. tight scenes.

## Notes

The raylib `ForwardPbrPipeline.fs` split into staged files (mirroring the MonoGame backend) is tracked separately and intentionally **not** included here — this PR is pure behavior fixes + additive features so it can merge independently.

## Verification
- `dotnet build` clean across all projects
- Sample games build and run against the changes
