### PR TITLE
refactor(cameras): unify and simplify 3D camera API across backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Cameras 3D — Breaking:** the 3D camera API is simplified and unified across backends. `Camera3D.create position target fov` replaces `lookAt`/`orthographic` (defaults: up = `Vector3.Up`, near = `0.1f`, far = `1000f`); `orbit` drops near/far/aspect params; `screenPointToRay` (MonoGame) now takes `Camera3D`. New `withUp`/`asOrthographic` (both backends) and `withNearFar` (MonoGame) modifiers override the defaults. The bare `Camera` type (`{ View; Projection }`) is removed — it was returned by the old constructors but never consumed by the renderer. Aspect ratio is computed from the active viewport at render time.
+
 ## [2.0.1] - 2026-07-08
 
 ### Fixed

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -159,36 +159,46 @@ layering is purely draw order.
 
 ### Creating a camera
 
-For 3D rendering, create a `Camera3D` directly. This is what `Draw3D.beginCamera` and `Camera3D.render` expect. The `Camera3D` struct is provided by your backend (raylib and MonoGame each carry their own), but the constructor shape mirrors across them:
+For 3D rendering, use `Camera3D.create`. It takes just three parameters — position, target, and field of view — with sensible defaults for everything else (up = `Vector3.Up`; MonoGame also defaults near = `0.1f`, far = `1000f` and computes aspect from the viewport at render time):
 
 ```fsharp
-let camera = Camera3D(
-    Vector3(0f, 10f, 20f),      // position
-    Vector3.Zero,                // target
-    Vector3.UnitY,               // up
-    45.0f,                       // FOV in degrees
-    CameraProjection.Perspective
-)
+// raylib (FOV in degrees)
+let camera = Camera3D.create (Vector3(0f, 10f, 20f)) Vector3.Zero 45.0f
+
+// MonoGame (FOV in radians)
+let camera = Camera3D.create (Vector3(0f, 10f, 20f)) Vector3.Zero (MathF.PI / 4f)
 ```
 
-For third-person or inspection cameras, use the `Camera3D.orbit` helper (both backends):
+For third-person or inspection cameras, use `Camera3D.orbit` (both backends):
 
 ```fsharp
-// raylib (FOV in degrees, returns the native Camera3D)
+// raylib (FOV in degrees)
 let camera = Camera3D.orbit Vector3.Zero yaw pitch radius 55.0f
 
-// MonoGame (FOV in radians, plus near/far/aspect, returns the Camera struct)
-let camera = Camera3D.orbit Vector3.Zero yaw pitch radius fov aspect near far
+// MonoGame (FOV in radians)
+let camera = Camera3D.orbit Vector3.Zero yaw pitch radius (MathF.PI / 4f)
 ```
 
-> _**NOTE — backend difference.**_ Both backends carry the same constructor
-> surface (`lookAt` / `orthographic` / `orbit` / `screenPointToRay`), but the
-> return type and FOV unit differ: raylib returns the native
-> `Raylib_cs.Camera3D` (FOV in **degrees**; near/far/aspect are handled
-> internally by `BeginMode3D`), while MonoGame returns its `Camera`
-> view/projection struct (FOV in **radians**; near/far/aspect are explicit
-> parameters). You can still construct the native raylib `Camera3D` struct
-> literal directly if you prefer.
+#### Camera modifiers
+
+Chain `with*` modifiers to override the defaults:
+
+```fsharp
+// Custom up vector (both backends)
+let camera = Camera3D.create pos target fov |> Camera3D.withUp customUp
+
+// Orthographic projection (both backends; FovY is reinterpreted as view height)
+let camera = Camera3D.create pos target 10f |> Camera3D.asOrthographic
+
+// Custom near/far planes (MonoGame only — raylib manages these internally)
+let camera = Camera3D.create pos target fov |> Camera3D.withNearFar 0.01f 5000f
+```
+
+> _**NOTE — backend difference.**_ Both backends share the same constructor
+> surface (`create` / `orbit`) and modifiers (`withUp` / `asOrthographic`).
+> MonoGame adds `withNearFar` (raylib manages near/far internally via
+> `BeginMode3D`). The FOV unit differs: raylib uses **degrees**, MonoGame
+> uses **radians**.
 
 ### Using in a view
 
@@ -248,7 +258,7 @@ let ray = Camera3D.screenPointToRay &camera mousePos
 // ray.Position  — origin point
 // ray.Direction — normalized direction into the scene
 
-// MonoGame — takes the Camera view/projection struct and viewport size, returns Mibo's Ray
+// MonoGame — takes the Camera3D and viewport size, returns Mibo's Ray
 let ray = Camera3D.screenPointToRay camera mousePos viewportWidth viewportHeight
 ```
 

--- a/docs/migration-from-monogame.md
+++ b/docs/migration-from-monogame.md
@@ -85,7 +85,7 @@ Most `open` declarations stay the same — the `Mibo.Elmish`, `Mibo.Input`, and
 | 3D rendering | Yes | Medium — `withPipeline` removed; use `Renderer3D.create (ForwardPipeline(...)) view` |
 | 2D animation | No | None — `SpriteSheet`/`AnimatedSprite` API unchanged |
 | 3D animation | N/A (new) | Low — the old package had no 3D animation; new backend ships `AnimatedModel` |
-| Camera | Yes | Low — `Camera`/`Camera2D`/`Camera3D` exist but `Camera3D` is now a struct record |
+| Camera | Yes | Low — `Camera2D`/`Camera3D` modules exist; `Camera3D.create` takes just position/target/FOV with defaulted up/near/far |
 | Culling | Yes | Low — `isGenericVisible` renamed `isVisibleBox` (box-vs-frustum test) |
 | Layout / Spatial | No | None — moved to Core, same API |
 | System pipeline | No | None — moved to Core, same API |
@@ -728,23 +728,8 @@ yourself.
 
 ## 10. Camera
 
-The `Camera` record and the `Camera2D`/`Camera3D` helper modules **exist** in
-`Mibo.MonoGame` (namespace `Mibo.Elmish`). The shared `Camera` is now a struct
-(avoiding per-frame allocations on the hot path):
-
-```fsharp
-[<Struct>]
-type Camera = {
-  View: Matrix
-  Projection: Matrix
-}
-```
-
-### `Camera3D` is now a struct record
-
-The old `Camera3D.lookAt` returned a `Camera`. The new flow separates the
-**camera description** (`Camera3D`, a struct record) from the **rendered config**
-(`Camera3DConfig`):
+The `Camera2D`/`Camera3D` helper modules **exist** in `Mibo.MonoGame`
+(namespace `Mibo.Elmish`). The `Camera3D` is a struct record:
 
 ```fsharp
 [<Struct>]
@@ -759,22 +744,24 @@ type Camera3D = {
 }
 ```
 
+### Simplified construction
+
+`Camera3D.create` takes just position, target, and FOV — sensible defaults
+handle the rest (up = `Vector3.Up`, near = `0.1f`, far = `1000f`). Chain
+`withUp` / `withNearFar` / `asOrthographic` to override:
+
 ```fsharp
-// Before
+// Before (old Mibo — 7 params, returned a Camera struct)
 let camera = Camera3D.lookAt cameraPos target Vector3.Up
                (MathHelper.ToRadians 45.0f) aspect 0.1f 1000.0f
-// (returned { View; Projection }, passed directly to the pipeline)
 
 // After
-let camera: Camera3D = {
-  Position = cameraPos
-  Target = target
-  Up = Vector3.UnitY
-  FovY = MathHelper.ToRadians(55.0f)
-  NearPlane = 0.1f
-  FarPlane = 1000.0f
-  Projection = CameraProjection.Perspective
-}
+let camera = Camera3D.create cameraPos target (MathHelper.ToRadians 55.0f)
+// or with overrides:
+let camera =
+    Camera3D.create cameraPos target fov
+    |> Camera3D.withUp customUp
+    |> Camera3D.withNearFar 0.01f 5000.0f
 
 // hand it to the 3D renderer via the Draw3D DSL:
 buffer
@@ -782,14 +769,14 @@ buffer
 |> ...
 ```
 
-The `Camera3D` module provides `lookAt`, `orthographic`, `orbit`, and
-`screenPointToRay` builders (they return a `Camera`). `Camera2D` provides the
-full 2D surface — `create`, `toMatrix`, `viewportBounds`, `screenToWorld`/
-`worldToScreen`, and `smoothFollow`/`clampTarget` (which return a new camera,
-since the camera's fields are immutable). The rendering config builders
-(`render`, `withViewport`, `withClear`, `splitScreen*`) live in the
-`Camera2D` and `Camera3D` modules themselves — there is no separate config
-module to open.
+The `Camera3D` module provides `create`, `orbit`, `screenPointToRay`, and
+the `withUp` / `withNearFar` / `asOrthographic` modifiers — all returning
+`Camera3D`. `Camera2D` provides the full 2D surface — `create`, `toMatrix`,
+`viewportBounds`, `screenToWorld`/`worldToScreen`, and `smoothFollow`/
+`clampTarget` (which return a new camera, since the camera's fields are
+immutable). The rendering config builders (`render`, `withViewport`,
+`withClear`, `splitScreen*`) live in the `Camera2D` and `Camera3D` modules
+themselves — there is no separate config module to open.
 
 ---
 
@@ -1087,7 +1074,7 @@ are the divergences to plan for (surfaced by comparing the `MonoThreeD` and
 | Input mapper | `MonoGameProgram.withInputMapper` | `RaylibProgram.withInputMapper` |
 | 3D pipeline | `ForwardPipeline(shadowBias=, shadowAtlas=)` | `ForwardPbrPipeline(shadowBiasConfig=, shadowAtlasConfig=)` (different field names) |
 | Shadow config | `ShadowBiasConfig.defaults`, `ShadowAtlasConfig { Resolution; GridSnapSize }` | explicit per-light biases, `shadowAtlasConfig { Resolution; DirectionalLightSize }` |
-| `Camera3D` | struct record, **radians** FOV, explicit near/far | the raylib `Camera3D` struct, **degrees** FOV, no explicit near/far |
+| `Camera3D` | struct record, **radians** FOV, defaulted near/far | the raylib `Camera3D` struct, **degrees** FOV, no explicit near/far |
 | Vector / Color / Matrix | `Microsoft.Xna.Framework.*` (`Color(int)`, `Matrix.Create*`) | `System.Numerics` + `Raylib_cs` (`Color(byte)`, `Raymath.Matrix*`) |
 | 3D animated model | `AnimatedModel` + `Draw3D.drawAnimatedModel` (bundles model+mesh+state) | `Animation3DState` + `Animation3DState.applyToModel` + `Draw3D.drawModel` |
 | Animated mesh loader | `assets.AnimatedMesh rawPath` (Assimp — XNB drops anim data) | not needed — raylib loads `.glb` once with animations |

--- a/docs/migration-to-v2.md
+++ b/docs/migration-to-v2.md
@@ -538,24 +538,31 @@ input.SetMouseCapture(MouseCapture.Captured)
 **Breaking (raylib only).** The raylib camera surface has two breaking changes
 in v2.
 
-**1. Dead `Camera`/`Ray` struct types removed; helpers return native types.**
+**1. Dead `Camera`/`Ray` struct types removed; simplified constructor API.**
 The raylib backend used to carry a `Mibo.Camera` struct (view + projection
 `Matrix4x4`) and a `Mibo.Ray` struct, with `Camera3D.lookAt` / `orbit` /
 `screenPointToRay` / `fromRaylib` built on top of them. Raylib never used these
 for rendering — it renders through the native `Raylib_cs.Camera3D` — so the
 structs and the `fromRaylib` converter are removed. The constructor helpers
 stay, but now return **native raylib types** so they compose directly with
-raylib's own APIs:
+raylib's own APIs. The old multi-parameter constructors (`lookAt` /
+`orthographic`) are replaced by a simplified `Camera3D.create position target
+fov` with `withUp` / `asOrthographic` modifiers:
 
-- `Camera3D.lookAt` / `orthographic` / `orbit` → `Raylib_cs.Camera3D`
+- `Camera3D.create` / `orbit` → `Raylib_cs.Camera3D`
   (FOV in **degrees**, raylib's convention).
 - `Camera3D.screenPointToRay` → `Raylib_cs.Ray` (wraps
   `Raylib.GetScreenToWorldRay`).
-- Removed: `Mibo.Camera`, `Mibo.Ray`, `Camera3D.fromRaylib`.
+- `Camera3D.withUp` / `asOrthographic` → `Raylib_cs.Camera3D` (modifiers).
+- Removed: `Mibo.Camera`, `Mibo.Ray`, `Camera3D.fromRaylib`,
+  `Camera3D.lookAt`, `Camera3D.orthographic`.
 
-Both backends now expose the same `Camera3D` constructor surface. On MonoGame
-these return the `Camera` view/projection struct (FOV in radians, with explicit
-near/far/aspect); on raylib they return the native structs above.
+Both backends now expose the same `Camera3D` constructor surface
+(`create` / `orbit`) and modifiers (`withUp` / `asOrthographic`). On MonoGame
+the constructors return the `Camera3D` struct record (FOV in **radians**,
+with defaulted near/far); on raylib they return the native `Raylib_cs.Camera3D`
+(FOV in **degrees**). MonoGame additionally offers `withNearFar` (raylib manages
+near/far internally via `BeginMode3D`).
 
 **2. 2D camera readers take the camera by reference.** `Camera2D.viewportBounds`,
 `screenToWorld`, and `worldToScreen` now take the camera by read-only reference
@@ -592,7 +599,7 @@ emitting that camera after the main one. The v2-only `Camera3D.overlay`,
 
 **Migration (raylib):** if you held a `Mibo.Camera` or `Mibo.Ray` value, switch
 to the native `Raylib_cs.Camera3D` / `Raylib_cs.Ray` (produced by
-`Camera3D.lookAt` / `orbit` / `screenPointToRay`). Add `&` at your
+`Camera3D.create` / `orbit` / `screenPointToRay`). Add `&` at your
 `viewportBounds` / `screenToWorld` / `worldToScreen` / `screenPointToRay` call
 sites. Code that already used `Raylib_cs.Camera3D` directly is otherwise
 unaffected.

--- a/docs/monogame-types.md
+++ b/docs/monogame-types.md
@@ -146,7 +146,7 @@ read `ctx.GraphicsDevice.Viewport`; that is no longer how you get the size.)
 | Custom shaders | GLSL | HLSL (`.fx` compiled to `.mgfx`) |
 | Texture filtering | property of the texture: `Texture.filter TextureFilter.Point` | property of the draw: `Draw.setSamplerState layer SamplerState.PointClamp` |
 | Default font | `Raylib.GetFontDefault()` | none — load `assets.Font "..."` |
-| `Camera3D` FOV | **degrees**, no explicit near/far | **radians**, explicit near/far planes |
+| `Camera3D` FOV | **degrees**, no explicit near/far | **radians**, defaulted near/far planes (override via `withNearFar`) |
 | 3D animated model | load `.glb` once (animations included) | double-load: `assets.Model` (XNB mesh) + `assets.AnimatedMesh`/`ModelAnimations` (raw `.glb` via Assimp) |
 | Pipeline class | `ForwardPbrPipeline(shadowBiasConfig=, shadowAtlasConfig=)` | `ForwardPipeline(shadowBias=, shadowAtlas=)` (different field names) |
 

--- a/src/Mibo.MonoGame/Camera.fs
+++ b/src/Mibo.MonoGame/Camera.fs
@@ -260,32 +260,6 @@ module Camera2D =
 // 3D Camera
 // ─────────────────────────────────────────────────────────────
 
-/// <summary>
-/// A universal Camera definition containing View and Projection matrices.
-/// </summary>
-/// <remarks>
-/// This struct is renderer-agnostic — both 2D and 3D renderers use the same concept.
-/// It is a struct (not a reference record) because it flows through the view function
-/// every frame; keeping it stack-allocated avoids per-frame Gen0 pressure on the hot path.
-/// Use the <see cref="T:Mibo.Elmish.Camera2D"/> or <see cref="T:Mibo.Elmish.Camera3D"/> modules to create cameras.
-/// </remarks>
-/// <example>
-/// <code>
-/// // 2D camera centered on player
-/// let camera = Camera2D.create playerPos 1.0f viewportSize
-///
-/// // 3D camera looking at origin
-/// let camera = Camera3D.lookAt position Vector3.Zero Vector3.Up fov aspect 0.1f 1000f
-/// </code>
-/// </example>
-[<Struct>]
-type Camera = {
-  /// <summary>The view matrix (camera position/rotation, transforms world to view space).</summary>
-  View: Matrix
-  /// <summary>The projection matrix (perspective/orthographic, transforms view to clip space).</summary>
-  Projection: Matrix
-}
-
 /// <summary>Camera projection mode.</summary>
 [<RequireQualifiedAccess>]
 type CameraProjection =
@@ -363,96 +337,59 @@ type Camera3DConfig = {
 /// </remarks>
 module Camera3D =
 
+  // ── Constructors ──
+
   /// <summary>
-  /// Creates a camera that looks at a target from a position.
+  /// Creates a perspective camera that looks at a target from a position.
   /// </summary>
-  /// <param name="position">Camera position in world space</param>
-  /// <param name="target">Point the camera is looking at</param>
-  /// <param name="up">Up vector (typically Vector3.UnitY)</param>
-  /// <param name="fov">Field of view in radians (e.g., MathF.PI / 4.0f)</param>
-  /// <param name="aspectRatio">Width / Height of the viewport</param>
-  /// <param name="nearPlane">Near clipping distance (objects closer are not rendered)</param>
-  /// <param name="farPlane">Far clipping distance (objects farther are not rendered)</param>
+  /// <remarks>
+  /// Defaults: up = <c>Vector3.Up</c>, near = <c>0.1f</c>, far = <c>1000f</c>.
+  /// Override with <see cref="M:Mibo.Elmish.Camera3D.withUp"/> /
+  /// <see cref="M:Mibo.Elmish.Camera3D.withNearFar"/>.
+  /// The aspect ratio is computed from the active viewport at render time.
+  /// </remarks>
+  /// <param name="position">Camera position in world space.</param>
+  /// <param name="target">Point the camera is looking at.</param>
+  /// <param name="fovY">Vertical field of view in radians (e.g., <c>MathF.PI / 4.0f</c>).</param>
   /// <example>
   /// <code>
-  /// let camera = Camera3D.lookAt
-  ///     (Vector3(0f, 10f, 20f))  // position
-  ///     Vector3.Zero              // target
-  ///     Vector3.Up                // up
-  ///     (MathF.PI / 4.0f)        // 45° FOV
-  ///     (16f / 9f)                // aspect ratio
-  ///     0.1f                      // near plane
-  ///     1000f                     // far plane
+  /// let camera = Camera3D.create (Vector3(0.f, 10.f, 20.f)) Vector3.Zero (MathF.PI / 4.f)
   /// </code>
   /// </example>
-  let inline lookAt
+  let inline create
     (position: Vector3)
     (target: Vector3)
-    (up: Vector3)
-    (fov: float32)
-    (aspectRatio: float32)
-    (nearPlane: float32)
-    (farPlane: float32)
-    : Camera =
+    (fovY: float32)
+    : Camera3D =
     {
-      View = Matrix.CreateLookAt(position, target, up)
-      Projection =
-        Matrix.CreatePerspectiveFieldOfView(
-          fov,
-          aspectRatio,
-          nearPlane,
-          farPlane
-        )
+      Position = position
+      Target = target
+      Up = Vector3.Up
+      FovY = fovY
+      NearPlane = 0.1f
+      FarPlane = 1000.f
+      Projection = CameraProjection.Perspective
     }
 
   /// <summary>
-  /// Creates an orthographic camera that looks at a target from a position.
-  /// </summary>
-  /// <param name="position">Camera position in world space</param>
-  /// <param name="target">Point the camera is looking at</param>
-  /// <param name="up">Up vector (typically Vector3.UnitY)</param>
-  /// <param name="width">Width of the orthographic view volume in world units</param>
-  /// <param name="height">Height of the orthographic view volume in world units</param>
-  /// <param name="nearPlane">Near clipping distance</param>
-  /// <param name="farPlane">Far clipping distance</param>
-  let inline orthographic
-    (position: Vector3)
-    (target: Vector3)
-    (up: Vector3)
-    (width: float32)
-    (height: float32)
-    (nearPlane: float32)
-    (farPlane: float32)
-    : Camera =
-    {
-      View = Matrix.CreateLookAt(position, target, up)
-      Projection = Matrix.CreateOrthographic(width, height, nearPlane, farPlane)
-    }
-
-  /// <summary>
-  /// Creates an orbiting camera using spherical coordinates.
+  /// Creates an orbiting perspective camera using spherical coordinates.
   /// </summary>
   /// <remarks>
   /// Useful for third-person cameras, inspection views, or editor cameras.
+  /// Defaults: up = <c>Vector3.Up</c>, near = <c>0.1f</c>, far = <c>1000f</c>.
   /// </remarks>
-  /// <param name="target">Point the camera orbits around</param>
-  /// <param name="yaw">Horizontal rotation angle in radians</param>
-  /// <param name="pitch">Vertical rotation angle in radians</param>
-  /// <param name="radius">Distance from target</param>
-  /// <param name="fov">Field of view in radians</param>
-  /// <param name="aspect">Aspect ratio</param>
-  /// <param name="near">Near plane</param>
-  /// <param name="far">Far plane</param>
+  /// <param name="target">Point the camera orbits around.</param>
+  /// <param name="yaw">Horizontal rotation angle in radians.</param>
+  /// <param name="pitch">Vertical rotation angle in radians.</param>
+  /// <param name="radius">Distance from target.</param>
+  /// <param name="fovY">Vertical field of view in radians.</param>
   let inline orbit
     (target: Vector3)
     (yaw: float32)
     (pitch: float32)
     (radius: float32)
-    (fov: float32)
-    (aspect: float32)
-    (near: float32)
-    (far: float32)
-    : Camera =
+    (fovY: float32)
+    : Camera3D =
     let position =
       Vector3(
         radius * MathF.Sin(yaw) * MathF.Cos(pitch),
@@ -461,7 +398,40 @@ module Camera3D =
       )
       + target
 
-    lookAt position target Vector3.UnitY fov aspect near far
+    create position target fovY
+
+  // ── Modifiers ──
+
+  /// <summary>Set the up vector (default is <c>Vector3.Up</c>).</summary>
+  let inline withUp (up: Vector3) (camera: Camera3D) : Camera3D = {
+    camera with
+        Up = up
+  }
+
+  /// <summary>Set the near and far clipping planes (defaults are <c>0.1f</c> / <c>1000f</c>).</summary>
+  let inline withNearFar
+    (nearPlane: float32)
+    (farPlane: float32)
+    (camera: Camera3D)
+    : Camera3D =
+    {
+      camera with
+          NearPlane = nearPlane
+          FarPlane = farPlane
+    }
+
+  /// <summary>
+  /// Switch the camera to orthographic projection.
+  /// </summary>
+  /// <remarks>
+  /// <c>FovY</c> is reinterpreted as the view height in world units.
+  /// </remarks>
+  let inline asOrthographic(camera: Camera3D) : Camera3D = {
+    camera with
+        Projection = CameraProjection.Orthographic
+  }
+
+  // ── Picking ──
 
   /// <summary>
   /// Creates a ray from screen coordinates for mouse/touch picking.
@@ -475,15 +445,39 @@ module Camera3D =
   /// <param name="viewportWidth">Viewport width in pixels.</param>
   /// <param name="viewportHeight">Viewport height in pixels.</param>
   let screenPointToRay
-    (camera: Camera)
+    (camera: Camera3D)
     (screenPos: Vector2)
     (viewportWidth: float32)
     (viewportHeight: float32)
     : Ray =
-    let mutable viewProj = camera.View * camera.Projection
+    let view = Matrix.CreateLookAt(camera.Position, camera.Target, camera.Up)
+
+    let projection =
+      match camera.Projection with
+      | CameraProjection.Perspective ->
+        let aspect =
+          if viewportHeight > 0.0f then
+            viewportWidth / viewportHeight
+          else
+            1.0f
+
+        Matrix.CreatePerspectiveFieldOfView(
+          camera.FovY,
+          aspect,
+          camera.NearPlane,
+          camera.FarPlane
+        )
+      | CameraProjection.Orthographic ->
+        Matrix.CreateOrthographic(
+          camera.FovY,
+          camera.FovY,
+          camera.NearPlane,
+          camera.FarPlane
+        )
+
+    let mutable viewProj = view * projection
     let mutable invertedViewProj = Matrix()
     Matrix.Invert(&viewProj, &invertedViewProj)
-
 
     let nx = 2.0f * screenPos.X / viewportWidth - 1.0f
     let ny = 1.0f - 2.0f * screenPos.Y / viewportHeight

--- a/src/Mibo.Raylib/Camera.fs
+++ b/src/Mibo.Raylib/Camera.fs
@@ -223,7 +223,8 @@ type Camera3DConfig = {
 /// <para>
 /// The raylib <c>Camera3D</c> is a native mutable struct. <c>screenPointToRay</c> takes it
 /// by <c>inref</c> (use <c>&amp;camera</c>); the config builders take it by value; the
-/// constructors (<c>lookAt</c>/<c>orthographic</c>/<c>orbit</c>) return a new <c>Camera3D</c>.
+/// constructors (<c>create</c>/<c>orbit</c>) and modifiers (<c>withUp</c>/<c>asOrthographic</c>)
+/// return a new <c>Camera3D</c>.
 /// </para>
 /// </remarks>
 module Camera3D =
@@ -234,48 +235,26 @@ module Camera3D =
   /// Creates a perspective <c>Camera3D</c> that looks at a target from a position.
   /// </summary>
   /// <remarks>
-  /// Mirrors the MonoGame <c>Camera3D.lookAt</c> capability, but returns the native
+  /// Mirrors the MonoGame <c>Camera3D.create</c> capability, but returns the native
   /// raylib <c>Camera3D</c> struct. The field-of-view is in **degrees** (raylib convention),
   /// unlike MonoGame's radians. Near/far planes and aspect ratio are managed internally
   /// by raylib's <c>BeginMode3D</c>, so they are not parameters here.
+  /// Up defaults to <c>Vector3.UnitY</c>; override with <see cref="M:Mibo.Elmish.Camera3D.withUp"/>.
   /// </remarks>
   /// <param name="position">Camera position in world space.</param>
   /// <param name="target">Point the camera is looking at.</param>
-  /// <param name="up">Up vector (typically <c>Vector3.UnitY</c>).</param>
   /// <param name="fovy">Vertical field of view in **degrees**.</param>
-  let inline lookAt
+  let inline create
     (position: Vector3)
     (target: Vector3)
-    (up: Vector3)
     (fovy: float32)
     : Raylib_cs.Camera3D =
     Raylib_cs.Camera3D(
       position,
       target,
-      up,
+      Vector3.UnitY,
       fovy,
       Raylib_cs.CameraProjection.Perspective
-    )
-
-  /// <summary>
-  /// Creates an orthographic <c>Camera3D</c> that looks at a target from a position.
-  /// </summary>
-  /// <param name="position">Camera position in world space.</param>
-  /// <param name="target">Point the camera is looking at.</param>
-  /// <param name="up">Up vector (typically <c>Vector3.UnitY</c>).</param>
-  /// <param name="size">Vertical size of the orthographic view volume in world units (raylib's <c>fovy</c> in ortho mode).</param>
-  let inline orthographic
-    (position: Vector3)
-    (target: Vector3)
-    (up: Vector3)
-    (size: float32)
-    : Raylib_cs.Camera3D =
-    Raylib_cs.Camera3D(
-      position,
-      target,
-      up,
-      size,
-      Raylib_cs.CameraProjection.Orthographic
     )
 
   /// <summary>
@@ -305,7 +284,29 @@ module Camera3D =
       )
       + target
 
-    lookAt position target Vector3.UnitY fovy
+    create position target fovy
+
+  // ── Modifiers ──
+
+  /// <summary>Set the up vector (default is <c>Vector3.UnitY</c>).</summary>
+  let inline withUp
+    (up: Vector3)
+    (camera: Raylib_cs.Camera3D)
+    : Raylib_cs.Camera3D =
+    let mutable c = camera
+    c.Up <- up
+    c
+
+  /// <summary>
+  /// Switch the camera to orthographic projection.
+  /// </summary>
+  /// <remarks>
+  /// <c>FovY</c> is reinterpreted as the vertical view size in world units.
+  /// </remarks>
+  let inline asOrthographic(camera: Raylib_cs.Camera3D) : Raylib_cs.Camera3D =
+    let mutable c = camera
+    c.Projection <- Raylib_cs.CameraProjection.Orthographic
+    c
 
   /// <summary>
   /// Creates a ray from screen coordinates for mouse/touch picking.

--- a/src/Templates/Mibo.Templates.csproj
+++ b/src/Templates/Mibo.Templates.csproj
@@ -13,7 +13,7 @@
     <ContentTargetFolders>content</ContentTargetFolders>
     <NoWarn>$(NoWarn);NU5128</NoWarn>
     <NoDefaultExcludes>true</NoDefaultExcludes>
-    <Version>2.0.2</Version>
+    <Version>2.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Templates/Templates/MiboMono2D/src/MiboMono2D.fsproj
+++ b/src/Templates/Templates/MiboMono2D/src/MiboMono2D.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mibo.MonoGame" Version="2.0.*" />
+    <PackageReference Include="Mibo.MonoGame" Version="2.*" />
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.4.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Templates/Templates/MiboMono3D/src/MiboMono3D.fsproj
+++ b/src/Templates/Templates/MiboMono3D/src/MiboMono3D.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mibo.MonoGame" Version="2.0.*" />
+    <PackageReference Include="Mibo.MonoGame" Version="2.*" />
     <PackageReference Include="MonoGame.Framework.Native" Version="3.8.4.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Templates/Templates/MiboRaylib2D/MiboRaylib2D.fsproj
+++ b/src/Templates/Templates/MiboRaylib2D/MiboRaylib2D.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mibo.Raylib" Version="2.0.*" />
+    <PackageReference Include="Mibo.Raylib" Version="2.*" />
   </ItemGroup>
 
 </Project>

--- a/src/Templates/Templates/MiboRaylib3D/MiboRaylib3D.fsproj
+++ b/src/Templates/Templates/MiboRaylib3D/MiboRaylib3D.fsproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mibo.Raylib" Version="2.0.*" />
+    <PackageReference Include="Mibo.Raylib" Version="2.*" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

The MonoGame `Camera3D` module had a type mismatch: constructors (`lookAt`/`orthographic`/`orbit`) returned a bare `Camera` struct (View/Projection matrices), but config builders (`render`/`splitScreen*`) and the rendering pipeline expected `Camera3D` (the description struct). Users could not pipe constructor output into `render` or `beginCamera`. Only MonoGame 3D was affected — raylib 2D/3D and MonoGame 2D were already consistent.

## Changes

**Simplified 3D camera API (both backends):**

- `Camera3D.create position target fov` replaces `lookAt`/`orthographic` — defaults: up = `Vector3.Up`, MonoGame also defaults near = `0.1f`, far = `1000f`
- `Camera3D.orbit` drops near/far/aspect params, uses the same defaults
- New modifiers: `withUp`, `asOrthographic` (both backends), `withNearFar` (MonoGame only)
- `screenPointToRay` (MonoGame) now takes `Camera3D` instead of the removed `Camera`
- Aspect ratio is computed from the active viewport at render time (no longer a constructor param)
- Removed the bare MonoGame `Camera` type (`{ View; Projection }`) — never consumed by the renderer

**Before → after:**

```fsharp
// Before (MonoGame — 7 params, returned unusable Camera)
let cam = Camera3D.lookAt pos target Vector3.Up fov aspect 0.1f 1000.f
// Camera3D.render cam  // ERROR: render expects Camera3D, not Camera

// After (both backends — 3 params, returns Camera3D)
let cam = Camera3D.create pos target fov
let config = Camera3D.render cam  // works!
```

**Docs updated:** `camera.md`, `migration-from-monogame.md`, `migration-to-v2.md`, `monogame-types.md`

**Templates:** bumped to 2.1.0, package references widened from `2.0.*` to `2.*`

## Test plan

- [x] `dotnet fantomas .` — clean
- [x] `dotnet build` both backends — 0 errors
- [x] `dotnet test` all three test suites — 913 passed, 0 failed
