### PR TITLE
docs: add MonoGame type quirks reference and backend-aware guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Docs:** new "MonoGame type quirks" reference collects the raylib-vs-MonoGame type differences that first-time MonoGame users hit — `System.Numerics` vs `Microsoft.Xna.Framework` math (Core layout/spatial/light APIs take `System.Numerics` on both backends, so a bare `Vector2` resolves to the wrong type on MonoGame), float vs int `Rectangle`, `Color` constructors, the `IAssets` namespace and asset-path conventions, and the live window size via `ctx.WindowWidth`/`ctx.WindowHeight`. The affected guide pages now cross-link to it.
+- **Templates:** the starters now steer AI assistants (and readers) to the API reference for exact signatures and to the guides only for general usage; the MonoGame starters additionally require reading the type-quirks reference before writing code.
+
 ## [2.0.0-rc-003] - 2026-07-07
 
 ### Added

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -9,6 +9,8 @@ index: 21
 
 Mibo provides an `IAssets` interface for loading and caching game assets. Each backend implements it against its native resource system with automatic caching, so you never load the same asset twice. The shape is the same across backends; the concrete asset *types* differ (raylib types vs XNA/MonoGame types).
 
+> _**NOTE**_: Both backend `IAssets` implementations live in the **`Mibo.Elmish`** namespace — resolve them the same way via `GameContext.getService<IAssets> ctx`. Only their **return types** and **path conventions** differ (raylib: raw file paths with extension; MonoGame: content-pipeline names without extension). See [MonoGame type quirks](monogame-types.html).
+
 ## Two layers
 
 - **`IAssetCache`** (`Mibo.Core`, backend-agnostic) — the generic cache surface: `Get`/`Create`/`GetOrCreate`/`Clear`/`Dispose` for *any* user asset by string key. Portable code (and the Headless runner) can use this without referencing a backend.

--- a/docs/graphics2d/buffer-and-commands.md
+++ b/docs/graphics2d/buffer-and-commands.md
@@ -31,6 +31,8 @@ let myView (ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
 
 The `|> Draw.drop` at the end silences the unused-value warning. It does nothing.
 
+> _**NOTE (backend types)**_: The snippets on this page use the **raylib** `Rectangle` (four `float32` fields). On the **MonoGame** backend, `Rectangle` is `Microsoft.Xna.Framework.Rectangle` with **int** fields — drop the `f` suffixes (`Rectangle(100, 100, 32, 32)`). `Vector2`/`Color` differ too. See [MonoGame type quirks](../monogame-types.html).
+
 ## Two ways to build commands
 
 ### Draw DSL (pipe-friendly)

--- a/docs/level-design/2d/core.md
+++ b/docs/level-design/2d/core.md
@@ -14,7 +14,7 @@ The Layout engine provides a tile-based level design system for 2D games. It liv
 > let grid =
 >     CellGrid2D.create 100 50 (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
 > ```
-> Backend-specific APIs (each backend's `Camera2D.create`/`Camera3D`, `SpriteState`, `TextState`) use that backend's native vector type — raylib uses `System.Numerics`, MonoGame uses `Microsoft.Xna.Framework` — so bare `Vector2(...)` is fine there as long as the matching namespace is open.
+> Backend-specific APIs (each backend's `Camera2D.create`/`Camera3D`, `SpriteState`, `TextState`) use that backend's native vector type — raylib uses `System.Numerics`, MonoGame uses `Microsoft.Xna.Framework` — so bare `Vector2(...)` is fine there as long as the matching namespace is open. See [MonoGame type quirks](../../monogame-types.html) for the full backend-type reference.
 
 ## Core Concepts
 

--- a/docs/monogame-types.md
+++ b/docs/monogame-types.md
@@ -95,7 +95,7 @@ a color from components differs:
   or float `0.0–1.0` (`Color(1.0f, 0.0f, 0.0f)`).
 
 Prefer named colors when you can; verify the overload you need in the
-[API reference](../reference/index.html).
+[API reference](reference/index.html).
 
 ## `IAssets`: same namespace, different types and paths
 
@@ -118,7 +118,7 @@ What differs is what the loaders **return** and the **path convention**:
 | `Effect` | — | `Effect` (compiled `.mgfx`) |
 | Path | **raw file on disk, with extension** (`"sprites/player.png"`) | **content-pipeline name, no extension** (`"sprites/player"`) |
 
-See [Assets](../assets.html) for the full loader table and the animation
+See [Assets](assets.html) for the full loader table and the animation
 double-load caveat (MonoGame needs the raw `.glb` via Assimp because the content
 pipeline drops animation data).
 

--- a/docs/monogame-types.md
+++ b/docs/monogame-types.md
@@ -1,0 +1,159 @@
+---
+title: MonoGame type quirks
+category: Documentation
+categoryindex: 0
+index: 1
+---
+
+# MonoGame type quirks (and how the backends differ)
+
+Most snippets in this documentation use the **raylib** backend's types by default
+(`System.Numerics` vectors, `Raylib_cs.Color`/`Rectangle`). On the **MonoGame**
+backend the native types are different (`Microsoft.Xna.Framework.*`), and a few of
+those differences are silent — code that compiles against one backend will not
+compile (or renders wrong) against the other.
+
+This page is the straight-to-the-point reference for those divergences. Read it
+once before wiring up a MonoGame project; reach for it whenever a snippet fails
+to compile or a value looks off.
+
+## The one rule: math types
+
+The vector/matrix/color/rectangle types are **not** the same type on the two
+backends. When a snippet shows a bare `Vector2(...)`/`Color(...)`/`Rectangle(...)`,
+the type it resolves to depends on which namespace is open.
+
+| Type | raylib backend | MonoGame backend |
+|------|----------------|------------------|
+| 2D vector | `System.Numerics.Vector2` | `Microsoft.Xna.Framework.Vector2` |
+| 3D vector | `System.Numerics.Vector3` | `Microsoft.Xna.Framework.Vector3` |
+| 4D vector / quaternion | `System.Numerics.Vector4` / `Quaternion` | `Microsoft.Xna.Framework.Vector4` / `Quaternion` |
+| Matrix | `System.Numerics.Matrix4x4` | `Microsoft.Xna.Framework.Matrix` |
+| Color | `Raylib_cs.Color` | `Microsoft.Xna.Framework.Color` |
+| Rectangle | `Raylib_cs.Rectangle` (**float**) | `Microsoft.Xna.Framework.Rectangle` (**int**) |
+
+### `Mibo.Core` always speaks `System.Numerics`
+
+`Mibo.Core`'s layout engines (`CellGrid2D`, `LayeredGrid2D`, `CellGrid3D`, hex
+variants), spatial indices, input-delta types, and 3D light records
+(`AmbientLight3D`/`DirectionalLight3D`/…) take `System.Numerics.Vector2`/
+`Vector3` on **both** backends. They are backend-agnostic and reference no
+graphics type.
+
+This is the single most common MonoGame stumble. A MonoGame project usually has
+`open Microsoft.Xna.Framework`, so a bare `Vector2(...)` resolves to XNA's vector
+and the Core call fails (`FS0193` / a type mismatch):
+
+```fsharp
+open Microsoft.Xna.Framework
+
+// Compiles on raylib; FAILS on MonoGame — bare Vector2 is XNA's:
+let grid = CellGrid2D.create 100 50 (Vector2(32f, 32f)) Vector2.Zero
+
+// Correct on MonoGame — qualify the Core-facing vector explicitly:
+let grid =
+    CellGrid2D.create 100 50
+        (System.Numerics.Vector2(32f, 32f)) System.Numerics.Vector2.Zero
+```
+
+**Rule of thumb:** for any `Mibo.Core`/`Mibo.Layout`/`Mibo.Layout3D` call, spell
+out `System.Numerics.Vector2`/`Vector3`. Backend-specific APIs (each backend's
+`Camera2D.create`/`Camera3D`, `SpriteState`, `TextState`, `Draw.*` geometry) take
+that backend's native type, so a bare `Vector2(...)` is correct there as long as
+the matching namespace is open.
+
+`Mibo.Core` also ships a backend-neutral `Mibo.Color` (byte RGBA) used by the 3D
+light records; convert it to the backend color at the draw edge if you need a
+native `Color`.
+
+## `Rectangle` is float on raylib, int on MonoGame
+
+`Raylib_cs.Rectangle` stores four `float32` fields; `Microsoft.Xna.Framework.
+Rectangle` stores four `int` fields. The same literal means different things:
+
+```fsharp
+// raylib (float Rectangle) — what the 2D docs usually show:
+let dest = Rectangle(100f, 100f, 32f, 32f)
+SpriteState.create(tex, dest, Rectangle(0f, 0f, 32f, 32f))
+
+// MonoGame (int Rectangle) — pixel coordinates:
+let dest = Rectangle(100, 100, 32, 32)
+SpriteState.create(tex, dest, Rectangle(0, 0, 32, 32))
+```
+
+This affects every `Draw.*` geometry argument and `SpriteState`/`TextState`
+destination rectangle on the 2D stack. If a snippet uses `100f`/`32f` literals
+inside a `Rectangle(...)`, it is raylib-only — drop the `f` suffixes on MonoGame.
+
+## `Color` literals
+
+Named colors (`Color.Red`, `Color.SkyBlue`, …) work on both backends. Constructing
+a color from components differs:
+
+- **raylib** `Raylib_cs.Color` — byte components (`Color(255uy, 0uy, 0uy)`).
+- **MonoGame** `Microsoft.Xna.Framework.Color` — int `0–255` (`Color(255, 0, 0)`)
+  or float `0.0–1.0` (`Color(1.0f, 0.0f, 0.0f)`).
+
+Prefer named colors when you can; verify the overload you need in the
+[API reference](../reference/index.html).
+
+## `IAssets`: same namespace, different types and paths
+
+`IAssets` lives in the **`Mibo.Elmish`** namespace on **both** backends (raylib:
+`Mibo.Raylib/Assets.fs`; MonoGame: `Mibo.MonoGame/Assets.fs`). You resolve it the
+same way:
+
+```fsharp
+let assets = GameContext.getService<IAssets> ctx
+```
+
+What differs is what the loaders **return** and the **path convention**:
+
+| | raylib | MonoGame |
+|---|--------|----------|
+| `Texture` | `Raylib_cs.Texture2D` | `Microsoft.Xna.Framework.Graphics.Texture2D` |
+| `Font` | `Raylib_cs.Font` (a `.ttf` file) | `SpriteFont` (compiled `.spritefont`) |
+| `Sound` | `Raylib_cs.Sound` | `SoundEffect` |
+| `Model` | `Raylib_cs.Model` | `Model` |
+| `Effect` | — | `Effect` (compiled `.mgfx`) |
+| Path | **raw file on disk, with extension** (`"sprites/player.png"`) | **content-pipeline name, no extension** (`"sprites/player"`) |
+
+See [Assets](../assets.html) for the full loader table and the animation
+double-load caveat (MonoGame needs the raw `.glb` via Assimp because the content
+pipeline drops animation data).
+
+## Window size: `ctx.WindowWidth` / `ctx.WindowHeight`
+
+The current drawable window size is on `GameContext`:
+
+```fsharp
+let w = ctx.WindowWidth
+let h = ctx.WindowHeight
+```
+
+These update on resize. Do **not** reach for `ctx.GameConfig.Width/Height` — that
+is the config-time struct record passed to `Program.withConfig`, not a live value,
+and `GameContext` does not expose it at runtime. (The old pre-v2 MonoGame path
+read `ctx.GraphicsDevice.Viewport`; that is no longer how you get the size.)
+
+## MonoGame-only divergences to plan for
+
+| Concern | raylib | MonoGame |
+|---------|--------|----------|
+| Host | `RaylibGame<_,_>` | `MiboGame<_,_>` (with a `MonoGameProgram` wrapper) |
+| Input mapper | `RaylibProgram.withInputMapper` | `MonoGameProgram.withInputMapper` |
+| Content pipeline | none — load raw files | `.mgcb` → `.xnb` content pipeline |
+| Custom shaders | GLSL | HLSL (`.fx` compiled to `.mgfx`) |
+| Texture filtering | property of the texture: `Texture.filter TextureFilter.Point` | property of the draw: `Draw.setSamplerState layer SamplerState.PointClamp` |
+| Default font | `Raylib.GetFontDefault()` | none — load `assets.Font "..."` |
+| `Camera3D` FOV | **degrees**, no explicit near/far | **radians**, explicit near/far planes |
+| 3D animated model | load `.glb` once (animations included) | double-load: `assets.Model` (XNB mesh) + `assets.AnimatedMesh`/`ModelAnimations` (raw `.glb` via Assimp) |
+| Pipeline class | `ForwardPbrPipeline(shadowBiasConfig=, shadowAtlasConfig=)` | `ForwardPipeline(shadowBias=, shadowAtlas=)` (different field names) |
+
+## Portability tip
+
+If you want game logic that survives a backend switch, pin the **Core-facing**
+math (anything that touches `Mibo.Core`/layout/spatial/lights) to
+`System.Numerics` even on MonoGame. Convert to the backend's vector/matrix/color
+types only at the view/draw edge. This keeps your model, update, and level-design
+code backend-neutral and avoids conversion boilerplate at the Core boundary.

--- a/docs/program.md
+++ b/docs/program.md
@@ -140,6 +140,8 @@ Gives you direct access to the `GameConfig` record before the game initializes.
     { cfg with Width = 1280; Height = 720; Title = "My Game"; TargetFPS = 60 })
 ```
 
+> _**NOTE**_: `Width`/`Height` here are **config-time** values. For the **live, resizable** window size at runtime (in `init`/`update`/`view`), read `ctx.WindowWidth`/`ctx.WindowHeight` — these update on resize. See the "Window size" section of [MonoGame type quirks](monogame-types.html) for the full note.
+
 > _**TIP**_: **Cumulative Pipeline**: You can call `withConfig` multiple times; each callback is executed in the order it was added, allowing you to layer configuration.
 
 > _**IMPORTANT**_: **Platform Specifics**: This is where you should put logic that varies by platform. For example, your Desktop project might set a fixed window size, while your Mobile project might handle screen orientation or full-screen modes.

--- a/src/Templates/Templates/MiboMono2D/AGENTS.md
+++ b/src/Templates/Templates/MiboMono2D/AGENTS.md
@@ -19,10 +19,6 @@ and ships **two interchangeable thin clients** sharing one library:
   `MonoGame.Framework.WindowsDX` (**DirectX**), `[<STAThread>]`,
   `app.manifest`. Same wiring as DesktopGL.
 
-The starter draws a bouncing red rectangle — pure Model-View-Update with a
-`Tick`-driven view. Treat it as Level 0 on the
-[scaling ladder](https://angelmunoz.github.io/Mibo/scaling.html).
-
 Mibo is an Elmish-based F# game framework that ships **composable building blocks**
 for games — grids and level layout, input mapping, lighting, particles, the
 `System` pipeline, a deferred command-buffer renderer, and more. **Before creating
@@ -38,6 +34,17 @@ likely already exists. Compose existing pieces; do not reinvent them.
 > See [2D Rendering](https://angelmunoz.github.io/Mibo/graphics2d/overview.html),
 > [2D Buffer & Commands](https://angelmunoz.github.io/Mibo/graphics2d/buffer-and-commands.html),
 > and [2D Lighting](https://angelmunoz.github.io/Mibo/graphics2d/lighting.html).
+
+## MonoGame type quirks — read this first
+
+MonoGame type quirks. You **MUST** read the
+[MonoGame type quirks](https://angelmunoz.github.io/Mibo/monogame-types.html)
+document before writing or extending any code in this project. MonoGame's native
+types (`Microsoft.Xna.Framework.Vector2`/`Matrix`/`Color`/`Rectangle`) differ
+from the raylib types most snippets use, and `Mibo.Core` layout/spatial/light
+APIs take `System.Numerics` on **both** backends — so a bare `Vector2(...)`
+resolves to the wrong type and fails to compile. Read that doc, then qualify your
+Core-facing vectors explicitly and use MonoGame's native types at the draw edge.
 
 ## Project structure you must keep (cross-backend split)
 
@@ -138,6 +145,14 @@ for when each rung pays off — you can ship a lot of games at Level 2–3.
 - Run the MVU loop in virtual time, headless, for unit tests → [Headless Mode](https://angelmunoz.github.io/Mibo/headless.html)
 
 ## Reference
+
+> **API shape vs usage.** If you need an exact signature, parameter list, return
+> type, or member set of a type/function, you **MUST** consult the
+> [API reference](https://angelmunoz.github.io/Mibo/reference/index.html) — not
+> the guides. The guides show patterns and general usage; they are not a complete
+> signature listing and you must not guess API shapes from prose. If you want
+> general usage or examples of a feature/module, use the documentation sections
+> linked above.
 
 - Full docs index → https://angelmunoz.github.io/Mibo/
 - API reference → https://angelmunoz.github.io/Mibo/reference/index.html

--- a/src/Templates/Templates/MiboMono3D/AGENTS.md
+++ b/src/Templates/Templates/MiboMono3D/AGENTS.md
@@ -20,10 +20,6 @@ and ships **two interchangeable thin clients** sharing one library:
   `app.manifest`. References `../src/MiboMono3D.fsproj` and the shared content,
   same three lines as DesktopGL.
 
-The starter draws a bouncing lit cube — pure Model-View-Update with a `Tick`-driven
-view. Treat it as Level 0 on the
-[scaling ladder](https://angelmunoz.github.io/Mibo/scaling.html).
-
 Mibo is an Elmish-based F# game framework that ships **composable building blocks**
 for games — grids and level layout, input mapping, lighting and shadows, GPU
 instancing, skeletal animation, the `System` pipeline, a deferred command-buffer
@@ -38,6 +34,17 @@ pieces; do not reinvent them.
 > [3D Rendering](https://angelmunoz.github.io/Mibo/graphics3d/overview.html),
 > [3D Lighting](https://angelmunoz.github.io/Mibo/graphics3d/lighting.html),
 > and [3D Materials](https://angelmunoz.github.io/Mibo/graphics3d/materials.html).
+
+## MonoGame type quirks — read this first
+
+MonoGame type quirks. You **MUST** read the
+[MonoGame type quirks](https://angelmunoz.github.io/Mibo/monogame-types.html)
+document before writing or extending any code in this project. MonoGame's native
+types (`Microsoft.Xna.Framework.Vector2`/`Matrix`/`Color`/`Rectangle`) differ
+from the raylib types most snippets use, and `Mibo.Core` layout/spatial/light
+APIs take `System.Numerics` on **both** backends — so a bare `Vector2(...)`
+resolves to the wrong type and fails to compile. Read that doc, then qualify your
+Core-facing vectors explicitly and use MonoGame's native types at the draw edge.
 
 ## Project structure you must keep (cross-backend split)
 
@@ -141,6 +148,14 @@ for when each rung pays off — you can ship a lot of games at Level 2–3.
 - Run the MVU loop in virtual time, headless, for unit tests → [Headless Mode](https://angelmunoz.github.io/Mibo/headless.html)
 
 ## Reference
+
+> **API shape vs usage.** If you need an exact signature, parameter list, return
+> type, or member set of a type/function, you **MUST** consult the
+> [API reference](https://angelmunoz.github.io/Mibo/reference/index.html) — not
+> the guides. The guides show patterns and general usage; they are not a complete
+> signature listing and you must not guess API shapes from prose. If you want
+> general usage or examples of a feature/module, use the documentation sections
+> linked above.
 
 - Full docs index → https://angelmunoz.github.io/Mibo/
 - API reference → https://angelmunoz.github.io/Mibo/reference/index.html

--- a/src/Templates/Templates/MiboRaylib2D/AGENTS.md
+++ b/src/Templates/Templates/MiboRaylib2D/AGENTS.md
@@ -8,8 +8,6 @@ building block you are about to write likely already exists. Compose existing
 pieces; do not reinvent them.
 
 This template targets the **raylib-cs** backend (`Mibo.Raylib`, host `RaylibGame`).
-The starter draws a bouncing red rectangle — pure Model-View-Update with a
-`Tick`-driven view. Treat it as Level 0 on the [scaling ladder](https://angelmunoz.github.io/Mibo/scaling.html).
 
 > **Default renderer.** The template wires a `Renderer2D` over a **deferred
 > command buffer** — the view fills a `RenderBuffer2D` with `Command2D` values
@@ -92,6 +90,14 @@ for when each rung pays off — you can ship a lot of games at Level 2–3.
 - Run the MVU loop in virtual time, headless, for unit tests → [Headless Mode](https://angelmunoz.github.io/Mibo/headless.html)
 
 ## Reference
+
+> **API shape vs usage.** If you need an exact signature, parameter list, return
+> type, or member set of a type/function, you **MUST** consult the
+> [API reference](https://angelmunoz.github.io/Mibo/reference/index.html) — not
+> the guides. The guides show patterns and general usage; they are not a complete
+> signature listing and you must not guess API shapes from prose. If you want
+> general usage or examples of a feature/module, use the documentation sections
+> linked above.
 
 - Full docs index → https://angelmunoz.github.io/Mibo/
 - API reference → https://angelmunoz.github.io/Mibo/reference/index.html

--- a/src/Templates/Templates/MiboRaylib3D/AGENTS.md
+++ b/src/Templates/Templates/MiboRaylib3D/AGENTS.md
@@ -8,8 +8,6 @@ sub-module, check the docs** — the building block you are about to write likel
 already exists. Compose existing pieces; do not reinvent them.
 
 This template targets the **raylib-cs** backend (`Mibo.Raylib`, host `RaylibGame`).
-The starter draws a bouncing lit cube — pure Model-View-Update with a `Tick`-driven
-view. Treat it as Level 0 on the [scaling ladder](https://angelmunoz.github.io/Mibo/scaling.html).
 
 > **Default renderer.** The template wires a `Renderer3D` with Mibo's built-in
 > **Forward PBR** pipeline (`ForwardPbrPipeline`) and a **shadow atlas** —
@@ -92,6 +90,14 @@ for when each rung pays off — you can ship a lot of games at Level 2–3.
 - Run the MVU loop in virtual time, headless, for unit tests → [Headless Mode](https://angelmunoz.github.io/Mibo/headless.html)
 
 ## Reference
+
+> **API shape vs usage.** If you need an exact signature, parameter list, return
+> type, or member set of a type/function, you **MUST** consult the
+> [API reference](https://angelmunoz.github.io/Mibo/reference/index.html) — not
+> the guides. The guides show patterns and general usage; they are not a complete
+> signature listing and you must not guess API shapes from prose. If you want
+> general usage or examples of a feature/module, use the documentation sections
+> linked above.
 
 - Full docs index → https://angelmunoz.github.io/Mibo/
 - API reference → https://angelmunoz.github.io/Mibo/reference/index.html


### PR DESCRIPTION
## Summary

Addresses the docs feedback in #69. Rather than the issue's suggested isometric-map sample (which caters to a specific use case), this adds a **general, straight-to-the-point backend-differences reference** so neither humans nor AI agents get tripped by the type divergences between the raylib and MonoGame backends.

## What changed

- **New `docs/monogame-types.md`** — "MonoGame type quirks" reference page. Consolidates the divergences that caused all four points in #69:
  - Math types: `System.Numerics` (raylib) vs `Microsoft.Xna.Framework` (MonoGame); `Mibo.Core` layout/spatial/light APIs take `System.Numerics` on **both** backends, so a bare `Vector2(...)` resolves to the wrong type on MonoGame. (#3)
  - `Rectangle` is **float on raylib, int on MonoGame** → affects `SpriteState`/`TextState`/`Draw.*`. (#4)
  - `Color` constructor differences.
  - `IAssets` lives in `Mibo.Elmish` on **both** backends; raylib = raw file paths w/ extension, MonoGame = content-pipeline names w/o extension. (#1)
  - Live window size via `ctx.WindowWidth`/`ctx.WindowHeight` (not the config-time `GameConfig`). (#2)
  - MonoGame-only divergences table (content pipeline, HLSL, `Effect` loader, 3D-anim double-load, `Draw.setSamplerState` vs `Texture.filter`, `Camera3D` radians vs degrees, pipeline class names) + a portability tip.
- **All 4 template `AGENTS.md`** — removed the "The starter draws a bouncing…" line; added an imperative **"API shape vs usage"** note to the Reference section (consult the API reference for exact signatures; use the guides for general usage — don't guess API shapes from prose).
- **MonoGame templates (2D + 3D)** — added an imperative **"MonoGame type quirks — read this first"** section linking the new doc.
- **Inline cross-links** (one-liners, no snippet rewrites) from `assets.md`, `program.md`, `graphics2d/buffer-and-commands.md`, and `level-design/2d/core.md`.
- **CHANGELOG** entry under `[Unreleased] → Added`.

## Not done (deliberate)

- No isometric / "first MonoGame map" sample — the framework supports unknown games; over-catering to one genre was rejected.
- No Architecture-index renumbering (the page lives in the `Documentation` category, next available index).

## Verification

- `dotnet fsdocs build` succeeds.
- `dotnet fantomas .` ran clean; the one pre-existing unrelated F# formatting diff was reverted so this PR only touches docs/templates/CHANGELOG.

Refs #69
