### PR TITLE
fix(raylib): stop native double-free on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Raylib:** games no longer abort on exit with `malloc: pointer being freed was not allocated`. Two native-lifetime fixes: model animations loaded via `IAssets.ModelAnimations` were freed through a pinned managed array (they're now released through raylib's native pointer), and the 3D forward pipeline double-freed its shaders on shutdown — raylib 6.0's `UnloadMaterial` now destroys the material's shader and map textures (not just its maps), so the pipeline frees only the maps it allocated and unloads each shader once.
+
 ## [2.0.0] - 2026-07-08
 
 ### Added

--- a/src/Mibo.Raylib/Assets.fs
+++ b/src/Mibo.Raylib/Assets.fs
@@ -78,6 +78,13 @@ type AssetsService(baseAssetPath: string voption) =
   let models = Dictionary<string, Model>()
   let modelAnimations = Dictionary<string, ModelAnimation[]>()
 
+  // raylib allocates the ModelAnimation array (and each keyframePoses) via
+  // RL_MALLOC; UnloadModelAnimations frees the array contents AND the array
+  // pointer itself. We copy structs into the managed array above for indexing
+  // but must free through the original native pointer — freeing a pinned
+  // managed array crashes ("pointer being freed was not allocated").
+  let modelAnimationBuffers = Dictionary<string, struct (nativeint * int)>()
+
   member _.BasePath = baseAssetPath
 
   interface IAssets with
@@ -142,13 +149,20 @@ type AssetsService(baseAssetPath: string voption) =
       match modelAnimations.TryGetValue(resolved) with
       | true, anims -> anims
       | _ ->
-        let animsSpan = Raylib.LoadModelAnimations(resolved)
-        let anims = Array.zeroCreate<ModelAnimation> animsSpan.Length
+        let mutable count = 0
+        let nativeAnims = Raylib.LoadModelAnimations(resolved, &count)
+        let anims = Array.zeroCreate<ModelAnimation> count
 
-        for i = 0 to animsSpan.Length - 1 do
-          anims[i] <- animsSpan[i]
+        for i = 0 to count - 1 do
+          anims[i] <- NativePtr.get nativeAnims i
 
         modelAnimations.Add(resolved, anims)
+
+        modelAnimationBuffers.Add(
+          resolved,
+          struct (NativePtr.toNativeInt nativeAnims, count)
+        )
+
         anims
 
     member _.Get<'T>(key: string) : 'T voption =
@@ -176,6 +190,7 @@ type AssetsService(baseAssetPath: string voption) =
       sounds.Clear()
       models.Clear()
       modelAnimations.Clear()
+      modelAnimationBuffers.Clear()
 
     member _.Dispose() =
       for kv in textures do
@@ -198,9 +213,11 @@ type AssetsService(baseAssetPath: string voption) =
 
       models.Clear()
 
-      for kv in modelAnimations do
-        Raylib.UnloadModelAnimations(kv.Value.AsSpan())
+      for KeyValue(_, struct (ptr, count)) in modelAnimationBuffers do
+        let nativeAnims: nativeptr<ModelAnimation> = NativePtr.ofNativeInt ptr
+        Raylib.UnloadModelAnimations(nativeAnims, count)
 
+      modelAnimationBuffers.Clear()
       modelAnimations.Clear()
 
       typedCache.Clear()

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -2206,13 +2206,22 @@ type ForwardPipelineBase
       skinned <- ShaderVariant(skLocs, MaterialCache 16)
 
     member _.Shutdown() =
+      // raylib 6.0 changed UnloadMaterial to destroy the material's shader AND
+      // every map texture (not just the maps array). The cached/depth/user
+      // materials here share the pipeline shaders (unloaded explicitly below)
+      // and their map textures are owned by AssetsService — so UnloadMaterial
+      // would double-free the shader and free textures it doesn't own. Free
+      // only the maps array (allocated by LoadMaterialDefault) via MemFree.
+      let freeMaps(mat: Material) =
+        Raylib.MemFree(NativePtr.toVoidPtr mat.Maps)
+
       for KeyValue(_, mat) in instanced.MaterialCache.cache do
-        Raylib.UnloadMaterial mat
+        freeMaps mat
 
       instanced.MaterialCache.cache.Clear()
 
       for KeyValue(_, mat) in skinned.MaterialCache.cache do
-        Raylib.UnloadMaterial mat
+        freeMaps mat
 
       skinned.MaterialCache.cache.Clear()
 
@@ -2222,14 +2231,14 @@ type ForwardPipelineBase
       Raylib.UnloadShader depthShadowShader
       Raylib.UnloadShader depthShadowSkinnedShader
 
-      Raylib.UnloadMaterial depthShadowMaterial
-      Raylib.UnloadMaterial depthShadowSkinnedMaterial
+      freeMaps depthShadowMaterial
+      freeMaps depthShadowSkinnedMaterial
 
       if userEffectMaterialCreated then
-        Raylib.UnloadMaterial userEffectMaterial
+        freeMaps userEffectMaterial
 
       for KeyValue(_, mat) in forward.MaterialCache.cache do
-        Raylib.UnloadMaterial mat
+        freeMaps mat
 
       forward.MaterialCache.cache.Clear()
 


### PR DESCRIPTION
## Summary

Fixes two native-lifetime bugs that caused raylib games to abort on shutdown with `malloc: pointer being freed was not allocated`.

Both are in `Mibo.Raylib` and both stem from how the code interacted with raylib's native ownership rules. Verified against raylib 6.0 (`~/repos/raylib`) and raylib-cs 8.0.0 (`~/repos/raylib-cs`).

### 1. `AssetsService` — model animations freed through a pinned managed array

`IAssets.ModelAnimations` copied the structs out of raylib's native `ModelAnimation` array into a managed `ModelAnimation[]`, then on dispose handed the managed array's span back to `Raylib.UnloadModelAnimations`.

raylib's `UnloadModelAnimations` (`rmodels.c:2543`) frees each `keyframePoses` **and** the array pointer itself (`RL_FREE(animations)`). Because raylib-cs `fixed`-pins a span over a managed array, the native call received a GC-heap pointer and tried to `free()` it → crash. It also leaked the original native array.

**Fix:** capture the native pointer via the `LoadModelAnimations(string, ref int)` overload, return a struct copy for indexing, and free through the original native pointer.

### 2. `ForwardPbrPipeline` — `UnloadMaterial` double-freed the shared shaders

raylib 6.0 made `UnloadMaterial` **destructive**: it now unloads the material's shader and every map texture, then frees the maps array (`rmodels.c:2245`). Previously it only freed the maps array.

`Shutdown` called `UnloadMaterial` on the cached materials, the depth-shadow materials, and the user-effect material. All of those share the pipeline's 5 shaders (unloaded explicitly afterward), so the second cached material — or the explicit `UnloadShader` — double-freed the shader program. The cached materials' map textures are also owned by `AssetsService`, so `UnloadMaterial` was freeing textures it didn't own.

**Fix:** free only the `maps` array each material allocated (via `Raylib.MemFree` = `RL_FREE`), and unload each pipeline shader exactly once. Matches the official raylib 6.0 guidance (`examples/shaders/shaders_basic_pbr.c` shows unbinding the shader before `UnloadMaterial`).

## Validation

- `dotnet build` (full Mibo solution) — succeeds
- `dotnet test` — 913/913 pass (Core 506, Raylib 393, MonoGame 14)
- `FPSSample/Raylib` builds against the fixed submodule
- Manually: `dotnet run --project FPSSample/Raylib` no longer aborts on window close (previously: `malloc: pointer being freed was not allocated`)

## Checklist

- [x] `dotnet fantomas .` run before staging
- [x] CHANGELOG entry added under `[Unreleased] > Fixed`
- [x] No `Option.get` / `ValueOption.get` introduced
