### PR TITLE
cleanup(culling): rename, backend-aware guide, MonoGame tests, fsdocs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@
 
 - **MonoGame — Breaking:** the camera modules are consolidated into a single `Camera2D`/`Camera3D` surface that mirrors the raylib layout. The standalone `Camera2DConfig` module is removed — its builders (`render`/`withViewport`/`splitScreen*`) now live in the `Camera2D` module, and `withClearColor` is renamed `withClear`. `Camera2D.smoothFollow`/`clampTarget` now return a new camera instead of mutating in place (the camera's fields are immutable).
 - **Raylib — Breaking:** the 2D camera readers (`viewportBounds`/`screenToWorld`/`worldToScreen`) and `Camera3D.screenPointToRay` now take the camera by read-only reference (`inref`), so call sites must pass `&camera` (the `smoothFollow`/`clampTarget` mutators already used `byref`). This skips copying the native `Camera2D`/`Camera3D` structs on per-frame reads. All raylib camera helpers are now `inline`.
+- **Culling — Breaking:** `Culling.isGenericVisible` is renamed `isVisibleBox` (it tests a bounding box against the frustum — the new name says what it does).
 
 ### Removed
 
 - **Cameras — Breaking:** removed `Camera3DConfig.PostProcessPasses` and the `Camera3D.withPostProcess`/`withoutPostProcess` builders — the pipelines never read them (v2 post-processing is command-driven via `Draw3D.postProcess`), so they were no-ops. Also removed `Camera2D.overlay`/`Camera3D.overlay` — they only set a viewport and a black clear (no compositing); the equivalent is `render |> withViewport |> withClear`, and on-top layering is draw order.
+
+### Fixed
+
+- **Docs:** the Culling guide now covers both backends (raylib's `Frustum` vs MonoGame's native `BoundingFrustum`, and the raylib `Camera2D.viewportBounds &camera` form), instead of describing only the raylib types.
 
 ## [2.0.0-rc-003] - 2026-07-07
 

--- a/Mibo.slnx
+++ b/Mibo.slnx
@@ -3,6 +3,7 @@
     <Project Path="src/Mibo.Core/Mibo.Core.fsproj" />
     <Project Path="src/Mibo.Core.Tests/Mibo.Core.Tests.fsproj" />
     <Project Path="src/Mibo.MonoGame/Mibo.MonoGame.fsproj" />
+    <Project Path="src/Mibo.MonoGame.Tests/Mibo.MonoGame.Tests.fsproj" />
     <Project Path="src/Mibo.Raylib/Mibo.Raylib.fsproj" />
     <Project Path="src/Mibo.Raylib.Tests/Mibo.Raylib.Tests.fsproj" />
     <Project Path="src/Templates/Mibo.Templates.csproj" />

--- a/docs/culling.md
+++ b/docs/culling.md
@@ -9,20 +9,25 @@ index: 14
 
 `Mibo.Elmish.Culling` is a helper module that keeps _visibility math_ separate from your renderer and your spatial partitioning.
 
-It operates on geometric primitives such as:
+It operates on geometric primitives:
 
-- Bounding frustums (computed from camera matrices)
-- `BoundingSphere` / `BoundingBox` (defined in `Mibo.Elmish` / `System.Numerics`)
-- 2D `Rectangle` overlap
+- A view frustum (built from a camera or light View×Projection matrix)
+- A bounding sphere / bounding box to test against it
+- 2D rectangle overlap
 
 ## 3D: frustum culling
 
-Create a `Frustum` from the camera's `View * Projection` matrix and test geometry:
+Build a frustum from a View×Projection matrix and test geometry against it. The frustum type is backend-specific — raylib ships its own `Frustum` (it has no native one), while MonoGame uses its native `BoundingFrustum`:
 
 ```fsharp
-// Extract frustum from camera matrices
-let frustum = Frustum(Matrix4x4.Multiply(cam.View, cam.Projection))
+// raylib: Mibo.Elmish.Frustum over System.Numerics.Matrix4x4
+let frustum = Frustum(viewProjection)
 
+// MonoGame: Microsoft.Xna.Framework.BoundingFrustum
+let frustum = BoundingFrustum(viewProjection)
+```
+
+```fsharp
 if Culling.isVisible frustum entitySphere then
     // submit draw commands
     ()
@@ -31,15 +36,27 @@ if Culling.isVisible frustum entitySphere then
 Or for axis-aligned bounding boxes:
 
 ```fsharp
-if Culling.isGenericVisible frustum nodeBounds then
+if Culling.isVisibleBox frustum nodeBounds then
     ()
 ```
 
+> _**Where does the View×Projection matrix come from?**_ On MonoGame, the camera
+> struct carries it directly — `BoundingFrustum(cam.View * cam.Projection)`. On
+> raylib, capture it inside `BeginMode3D`
+> (`Rlgl.GetMatrixModelview() * Rlgl.GetMatrixProjection()`), or build it from
+> `Raylib.GetCameraMatrix3D(camera)` and a perspective matrix.
+
 ## 2D: rectangle overlap
 
-Use `Camera2D.viewportBounds` with `Culling.isVisible2D`:
+Use `Camera2D.viewportBounds` with `Culling.isVisible2D` (the rectangle type is
+the backend's native one — float `Rectangle` on raylib, int `Rectangle` on
+MonoGame):
 
 ```fsharp
+// raylib — viewportBounds takes the camera by reference (&)
+let viewBounds = Camera2D.viewportBounds &camera viewportWidth viewportHeight
+
+// MonoGame — immutable camera, passed by value
 let viewBounds = Camera2D.viewportBounds camera viewportWidth viewportHeight
 
 if Culling.isVisible2D viewBounds spriteBounds then

--- a/docs/migration-from-monogame.md
+++ b/docs/migration-from-monogame.md
@@ -86,6 +86,7 @@ Most `open` declarations stay the same — the `Mibo.Elmish`, `Mibo.Input`, and
 | 2D animation | No | None — `SpriteSheet`/`AnimatedSprite` API unchanged |
 | 3D animation | N/A (new) | Low — the old package had no 3D animation; new backend ships `AnimatedModel` |
 | Camera | Yes | Low — `Camera`/`Camera2D`/`Camera3D` exist but `Camera3D` is now a struct record |
+| Culling | Yes | Low — `isGenericVisible` renamed `isVisibleBox` (box-vs-frustum test) |
 | Layout / Spatial | No | None — moved to Core, same API |
 | System pipeline | No | None — moved to Core, same API |
 

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -581,12 +581,28 @@ let bounds = Camera2D.viewportBounds &camera w h
 > place, and none of its helpers use `&`. The two backends otherwise expose the
 > same camera operations.
 
+**3. `overlay` camera helpers removed.** The 1.x picture-in-picture helper
+(`Camera2D.overlay`) is gone — it only set a viewport and a black clear (no
+compositing), and on-top layering was draw order anyway. Build the same with
+`Camera2D.render camera |> Camera2D.withViewport rect |> Camera2D.withClear Color.Black`,
+emitting that camera after the main one. The v2-only `Camera3D.overlay`,
+`Camera3DConfig.PostProcessPasses`, and `Camera3D.withPostProcess`/
+`withoutPostProcess` are removed too — v2 post-processing is command-driven via
+`Draw3D.postProcess`.
+
 **Migration (raylib):** if you held a `Mibo.Camera` or `Mibo.Ray` value, switch
 to the native `Raylib_cs.Camera3D` / `Raylib_cs.Ray` (produced by
 `Camera3D.lookAt` / `orbit` / `screenPointToRay`). Add `&` at your
 `viewportBounds` / `screenToWorld` / `worldToScreen` / `screenPointToRay` call
 sites. Code that already used `Raylib_cs.Camera3D` directly is otherwise
 unaffected.
+
+### Culling helper renamed
+
+`Culling.isGenericVisible` is renamed `isVisibleBox` — it tests a bounding box
+against the frustum, and the new name says so. Same arguments; just rename the
+call site. (`isVisible` for spheres and `isVisible2D` for rectangles are
+unchanged.)
 
 ---
 

--- a/src/Mibo.MonoGame.Tests/CullingTests.fs
+++ b/src/Mibo.MonoGame.Tests/CullingTests.fs
@@ -1,0 +1,159 @@
+module Mibo.MonoGame.Tests.Culling
+
+open System
+open Expecto
+open Microsoft.Xna.Framework
+open Mibo.Elmish
+
+// A frustum for a camera at (0,0,10) looking down -Z toward the origin.
+let makeFrustum() =
+  let view =
+    Matrix.CreateLookAt(Vector3(0.f, 0.f, 10.f), Vector3.Zero, Vector3.Up)
+
+  let proj =
+    Matrix.CreatePerspectiveFieldOfView(MathHelper.PiOver4, 1.0f, 0.1f, 100.f)
+
+  BoundingFrustum(view * proj)
+
+let isVisibleSphereTests =
+  testList "Culling.isVisible (sphere)" [
+    test "sphere at origin is visible" {
+      let f = makeFrustum()
+      let sphere = BoundingSphere(Vector3.Zero, 1.0f)
+      Expect.isTrue (Culling.isVisible f sphere) "Origin is inside the frustum"
+    }
+
+    test "sphere behind the camera is not visible" {
+      let f = makeFrustum()
+      let sphere = BoundingSphere(Vector3(0.f, 0.f, 1000.f), 1.0f)
+
+      Expect.isFalse
+        (Culling.isVisible f sphere)
+        "Behind the camera should be culled"
+    }
+
+    test "sphere far off to the side is not visible" {
+      let f = makeFrustum()
+      let sphere = BoundingSphere(Vector3(1000.f, 0.f, 0.f), 1.0f)
+
+      Expect.isFalse
+        (Culling.isVisible f sphere)
+        "Far outside the frustum should be culled"
+    }
+  ]
+
+let isVisibleBoxTests =
+  testList "Culling.isVisibleBox (box)" [
+    test "box around origin is visible" {
+      let f = makeFrustum()
+      let box = BoundingBox(Vector3(-1.f, -1.f, -1.f), Vector3(1.f, 1.f, 1.f))
+
+      Expect.isTrue
+        (Culling.isVisibleBox f box)
+        "Box at origin is inside the frustum"
+    }
+
+    test "box far off to the side is not visible" {
+      let f = makeFrustum()
+
+      let box =
+        BoundingBox(Vector3(999.f, -1.f, -1.f), Vector3(1001.f, 1.f, 1.f))
+
+      Expect.isFalse
+        (Culling.isVisibleBox f box)
+        "Far outside the frustum should be culled"
+    }
+
+    test "box behind the camera is not visible" {
+      let f = makeFrustum()
+
+      let box =
+        BoundingBox(Vector3(-1.f, -1.f, 999.f), Vector3(1.f, 1.f, 1001.f))
+
+      Expect.isFalse
+        (Culling.isVisibleBox f box)
+        "Behind the camera should be culled"
+    }
+  ]
+
+let isVisible2DTests =
+  testList "Culling.isVisible2D" [
+    test "overlapping rectangles are visible" {
+      let view = Rectangle(0, 0, 800, 600)
+      let item = Rectangle(100, 100, 50, 50)
+
+      Expect.isTrue
+        (Culling.isVisible2D view item)
+        "Overlapping should be visible"
+    }
+
+    test "non-overlapping rectangles are not visible" {
+      let view = Rectangle(0, 0, 800, 600)
+      let item = Rectangle(900, 100, 50, 50)
+
+      Expect.isFalse
+        (Culling.isVisible2D view item)
+        "Non-overlapping should not be visible"
+    }
+
+    test "partially overlapping right edge is visible" {
+      let view = Rectangle(0, 0, 800, 600)
+      let item = Rectangle(780, 100, 50, 50)
+
+      Expect.isTrue
+        (Culling.isVisible2D view item)
+        "Partially overlapping should be visible"
+    }
+
+    test "partially overlapping bottom edge is visible" {
+      let view = Rectangle(0, 0, 800, 600)
+      let item = Rectangle(100, 580, 50, 50)
+
+      Expect.isTrue
+        (Culling.isVisible2D view item)
+        "Partially overlapping bottom should be visible"
+    }
+
+    test "item to the left is not visible" {
+      let view = Rectangle(100, 100, 200, 200)
+      let item = Rectangle(0, 150, 50, 50)
+
+      Expect.isFalse
+        (Culling.isVisible2D view item)
+        "Item to the left should not be visible"
+    }
+
+    test "item above is not visible" {
+      let view = Rectangle(100, 100, 200, 200)
+      let item = Rectangle(150, 0, 50, 50)
+
+      Expect.isFalse
+        (Culling.isVisible2D view item)
+        "Item above should not be visible"
+    }
+
+    test "identical rectangles are visible" {
+      let r = Rectangle(10, 20, 100, 100)
+
+      Expect.isTrue
+        (Culling.isVisible2D r r)
+        "Identical rectangles should be visible"
+    }
+
+    test "contained item is visible" {
+      let view = Rectangle(0, 0, 800, 600)
+      let item = Rectangle(100, 100, 10, 10)
+
+      Expect.isTrue
+        (Culling.isVisible2D view item)
+        "Contained item should be visible"
+    }
+  ]
+
+[<Tests>]
+let tests =
+  testList "Culling" [
+    isVisibleSphereTests
+    isVisibleBoxTests
+    isVisible2DTests
+  ]

--- a/src/Mibo.MonoGame.Tests/Main.fs
+++ b/src/Mibo.MonoGame.Tests/Main.fs
@@ -1,0 +1,7 @@
+module Mibo.MonoGame.Tests.Main
+
+open Expecto
+
+[<EntryPoint>]
+let main argv =
+  Tests.runTestsInAssemblyWithCLIArgs [] argv

--- a/src/Mibo.MonoGame.Tests/Mibo.MonoGame.Tests.fsproj
+++ b/src/Mibo.MonoGame.Tests/Mibo.MonoGame.Tests.fsproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <TargetFramework>net8.0</TargetFramework>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="CullingTests.fs" />
+    <Compile Include="Main.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Expecto" Version="10.*" />
+    <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.15.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="MonoGame.Framework.Native" Version="3.8.4.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mibo.MonoGame\Mibo.MonoGame.fsproj" />
+  </ItemGroup>
+</Project>

--- a/src/Mibo.MonoGame/Culling.fs
+++ b/src/Mibo.MonoGame/Culling.fs
@@ -17,9 +17,9 @@ module Culling =
   let inline isVisible (frustum: BoundingFrustum) (sphere: BoundingSphere) =
     frustum.Contains(sphere) <> ContainmentType.Disjoint
 
-  /// <summary>Checks if a bounding box is within the view frustum.</summary>
+  /// <summary>Checks if an axis-aligned bounding box is within the view frustum.</summary>
   /// <remarks>Returns true if fully inside or intersecting (partially visible). Useful for culling axis-aligned geometry or spatial partition nodes.</remarks>
-  let inline isGenericVisible (frustum: BoundingFrustum) (box: BoundingBox) =
+  let inline isVisibleBox (frustum: BoundingFrustum) (box: BoundingBox) =
     frustum.Contains(box) <> ContainmentType.Disjoint
 
   /// <summary>Checks if a 2D rectangle intersects with visible camera bounds.</summary>

--- a/src/Mibo.Raylib/Culling.fs
+++ b/src/Mibo.Raylib/Culling.fs
@@ -155,9 +155,9 @@ module Culling =
     let containment = frustum.Contains(sphere)
     containment <> ContainmentType.Disjoint
 
-  /// <summary>Checks if a bounding box is within the view frustum.</summary>
+  /// <summary>Checks if an axis-aligned bounding box is within the view frustum.</summary>
   /// <remarks>Returns true if fully inside or intersecting (partially visible). Useful for culling axis-aligned geometry or spatial partition nodes.</remarks>
-  let inline isGenericVisible (frustum: Frustum) (box: BoundingBox) =
+  let inline isVisibleBox (frustum: Frustum) (box: BoundingBox) =
     let containment = frustum.Contains(box)
     containment <> ContainmentType.Disjoint
 

--- a/src/Mibo.Raylib/Culling.fs
+++ b/src/Mibo.Raylib/Culling.fs
@@ -165,7 +165,7 @@ module Culling =
   /// <remarks>Use with <see cref="M:Mibo.Elmish.Camera2D.viewportBounds"/> to get the view bounds.</remarks>
   /// <example>
   /// <code>
-  /// let viewBounds = Camera2D.viewportBounds &camera width height
+  /// let viewBounds = Camera2D.viewportBounds &amp;camera width height
   /// if Culling.isVisible2D viewBounds sprite.Bounds then
   ///     // Render sprite
   /// </code>


### PR DESCRIPTION
# Culling cleanup: rename, backend-aware guide, MonoGame tests, fsdocs fix

Follow-up to #70 / #72 for the `Culling` module. The code was already at parity (same `isVisible`/`isVisibleBox`/`isVisible2D` surface on both backends); the gaps were doc/test/naming plus one XML-doc regression.

## Changed
- **Breaking:** renamed `Culling.isGenericVisible` → `isVisibleBox` (it tests a bounding box against the frustum — the new name says what it does). No internal consumers; only the two definitions + the guide.

## Fixed
- `docs/culling.md` was raylib-only — it showed `Frustum(Matrix4x4…)` and claimed primitives are "defined in `Mibo.Elmish`". Rewritten to cover both backends: raylib's `Frustum` vs MonoGame's native `BoundingFrustum`, where the View×Projection matrix comes from on each, and the raylib `Camera2D.viewportBounds &camera` form.
- XML-doc regression from #72: the `<code>` example in `Culling.fs` used a raw `&camera`, which is invalid XML and crashed `fsdocs build` (`XmlException: ' ' is an unexpected token`). Escaped to `&amp;camera` — `fsdocs build` now passes.

## Added
- `Mibo.MonoGame.Tests` project (Expecto harness mirroring `Mibo.Raylib.Tests`), wired into `Mibo.slnx`, with 14 culling tests against native `BoundingFrustum`/`BoundingSphere`/`BoundingBox` and int `Rectangle`. Establishes a home for future MonoGame-side parity tests. (Pure math — runs headless, no GPU.)

## Verification
- `dotnet build`: 0 warnings, 0 errors.
- `dotnet test`: 14 MonoGame + 506 Core + 393 raylib passing.
- `dotnet fsdocs build`: clean (was failing before the XML escape fix).
