### PR TITLE
feat: unified fluent draw DSL for 2D and 3D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Core:** a unified fluent draw DSL for 2D and 3D, identical on both backends. View code chains calls on the render buffer (`buffer.beginCamera(cam).fillCircle(...).endCamera()`) with optional parameters for anything that has a sensible default (`layer`, `tint`, `thickness`, ...). Colors use the backend-neutral `Mibo.Color`, vectors and matrices use `System.Numerics` (MonoGame converts at the boundary), and backend values — textures, fonts, cameras, shaders, models, materials, sprite/text/animation state records — pass through unchanged. Backend-only features (MonoGame's sampler-state control, raylib's explicit-palette skinned draw) are available only on the backend that supports them; calling them on the other is a compile error. The whole chain is erased at compile time and emits the same buffer commands as hand-written code — no dispatch, no allocation. See `docs/draw-dsl.md`.
+
+### Deprecated
+
+- **Raylib, MonoGame:** the function-based (piped) draw modules — `Draw`, `Draw3D`, `LightDraw`, `ParticleDraw` — are deprecated and will be removed in a future release. They remain functional in this release; new code should use the fluent draw DSL (see `docs/draw-dsl.md`).
+
 ## [3.0.0] - 2026-07-18
 
 ### Added

--- a/docs/animation.md
+++ b/docs/animation.md
@@ -7,7 +7,7 @@ index: 22
 
 # Animation (2D Sprite Animation)
 
-Mibo provides a format-agnostic 2D animation system in `Mibo.Animation`. It integrates with the existing `Draw.sprite` / `LightDraw.litSprite` rendering pipeline.
+Mibo provides a format-agnostic 2D animation system in `Mibo.Animation`. It integrates with the `.sprite(...)` / `.litSprite(...)` rendering pipeline.
 
 ## Core Types
 
@@ -35,13 +35,10 @@ let sprite = AnimatedSprite.create sheet "idle"
 // 3. Update each frame (in your animation system)
 let updatedSprite = AnimatedSprite.update deltaTime sprite
 
-// 4. Draw (in your view)
-let src = AnimatedSprite.currentSource sprite
-buffer |> Draw.sprite {
-    Texture = sheet.Texture; Dest = r (int position.X) (int position.Y) 32 32
-    Source = src; Origin = Vector2.Zero; Rotation = 0f
-    Color = Color.White; Layer = 0<RenderLayer>
-}
+// 4. Draw (in your view) — lit path: pass the AnimatedSprite directly
+buffer
+  .litAnimatedSprite(lighting, Rectangle(position.X, position.Y, 32f, 32f), sprite, layer = 10<RenderLayer>)
+  .drop()
 ```
 
 ## SpriteSheet Factory Functions
@@ -152,36 +149,25 @@ sprite
 
 ### Drawing
 
-`AnimatedSprite` does not provide its own draw functions. Instead, use `AnimatedSprite.currentSource` to get the current frame's source rectangle, then draw via the general `Draw.sprite` or `LightDraw.litSprite`:
+**Lit path** — `.litAnimatedSprite(...)` consumes the `AnimatedSprite` directly: it extracts the current frame's source rect, applies `FlipX`/`FlipY`, and picks up the sheet's texture and normal map:
+
+```fsharp
+buffer
+  .litAnimatedSprite(lighting, playerDest, model.PlayerSprite, layer = 20<RenderLayer>)
+  .drop()
+```
+
+**Unlit path** — use `AnimatedSprite.currentSource` to get the current frame's source rectangle, then draw a sprite record:
 
 ```fsharp
 let src = AnimatedSprite.currentSource sprite
-buffer |> Draw.sprite {
-    Texture = sprite.Sheet.Texture
-    Dest = Rectangle(int position.X, int position.Y, int src.Width, int src.Height)
-    Source = src
-    Origin = Vector2.Zero
-    Rotation = sprite.Rotation
-    Color = sprite.Color
-    Layer = layer
-}
-```
 
-### Manual Frame Access
-
-```fsharp
-let sourceRect = AnimatedSprite.currentSource sprite
-let texture = sprite.Sheet.Texture
-
-buffer.Add(layer, DrawSprite {
-    Texture = texture
-    Dest = Rectangle(position.X, position.Y, float32 sourceRect.Width, float32 sourceRect.Height)
-    Source = sourceRect
-    Origin = Vector2.Zero
-    Rotation = 0f
-    Color = Color.White
-    Layer = layer
-})
+buffer
+  .sprite(
+    SpriteState.create(sprite.Sheet.Texture, Rectangle(position.X, position.Y, 32f, 32f), src)
+    |> SpriteState.withLayer 10<RenderLayer>
+  )
+  .drop()
 ```
 
 ## Animation Type

--- a/docs/animation3d.md
+++ b/docs/animation3d.md
@@ -12,10 +12,10 @@ Mibo provides a three-tier 3D skeletal animation system in `Mibo.Animation`. It 
 > _**NOTE — backend differences.**_ The types (`Animation3DClips`, `Animation3DState`,
 > `AnimatedMesh`) mirror across backends, but the skinning path differs:
 > - **raylib**: CPU skinning via `Raylib.UpdateModelAnimation` / `UpdateModelAnimationEx`
->   (mutates the model's bone matrices); render with `Draw3D.drawModel` (per-entity model copy)
->   or `Draw3D.drawSkinnedMesh` (shared mesh + bone matrices).
+>   (mutates the model's bone matrices); render with `.model(...)` (per-entity model copy)
+>   or `.skinnedMesh(...)` (shared mesh + bone matrices).
 > - **MonoGame**: clips load from the raw model file via Assimp (`assets.ModelAnimations` →
-> `Animation3DClips`); render with `Draw3D.drawAnimatedModel animatedModel transform` (the bone
+> `Animation3DClips`); render with `.animatedModel(animModel, transform)` (the bone
 > palette is derived internally from an `AnimatedModel` state value — the caller never handles
 > a `Matrix[]`).
 
@@ -43,9 +43,10 @@ let anim = Animation3DState.create model clips "idle" 60.0f
 // 3. Update each frame (in your animation system)
 let anim = anim |> Animation3DState.update deltaTime
 
-// 4. Apply and render (in your view)
-Animation3DState.applyToModel anim
-buffer |> Draw3D.drawModel anim.Model transform
+// 4. Render (in your view) — the witness applies the pose and draws
+buffer
+  .animatedModel(anim, transform)
+  .drop()
 ```
 
 ## Three API Tiers
@@ -73,19 +74,23 @@ let mesh = AnimatedMesh.fromModel model  // load once, share
 // Per-entity (lightweight — just matrix math)
 let bones = AnimatedMesh.computeBoneMatrices clip frame mesh
 
-// Render — GPU does the skinning
-buffer |> Draw3D.drawSkinnedMesh mesh.Mesh transform material bones
+// Render — GPU does the skinning (raylib)
+buffer
+  .skinnedMesh(mesh.Mesh, transform, material, bones)
+  .drop()
 ```
 
 ### Tier 3 — Per-Model CPU Skinning (`Animation3DState`)
 
-Simplest API. Each entity owns its own `Model` copy. Raylib's `UpdateModelAnimation` handles skinning on the CPU.
+Simplest API. Each entity owns its own model state. `.animatedModel(...)` applies the pose for you:
 
 ```fsharp
 let anim = Animation3DState.create model clips "idle" 60.0f
 let anim = anim |> Animation3DState.update dt
-Animation3DState.applyToModel anim  // mutates model's bone matrices
-buffer |> Draw3D.drawModel anim.Model transform
+
+buffer
+  .animatedModel(anim, transform)
+  .drop()
 ```
 
 ### When to Use Which
@@ -94,7 +99,7 @@ buffer |> Draw3D.drawModel anim.Model transform
 |----------|------|-----|
 | 1–5 animated characters | Tier 3 | Simple, no shader changes |
 | 10+ animated enemies | Tier 2 | Share mesh, GPU skinning |
-| Hundreds of units (RTS) | Tier 2 + instancing | `DrawMeshInstanced` with skinning |
+| Hundreds of units (RTS) | Tier 2 + instancing | instanced skinned draws |
 
 ## Animation3DClips API
 
@@ -172,15 +177,7 @@ let blending = Animation3DState.isBlending anim  // true during blend
 let anim = anim |> Animation3DState.update deltaTime
 ```
 
-Advances the current frame (and blend target frame if blending). Respects `Loop` and `Speed` settings. Does not apply to the model — use `applyToModel` after.
-
-### Apply to Model
-
-```fsharp
-Animation3DState.applyToModel anim
-```
-
-Calls `Raylib.UpdateModelAnimation` (or `UpdateModelAnimationEx` when blending) which mutates the model's bone matrices. Must be called before rendering with `DrawModel`.
+Advances the current frame (and blend target frame if blending). Respects `Loop` and `Speed` settings.
 
 ### Query
 
@@ -225,14 +222,16 @@ The algorithm matches raylib's `UpdateModelAnimation`:
 ### Rendering
 
 ```fsharp
-buffer |> Draw3D.drawSkinnedMesh mesh.Mesh transform material bones
+buffer
+  .skinnedMesh(mesh.Mesh, transform, material, bones)
+  .drop()
 ```
 
 The shader receives bone matrices as a `boneMatrices[128]` uniform and applies skinning on the GPU via `vertexBoneIndices` / `vertexBoneWeights` vertex attributes.
 
 ## Integration with MVU
 
-Animation state lives in your Elmish model. Update in a system, apply in the view:
+Animation state lives in your Elmish model. Update in a system, draw in the view:
 
 ```fsharp
 // Types.fs
@@ -246,8 +245,9 @@ let animationSystem dt model =
     struct (model, Cmd.none)
 
 // View.fs
-Animation3DState.applyToModel model.PlayerAnim
-buffer |> Draw3D.drawModel model.PlayerAnim.Model transform
+buffer
+  .animatedModel(model.PlayerAnim, playerTransform)
+  .drop()
 ```
 
 ## Model Format
@@ -260,7 +260,7 @@ Animations are loaded from the model file via `assets.ModelAnimations`. The anim
 
 1. **Resolve clip names once at init**: Use `tryGetClipIndex` + `playByIndex` to avoid string lookups in the hot path
 2. **Share Animation3DClips**: Create clips once, reuse across all entities using the same model
-3. **Tier 2 for many entities**: Share a single mesh and avoid per-entity model copies — use `AnimatedMesh` + `computeBoneMatrices` + `Draw3D.drawSkinnedMesh` (raylib), or the shared-mesh path with `Draw3D.drawAnimatedModel` (MonoGame)
+3. **Tier 2 for many entities**: Share a single mesh and avoid per-entity model copies — use `AnimatedMesh` + `computeBoneMatrices` + `.skinnedMesh(...)` (raylib), or the shared-mesh path with `.animatedModel(...)` (MonoGame)
 4. **Blend duration**: Keep blend durations short (0.1–0.3s) to minimize double-animation overhead
 
 ## See Also

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -93,7 +93,7 @@ let atlas = assets.Texture("tiles.png") |> Texture.filter TextureFilter.Point
 | `Texture.wrap TextureWrap.Repeat tex` | Set the wrap/addressing mode (Clamp/Repeat/MirrorClamp/MirrorRepeat) |
 | `Texture.mipmaps tex` | Generate mipmaps (the loader already does this on load) |
 
-Apply it once (e.g. in `init`) — not every frame — since it mutates the cached texture's sampler. (`TextureFilter` is `Raylib_cs.TextureFilter`: `Point`, `Bilinear`, `Trilinear`, `Aniso4x/8x/16x`; `TextureWrap` is `Raylib_cs.TextureWrap`: `Clamp`, `Repeat`, `MirrorClamp`, `MirrorRepeat`.) MonoGame controls sampling per draw via `Draw.setSamplerState` instead; see [2D Buffer & Commands](graphics2d/buffer-and-commands.html).
+Apply it once (e.g. in `init`) — not every frame — since it mutates the cached texture's sampler. (`TextureFilter` is `Raylib_cs.TextureFilter`: `Point`, `Bilinear`, `Trilinear`, `Aniso4x/8x/16x`; `TextureWrap` is `Raylib_cs.TextureWrap`: `Clamp`, `Repeat`, `MirrorClamp`, `MirrorRepeat`.) MonoGame controls sampling per draw via `.setSamplerState(...)` instead; see [2D Buffer & Commands](graphics2d/buffer-and-commands.html).
 
 
 

--- a/docs/camera.md
+++ b/docs/camera.md
@@ -7,7 +7,7 @@ index: 13
 
 # Camera
 
-Cameras control what part of the world you see and how it maps to the screen. Mibo provides `Camera2D` for 2D games and `Camera3D` for 3D games. Both support single-camera and split-screen patterns. The `Draw.beginCamera`/`Draw3D.beginCamera` DSL and the `Camera2DConfig`/`Camera3DConfig` modifiers share the same shape across backends; only the underlying camera struct's field layout is backend-specific.
+Cameras control what part of the world you see and how it maps to the screen. Mibo provides `Camera2D` for 2D games and `Camera3D` for 3D games. Both support single-camera and split-screen patterns. The fluent `.beginCamera(...)`/`.beginCameraWith(...)` members and the `Camera2DConfig`/`Camera3DConfig` modifiers share the same shape across backends; only the underlying camera struct's field layout is backend-specific.
 
 ## What and Why
 
@@ -20,10 +20,10 @@ Cameras control what part of the world you see and how it maps to the screen. Mi
 
 | Situation | Use |
 |-----------|-----|
-| 2D game with scrolling world | `Camera2D.create` + `Draw.beginCamera` |
-| 2D game with split-screen or HUD | `Camera2DConfig` + `Draw.beginCameraWith` |
-| 3D game | `Camera3D` struct + `Draw3D.beginCamera` |
-| 3D split-screen or picture-in-picture | `Camera3DConfig` + `Draw3D.beginCameraWith` |
+| 2D game with scrolling world | `Camera2D.create` + `.beginCamera(...)` |
+| 2D game with split-screen or HUD | `Camera2DConfig` + `.beginCameraWith(...)` |
+| 3D game | `Camera3D` struct + `.beginCamera(...)` |
+| 3D split-screen or picture-in-picture | `Camera3DConfig` + `.beginCameraWith(...)` |
 | Mouse picking in 3D | `Camera3D.screenPointToRay` |
 | Culling off-screen objects | `Camera2D.viewportBounds` |
 
@@ -47,18 +47,19 @@ let camera = Camera2D.create (Vector2(400f, 300f)) 1.0f viewportSize
 
 ### Using in a view
 
-Wrap your world-space draw commands between `beginCamera` and `endCamera`. The `layer` parameter controls draw order — camera and content must share the same layer range.
+Wrap your world-space draw commands between `.beginCamera(...)` and `.endCamera(...)`. The `layer` parameter controls draw order — camera and content must share the same layer range.
 
 ```fsharp
 buffer
-|> Draw.beginCamera 0<RenderLayer> camera
-|> Draw.fillRect (0<RenderLayer>, Color.Green) groundRect
-|> Draw.fillCircle (0<RenderLayer>, Color.Red) (playerPos, 16f)
-|> Draw.endCamera 999<RenderLayer>
-|> Draw.text (1000<RenderLayer>, Color.White) hudTextState
+  .beginCamera(camera)
+  .fillRect(0f, 0f, 800f, 600f, Color.Green)
+  .fillCircle(playerPos, 16f, Color.Red)
+  .endCamera(layer = 999<RenderLayer>)
+  .text(font, "HUD", Vector2(10f, 10f), 20f, layer = 1000<RenderLayer>)
+  .drop()
 ```
 
-> _**TIP**_: Put UI draws *after* `endCamera` on a higher layer so they render in screen space, not world space.
+> _**TIP**_: Put UI draws *after* `.endCamera(...)` on a higher layer so they render in screen space, not world space.
 
 ### Camera movement
 
@@ -116,9 +117,10 @@ let config =
     |> Camera2D.withClear Color.CornflowerBlue
 
 buffer
-|> Draw.beginCameraWith 0<RenderLayer> config
-|> // ... world content ...
-|> Draw.endCamera 999<RenderLayer>
+  .beginCameraWith(config)
+  // ... world content ...
+  .endCamera(layer = 999<RenderLayer>)
+  .drop()
 ```
 
 ### Split-screen
@@ -130,13 +132,14 @@ let left = Camera2D.splitScreenLeft player1Camera Color.CornflowerBlue
 let right = Camera2D.splitScreenRight player2Camera Color.DarkGreen
 
 buffer
-|> Draw.beginCameraWith 0<RenderLayer> left
-|> // ... player 1 content ...
-|> Draw.endCamera 99<RenderLayer>
-|> Draw.beginCameraWith 100<RenderLayer> right
-|> // ... player 2 content ...
-|> Draw.endCamera 199<RenderLayer>
-|> Draw.text (200<RenderLayer>, Color.White) hudState
+  .beginCameraWith(left)
+  // ... player 1 content ...
+  .endCamera(layer = 99<RenderLayer>)
+  .beginCameraWith(right, layer = 100<RenderLayer>)
+  // ... player 2 content ...
+  .endCamera(layer = 199<RenderLayer>)
+  .text(font, "HUD", Vector2(10f, 10f), 20f, layer = 200<RenderLayer>)
+  .drop()
 ```
 
 Available split-screen helpers:
@@ -204,11 +207,11 @@ let camera = Camera3D.create pos target fov |> Camera3D.withNearFar 0.01f 5000f
 
 ```fsharp
 buffer
-|> Draw3D.beginCamera camera
-|> Draw3D.drawModel playerModel playerTransform
-|> Draw3D.addPointLight { Position = torchPos; Color = Color.White; Intensity = 1f; Radius = 10f; CastsShadows = false; ShadowBias = ValueNone }
-|> Draw3D.endCamera
-|> Draw3D.drop
+  .beginCamera(camera)
+  .model(playerModel, playerTransform)
+  .addPointLight { Position = torchPos; Color = Color.White; Intensity = 1f; Radius = 10f; CastsShadows = false; ShadowBias = ValueNone }
+  .endCamera()
+  .drop()
 ```
 
 ### 3D config modifiers
@@ -226,10 +229,10 @@ let config =
     |> Camera3D.withClear Color.SkyBlue
 
 buffer
-|> Draw3D.beginCameraWith config
-|> Draw3D.drawModel sceneModel sceneTransform
-|> Draw3D.endCamera
-|> Draw3D.drop
+  .beginCameraWith(config)
+  .model(sceneModel, sceneTransform)
+  .endCamera()
+  .drop()
 ```
 
 ### Split-screen (3D)
@@ -239,13 +242,13 @@ let left = Camera3D.splitScreenLeft player1Camera Color.SkyBlue
 let right = Camera3D.splitScreenRight player2Camera Color.SkyBlue
 
 buffer
-|> Draw3D.beginCameraWith left
-|> // ... player 1 scene ...
-|> Draw3D.endCamera
-|> Draw3D.beginCameraWith right
-|> // ... player 2 scene ...
-|> Draw3D.endCamera
-|> Draw3D.drop
+  .beginCameraWith(left)
+  // ... player 1 scene ...
+  .endCamera()
+  .beginCameraWith(right)
+  // ... player 2 scene ...
+  .endCamera()
+  .drop()
 ```
 
 ### Mouse picking

--- a/docs/draw-dsl.md
+++ b/docs/draw-dsl.md
@@ -1,0 +1,247 @@
+---
+title: Draw DSL
+category: Rendering
+categoryindex: 3
+index: 11
+---
+
+# Draw DSL
+
+The **fluent Draw DSL** is the recommended way to write view code in Mibo. It is a single API for **2D and 3D** that works identically on **both backends** (raylib and MonoGame): you chain calls on the render buffer, and the chain compiles down to the same direct buffer commands you would write by hand — there is no runtime cost.
+
+> [!IMPORTANT]
+> The fluent DSL is the blessed path going forward. The function-based (piped) modules — `Draw`, `Draw3D`, `LightDraw`, `ParticleDraw` — still work in this release but **will be removed in a future version**. New code should use the fluent DSL; see [Migrating from the piped DSL](#migrating-from-the-piped-dsl).
+
+```fsharp
+open Mibo.Elmish.Graphics   // the Draw extensions
+open Mibo.Elmish.Graphics2D // buffer, SpriteState, RenderLayer
+
+let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
+  buffer
+    .beginCamera(model.Camera)
+    .fillCircle(Vector2(400f, 300f), 48f, Color.Blue)
+    .sprite(model.PlayerSprite)
+    .lineThick(Vector2.Zero, Vector2(800f, 600f), Color.White, thickness = 2f)
+    .endCamera()
+    .text(model.Font, "HP 100", Vector2(10f, 10f), 20f, layer = 1001<RenderLayer>)
+  .drop()
+```
+
+Every member returns the buffer, so calls chain. End a chain with `.drop()` to discard the buffer (or pipe it into another view function when composing views).
+
+## Parameters and defaults
+
+Parameters are ordered by how often you set them; anything with a sensible default is an **optional parameter** you pass by name:
+
+| Parameter | Default | Notes |
+| --- | --- | --- |
+| `layer` | `0<RenderLayer>` | 2D draw ordering, as today |
+| `tint` | `Color.White` | sprite/text tint |
+| `thickness` | `1.0f` | outlines and thick lines |
+| `roundness` / `segments` | `0.5f` / `8` | rounded rects (`16` for sectors/rings) |
+| `intensity` / `castsShadows` | `1.0f` / `false` | 2D lights from parts |
+| `spacing` | `1.0f` | text — used by raylib, ignored by MonoGame (see [Sprites and text](#sprites-and-text)) |
+
+```fsharp
+buffer
+  .fillRect(10f, 10f, 220f, 36f, Color.Red)                       // all defaults
+  .fillRect(10f, 56f, 220f, 36f, Color.Blue, layer = 5<RenderLayer>)
+  .rectOutline(10f, 10f, 220f, 36f, Color.White, thickness = 2f)
+  .drop()
+```
+
+Optional parameters are struct optionals — they allocate nothing whether you pass them or not.
+
+## Shared vocabulary
+
+The DSL speaks a small set of backend-neutral types. Each backend converts them at the buffer boundary, inline:
+
+- **Colors** — `Mibo.Color` (byte RGBA, `Color.rgb`/`Color.create` plus named values). Convert to/from a backend color with the existing `op_Implicit`/`.ToMiboColor()` extensions when you need one.
+- **Vectors and matrices** — `System.Numerics` (`Vector2`, `Vector3`, `Matrix4x4`). raylib uses these natively; the MonoGame witnesses convert through the same `op_Implicit`/`.ToNumerics()` conversions MonoGame already ships.
+- **Rectangles** — passed as plain `x, y, w, h` floats (rounded to ints on MonoGame, which is pixel-based). A few members keep int pixel coordinates to match the underlying APIs (`rectGradientV`/`rectGradientH`, `circleGradient`, ellipses).
+
+```fsharp
+// The same call, both backends:
+buffer
+  .fillCircle(Vector2(400f, 300f), 48f, Color.rgb 255uy 200uy 100uy)
+  .drop()
+```
+
+## Backend handles
+
+Anything that *is* a backend type simply passes through as that type — there is no wrapper and no conversion. This is what lets one DSL cover both backends:
+
+- GPU handles: `Texture2D`, `Font`/`SpriteFont`, `Shader`/`Effect`, render targets, models, meshes, materials, sampler states.
+- Backend state records: `SpriteState`, `TextState`, `AnimatedSprite`, the 2D light/occluder records, `AnimatedModel`/animation states.
+- Cameras and camera configs (`Camera2D`/`Camera3D` and their `*Config` records).
+
+```fsharp
+// raylib view
+buffer.beginCamera(model.Camera)          // Raylib_cs.Camera2D
+buffer.sprite(tileSprite)                 // raylib SpriteState
+buffer.drop()
+
+// MonoGame view — identical shape
+buffer.beginCamera(model.Camera)          // Mibo MonoGame Camera2D record
+buffer.sprite(tileSprite)                 // MonoGame SpriteState
+buffer.drop()
+```
+
+Because handles are backend-typed, a view file written against one backend compiles unchanged against the other as long as it only builds values both sides have (this is how the samples share code across clients).
+
+## 2D tour
+
+### Shapes
+
+Rectangles, rounded rects, gradients, circles, sectors, rings, ellipses, lines, beziers, triangles, polygons — all available with the optional-parameter defaults from the table above.
+
+```fsharp
+buffer
+  .fillRect(0f, 0f, 64f, 64f, Color.Green)
+  .circleSector(Vector2(120f, 120f), 40f, 0f, 180f, Color.Red, segments = 24)
+  .triangle(Vector2(0f, 0f), Vector2(10f, 20f), Vector2(20f, 0f), Color.Blue)
+  .drop()
+```
+
+`lineStrip`/`triangleFan`/`triangleStrip` take the backend's vector-array type directly (System.Numerics arrays on raylib, XNA arrays on MonoGame) — no per-frame conversion.
+
+### Sprites and text
+
+Sprites use the backend `SpriteState` record as today; text has both the record form and a parts form that skips the builder chain:
+
+```fsharp
+// record form (unchanged from today)
+buffer.sprite(SpriteState.create(tex, dest, src) |> SpriteState.withLayer 10<RenderLayer>)
+
+// text, parts form — size maps to each backend's sizing model:
+// raylib: font size in pixels; MonoGame: uniform scale
+buffer
+  .text(font, "HP 100", Vector2(10f, 10f), 20f, layer = 1001<RenderLayer>)
+  .text(state)                  // or the backend TextState record
+  .drop()
+```
+
+### Cameras, shaders, targets, render state
+
+```fsharp
+buffer
+  .beginCamera(worldCamera)
+  // ...world draws...
+  .endCamera(layer = 1000<RenderLayer>)
+  .setBlend(BlendMode.Additive)           // backend blend handle
+  .setScissor(0, 0, 320, 240)
+  .clearScissor()
+  .setViewport(0, 0, 640, 480)
+  .clear(Color.Black)
+  .drop()
+```
+
+`beginCameraWith` takes the backend camera-config record (viewport/clear), `beginShader`/`beginTarget` take the backend shader/effect and render-target handles.
+
+### Lighting
+
+The 2D lighting API takes the light context plus the usual records — or plain parts for one-off directional lights:
+
+```fsharp
+buffer
+  .setAmbient(lighting, ambientColor, layer = 5<RenderLayer>)
+  .addDirectionalLight(lighting, sunDir, Color.rgb 255uy 245uy 220uy,
+                      intensity = 1.5f, castsShadows = true, layer = 6<RenderLayer>)
+  .addPointLight(lighting, torchLight, layer = 7<RenderLayer>)
+  .addOccluder(lighting, wallSegment, layer = 8<RenderLayer>)
+  .litSprite(lighting, tileSprite)
+  .litAnimatedSprite(lighting, playerDest, model.PlayerSprite, layer = 20<RenderLayer>)
+  .endLighting(lighting, layer = 999<RenderLayer>)
+  .drop()
+```
+
+### Particles and post-processing
+
+```fsharp
+buffer
+  .particles(model.ParticleTexture, model.ParticleBuffer, count, layer = 3<RenderLayer>)
+  .postProcess(fun pp ->
+    // runs once after the scene renders; `pp` is the backend's
+    // PostProcessContext2D — draw a fullscreen quad of pp.Source
+    ())
+  .drawImmediate(fun () ->
+    // flush the batch and run raw backend draw calls
+    ())
+  .drop()
+```
+
+## 3D tour
+
+The same buffer-chaining style; 3D members ignore `layer` (3D commands are unsorted).
+
+```fsharp
+buffer
+  .setShadowOrigin(shadowFocus)
+  .setAmbientLight { Color = Color(30, 30, 40, 255); Intensity = 0.4f }
+  .addDirectionalLight sunLight           // Core light types — shared by both backends
+  .addPointLight torchLight
+  .beginCamera(worldCamera)
+  .model(terrainModel, terrainTransform)
+  .modelWith(playerModel, playerTransform, highlightMaterial)
+  .modelWithPerMesh(ghostModel, ghostTransform, fun i -> ghostMaterials[i])
+  .animatedModel(model.PlayerAnim, playerTransform)
+  .skinnedMesh(mesh, transform, material, bones)   // explicit palette (raylib)
+  .instanced(chunkMesh, chunkTransforms, chunkMaterial, chunkCount)
+  .billboard(markerTex, Vector3(0f, 2f, 0f), Vector2(1f, 1f), Color.White)
+  .line3D(Vector3.Zero, Vector3.UnitY, Color.Red)
+  .endCamera()
+  .postProcess(fun pp -> (* color-only pass *))
+  .postProcessWithDepth(fun pp -> (* fog, DOF, SSAO *))
+  .drop()
+```
+
+- **Models and materials** — `model`, `modelWith` (whole-model override), `modelWithPerMesh` (resolver by flat mesh-part index). Materials are the backend `Material3D`.
+- **Meshes and instancing** — `mesh` (raylib `Mesh` / MonoGame `PrimitiveMesh`) and `instanced` for bulk draws.
+- **Animated models** — `animatedModel` consumes the backend animation state record; the bone palette is derived for you (MonoGame computes it from the state; raylib applies it to the model). `animatedModelWith`/`animatedModelWithPerMesh` add material overrides. `skinnedMesh` is the explicit-palette form (raylib).
+- **Effect scopes** — `beginEffect`/`endEffect` shade a group with your own shader, inheriting the scene's camera/lights/shadows; see `docs/shader-uniforms.md`.
+- **Lights** — `AmbientLight3D`, `DirectionalLight3D`, `PointLight3D`, `SpotLight3D` are backend-neutral Core types already shared by both backends.
+
+## Backend-specific members
+
+Some features exist on one backend only. The DSL keeps them in the same fluent surface — they simply have no counterpart on the other backend, so **calling them there is a compile error** naming the missing operation:
+
+```fsharp
+// MonoGame only — stops tile-atlas bleeding:
+buffer.setSamplerState(SamplerState.PointClamp, layer = 9<RenderLayer>)
+
+// raylib only — explicit-palette skinned draw:
+buffer.skinnedMesh(mesh, transform, material, bones)
+```
+
+This is how asymmetry is meant to look: write the call where the feature exists; the compiler stops you from accidentally porting it.
+
+## Migrating from the piped DSL
+
+The piped modules keep working in this release, but they will be removed. The fluent equivalent of each pattern:
+
+| Piped (old) | Fluent (new) |
+| --- | --- |
+| `buffer \|> Draw.fillRect (layer, color) rect` | `buffer.fillRect(x, y, w, h, color, layer = layer)` |
+| `buffer \|> Draw.sprite state` | `buffer.sprite state` |
+| `buffer \|> Draw.text state` | `buffer.text state` or `buffer.text(font, s, pos, size, ...)` |
+| `buffer \|> Draw.beginCamera 0<RenderLayer> cam` | `buffer.beginCamera cam` |
+| `buffer \|> LightDraw.litSprite ctx state` | `buffer.litSprite(ctx, state)` |
+| `buffer \|> LightDraw.litAnimatedSprite ctx layer dest anim` | `buffer.litAnimatedSprite(ctx, dest, anim, layer = layer)` |
+| `buffer \|> LightDraw.addPointLight ctx layer light` | `buffer.addPointLight(ctx, light, layer = layer)` |
+| `buffer \|> ParticleDraw.particles tex data count layer` | `buffer.particles(tex, data, count, layer = layer)` |
+| `buffer \|> Draw3D.drawModel model transform` | `buffer.model(model, transform)` |
+| `buffer \|> Draw3D.drawAnimatedModel anim transform` | `buffer.animatedModel(anim, transform)` |
+| `buffer \|> Draw3D.addPointLight light` | `buffer.addPointLight light` |
+| `buffer \|> Draw3D.beginCamera cam \|> ... \|> Draw3D.endCamera` | `buffer.beginCamera(cam) .... .endCamera()` |
+| `... \|> Draw.drop` | `.... .drop()` (or chain into the next view) |
+
+Notes for migrating:
+
+- **Colors** move from backend colors to `Mibo.Color` — drop the `toRaylibColor`/`toMonoGameColor` calls at draw sites (the witnesses convert for you), and use `.ToMiboColor()` where you still need to go the other way.
+- **Rectangles** in shape calls become `x, y, w, h` floats. Backend `Rectangle` values still appear in `SpriteState`/lit-sprite destinations, which are pass-through records.
+- **`Draw.drop`** becomes `.drop()` at the end of the chain — or pipe the buffer into the next view function (`|> MinimapView.view ctx model`).
+- **MonoGame vectors** at draw sites become `System.Numerics`; drop the `Vector2.op_Implicit` conversions you only added to satisfy the old API (the witnesses convert). Values that feed backend records (e.g. `PointLight2D.Position`) still need the backend vector type.
+
+## How it works (for the curious)
+
+Each fluent member is an inline extension resolved at compile time against a small set of `member inline` plug points on the render buffer. The entire chain — optional parameters included — erases at the call site, leaving the same direct `buffer.Add(Command...)` sequence you would write by hand: no dispatch, no closure allocation, no wrapper types. That is also why a member with no plug point on the current backend is a compile error rather than a runtime surprise.

--- a/docs/graphics2d/buffer-and-commands.md
+++ b/docs/graphics2d/buffer-and-commands.md
@@ -7,7 +7,7 @@ index: 12
 
 # Buffer & Commands
 
-Every frame, your view function receives a `RenderBuffer2D` and populates it with commands. This page covers all command types and how to use them.
+Every frame, your view function receives a `RenderBuffer2D` and populates it with commands. This page explains how to think about the buffer; the member-level details live in [Draw DSL](../draw-dsl.html) and the API reference.
 
 ## The buffer lifecycle
 
@@ -20,107 +20,50 @@ The buffer is **pre-cleared** by the renderer each frame. Do not call `Clear()` 
 
 ```fsharp
 let myView (ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
-  let bg = Rectangle(0f, 0f, 800f, 600f)
   let player = SpriteState.create(tex, Rectangle(100f, 100f, 32f, 32f), Rectangle(0f, 0f, 32f, 32f))
 
   buffer
-  |> Draw.fillRect (0<RenderLayer>, Color.SkyBlue) bg
-  |> Draw.sprite player
-  |> Draw.drop
+    .fillRect(0f, 0f, 800f, 600f, Color.SkyBlue)
+    .sprite(player)
+    .drop()
 ```
 
-The `|> Draw.drop` at the end silences the unused-value warning. It does nothing.
+The `.drop()` at the end silences the unused-value warning. It does nothing.
 
-> _**NOTE (backend types)**_: The snippets on this page use the **raylib** `Rectangle` (four `float32` fields). On the **MonoGame** backend, `Rectangle` is `Microsoft.Xna.Framework.Rectangle` with **int** fields — drop the `f` suffixes (`Rectangle(100, 100, 32, 32)`). `Vector2`/`Color` differ too. See [MonoGame type quirks](../monogame-types.html).
+## Layers, not call order
 
-## Two ways to build commands
-
-### Draw DSL (pipe-friendly)
-
-Use the `Draw` module for everyday rendering. Every `Draw.*` function takes styling parameters first, geometry parameters second, and the buffer last — enabling partial application:
+Commands execute in **layer order**, not insertion order. Every 2D member takes an optional `layer` (default `0<RenderLayer>`); within one layer, insertion order is preserved. This means you can write your view in whatever order reads best — backgrounds low, world in the middle, UI high:
 
 ```fsharp
-// Partial application: bind styling once
-let redFill = Draw.fillRect (10<RenderLayer>, Color.Red)
-let blueOutline = Draw.rectOutline (10<RenderLayer>, Color.Blue, 2f)
-
 buffer
-|> redFill groundRect
-|> blueOutline groundRect
-|> Draw.text (TextState.create(font, "Score: 100", Vector2(10f, 10f)))
+  .text(font, "HP 100", Vector2(10f, 10f), 20f, layer = 1001<RenderLayer>)
+  .fillCircle(worldPos, 20f, Color.Red, layer = 10<RenderLayer>)
+  .rectGradientV(0, 0, w, h, skyTop, skyBot, layer = -1000<RenderLayer>)
+  .drop()
 ```
 
-### Command2D factories (command-first)
+Even though the text was added first, the sky gradient draws first, then the circle, then the UI.
 
-Use `Command2D.*` when you need to store a command or build one without a buffer:
+## Neutral inputs, backend records
+
+The fluent DSL takes `Mibo.Color`, `System.Numerics` vectors, and float rectangle coordinates on **both backends** — the buffer converts for you. Backend state records (`SpriteState`, `TextState`, light records, particle arrays) pass through as the backend's own types: **raylib** `Rectangle` (four `float32` fields) vs **MonoGame** `Microsoft.Xna.Framework.Rectangle` (**int** fields). See [MonoGame type quirks](../monogame-types.html).
+
+Sprites and text have builder-equipped state records when you want to carry them around:
 
 ```fsharp
-let dest = Rectangle(0f, 0f, 64f, 64f)
-let source = Rectangle(0f, 0f, 64f, 64f)
-let mySprite = Command2D.sprite (SpriteState.create(tex, dest, source))
+let sprite = SpriteState.create(tex, Rectangle(100f, 100f, 32f, 32f), Rectangle(0f, 0f, 32f, 32f))
+let redSprite = { sprite with Color = Color.Red; Layer = 10<RenderLayer> }
+let spinning = { sprite with Rotation = 0.785f } // ~45 degrees
 
-// Later, add to buffer:
-buffer.Add(mySprite)
+buffer.sprite(sprite).drop()
 ```
 
-## Command reference
-
-All commands live in two modules in `Mibo.Elmish.Graphics2D`:
-
-| Category | Draw DSL function | What it draws |
-|----------|------------------|---------------|
-| **Sprite** | `Draw.sprite state` | Textured sprite via `DrawTexturePro` |
-| **Text** | `Draw.text state` | Text via `DrawTextEx` |
-| **Rect** | `Draw.fillRect (layer, color) rect` | Filled rectangle |
-| | `Draw.rectOutline (layer, color, thickness) rect` | Rectangle outline |
-| | `Draw.fillRectRounded (layer, color, roundness, segments) rect` | Rounded rectangle |
-| | `Draw.rectRoundedOutline (layer, color, roundness, segments, thickness) rect` | Rounded outline |
-| | `Draw.rectGradientV layer (x, y, w, h, top, bottom)` | Vertical gradient rect |
-| | `Draw.rectGradientH layer (x, y, w, h, left, right)` | Horizontal gradient rect |
-| | `Draw.rectGradient layer (rect, tl, bl, tr, br)` | 4-corner gradient rect |
-| **Circle** | `Draw.fillCircle (layer, color) (center, radius)` | Filled circle |
-| | `Draw.circleOutline (layer, color) (center, radius)` | Circle outline |
-| | `Draw.circleSector (layer, color) (center, radius, startAngle, endAngle, segments)` | Pie slice |
-| | `Draw.circleGradient layer (cx, cy, radius, inner, outer)` | Gradient circle |
-| | `Draw.fillRing (layer, color) (center, innerR, outerR, startAngle, endAngle, segments)` | Ring / arc |
-| | `Draw.ringOutline (layer, color) (center, innerR, outerR, startAngle, endAngle, segments)` | Ring outline |
-| | `Draw.fillEllipse (layer, color) (cx, cy, radiusH, radiusV)` | Filled ellipse |
-| | `Draw.ellipseOutline (layer, color) (cx, cy, radiusH, radiusV)` | Ellipse outline |
-| **Line** | `Draw.line (layer, color) (start, finish)` | 1px line |
-| | `Draw.lineThick (layer, color, thickness) (start, finish)` | Thick line |
-| | `Draw.lineStrip (layer, color) points` | Connected line segments |
-| | `Draw.bezier (layer, color, thickness) (start, control, finish)` | Quadratic bezier |
-| **Triangle** | `Draw.triangle (layer, color) (v1, v2, v3)` | Filled triangle |
-| | `Draw.triangleFan (layer, color) points` | Triangle fan |
-| | `Draw.triangleStrip (layer, color) points` | Triangle strip |
-| **Polygon** | `Draw.fillPoly (layer, color) (center, sides, radius, rotation)` | Regular polygon |
-| | `Draw.polyOutline (layer, color, thickness) (center, sides, radius, rotation)` | Polygon outline |
-| **Camera** | `Draw.beginCamera layer camera` | Start camera transform |
-| | `Draw.endCamera layer` | End camera transform |
-| **Shader** | `Draw.beginShader layer shader` | Start shader mode |
-| | `Draw.endShader layer` | End shader mode |
-| **Target** | `Draw.beginTarget layer target` | Render to texture |
-| | `Draw.endTarget layer` | End render-to-texture |
-| **State** | `Draw.setBlend layer mode` | Set blend mode |
-| | `Draw.setScissor layer (x, y, w, h)` | Enable scissor rect |
-| | `Draw.clearScissor layer` | Disable scissor |
-| | `Draw.setLineWidth layer width` | Set line thickness |
-| | `Draw.setViewport layer (x, y, w, h)` | Set viewport |
-| | `Draw.setSamplerState layer sampler` | Set sprite sampler (MonoGame) |
-| **Clear** | `Draw.clear layer color` | Clear background |
-| **Immediate** | `Draw.drawImmediate layer action` | Escape hatch (see [Custom Commands](custom-commands.html)) |
-
-## Per-command styling
-
-All `Draw` functions group styling parameters first. This lets you bind them once:
+For text, the parts form is usually shortest — `size` maps to each backend's sizing model (raylib: font size in pixels; MonoGame: uniform scale):
 
 ```fsharp
-let hudText text = Draw.text (TextState.create(font, text, Vector2(10f, 10f)))
-
-// Reuse with different data:
 buffer
-|> hudText "HP: 100"
-|> hudText "Score: 5000"
+  .text(font, "Score: 100", Vector2(10f, 10f), 20f, tint = Color.Yellow, layer = 100<RenderLayer>)
+  .drop()
 ```
 
 ## State commands (blend, scissor, viewport)
@@ -129,62 +72,49 @@ State commands affect subsequent draws within the same layer range:
 
 ```fsharp
 buffer
-|> Draw.setBlend 0<RenderLayer> BlendMode.Additive
-|> Draw.fillCircle (10<RenderLayer>, Color.Red) (center, 20f)
-|> Draw.setBlend 0<RenderLayer> BlendMode.Alpha
+  .setBlend(BlendMode.Additive)
+  .fillCircle(center, 20f, Color.Red, layer = 10<RenderLayer>)
+  .setBlend(BlendMode.AlphaBlend)
+  .drop()
 ```
 
 Blend mode, scissor rect, line width, and viewport are reset at the start of each frame.
 
 ### Sampler state (MonoGame only)
 
-`Draw.setSamplerState layer sampler` sets the sampler used for subsequent sprites, modeled on `setBlend`. It applies to subsequent draws and flushes/restarts the sprite batch. This is **MonoGame-only** — `SamplerState` is `Microsoft.Xna.Framework.Graphics.SamplerState` (e.g. `SamplerState.PointClamp`, `SamplerState.LinearClamp`).
+`.setSamplerState(sampler, ?layer)` sets the sampler used for subsequent sprites and flushes/restarts the sprite batch. It is **MonoGame-only**: calling it on the raylib buffer is a compile error, because the raylib buffer has no corresponding operation.
 
 ```fsharp
 buffer
-|> Draw.setSamplerState 0<RenderLayer> SamplerState.PointClamp
-|> Draw.sprite (SpriteState.create (atlas, dest, src))
+  .setSamplerState(SamplerState.PointClamp, layer = 9<RenderLayer>)
+  .sprite(SpriteState.create(atlas, dest, src))
+  .drop()
 ```
 
 The sampler defaults to `SamplerState.LinearClamp` and is reset each frame, alongside blend mode, scissor, line width, and viewport.
 
 > **raylib** has no equivalent command — a texture's filter is a property of the texture, not the batch. Override the load-time default with the `Texture.filter` helper: `assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point` (apply once at load/init, not per frame). See [Assets](../assets.html).
 
-## Text and sprite state types
-
-Sprite and text use state records. Use the `create` builders for quick setup. A `SpriteState` exposes the full field set: `Texture`, `Dest`, `Source`, `Origin`, `Rotation` (radians), `Color`, `Layer`, and `NormalMap` (for 2D lighting).
-
-```fsharp
-// Sprite: texture + destination + source rect
-let sprite = SpriteState.create(tex, Rectangle(100f, 100f, 32f, 32f), Rectangle(0f, 0f, 32f, 32f))
-
-// Sprite with custom color
-let redSprite = { sprite with Color = Color.Red; Layer = 10<RenderLayer> }
-
-// SpriteState also exposes Rotation (radians), Origin (pivot, pixels), and NormalMap (2D lighting).
-let spinning = { sprite with Rotation = 0.785f } // ~45 degrees
-
-// Text: font + string + position
-let scoreText = TextState.create(font, "Score: 100", Vector2(10f, 10f))
-
-// Text with custom size
-let bigText = { scoreText with FontSize = 24f; Color = Color.Yellow; Layer = 100<RenderLayer> }
-```
-
 ## Cameras
 
-Wrap world-space content between `Draw.beginCamera` and `Draw.endCamera`:
+Wrap world-space content between `.beginCamera(...)` and `.endCamera(...)`:
 
 ```fsharp
 let camera = Camera2D.create (Vector2(400f, 300f)) 1.0f viewportSize
-let hudLabel = TextState.create(font, "HUD", Vector2(10f, 10f))
 
 buffer
-|> Draw.beginCamera 0<RenderLayer> camera
-|> Draw.fillCircle (10<RenderLayer>, Color.Red) (worldPos, 20f)
-|> Draw.endCamera 1000<RenderLayer>
-// After endCamera, draws are in screen space:
-|> Draw.text hudLabel
+  .beginCamera(camera)
+  .fillCircle(worldPos, 20f, Color.Red, layer = 10<RenderLayer>)
+  .endCamera(layer = 1000<RenderLayer>)
+  // After endCamera, draws are in screen space:
+  .text(font, "HUD", Vector2(10f, 10f), 20f, layer = 1001<RenderLayer>)
+  .drop()
 ```
 
 See [Camera](../camera.html) for details.
+
+## Next steps
+
+- [Draw DSL](../draw-dsl.html) — the full fluent surface with defaults
+- [Custom Commands](custom-commands.html) — the `.drawImmediate(...)` escape hatch
+- [Performance](performance.html) — writing efficient rendering code

--- a/docs/graphics2d/custom-commands.md
+++ b/docs/graphics2d/custom-commands.md
@@ -7,7 +7,7 @@ index: 16
 
 # Custom Commands & Escape Hatches
 
-The 2D rendering system is built on a discriminated union (`Command2D`). The `Draw.*` DSL covers standard shapes, sprites, text, and render state. When you need to go outside those primitives, `DrawImmediate` is the escape hatch.
+The 2D rendering system is built on a discriminated union (`Command2D`). The fluent Draw DSL covers standard shapes, sprites, text, and render state. When you need to go outside those primitives, `.drawImmediate(...)` is the escape hatch.
 
 ## What and Why
 
@@ -17,30 +17,30 @@ You give up batching. You gain full control.
 
 ## When to use
 
-Use `DrawImmediate` when:
+Use `.drawImmediate(...)` when:
 
 - You need direct `Rlgl.*` calls (custom vertices, instancing, compute dispatches).
 - You're integrating a third-party renderer that writes to the GL context directly.
-- The built-in `Draw.*` commands can't express what you need.
+- The fluent DSL can't express what you need.
 
-Otherwise, use `Draw.*`. It batches automatically and is faster.
+Otherwise, use the fluent members. They batch automatically and are faster.
 
 ## When to use which
 
 | Scenario | Approach |
 |----------|----------|
-| Standard sprites, text, shapes | `Draw.*` DSL |
-| Direct rlgl / instancing / compute | `DrawImmediate` |
+| Standard sprites, text, shapes | Fluent Draw DSL |
+| Direct rlgl / instancing / compute | `.drawImmediate(...)` |
 
 ## DrawImmediate
 
 There are two ways to create a `DrawImmediate` command:
 
-### Via the Draw DSL (pipe-friendly)
+### Via the fluent DSL
 
 ```fsharp
 buffer
-|> Draw.drawImmediate 0<RenderLayer> (fun () ->
+  .drawImmediate(fun () ->
     Rlgl.Begin(DrawMode.Quads)
     Rlgl.Color4f(1f, 0f, 0f, 1f)
     Rlgl.Vertex2f(0f, 0f)
@@ -49,12 +49,14 @@ buffer
     Rlgl.Vertex2f(0f, 100f)
     Rlgl.End()
   )
+  .drop()
 ```
 
 ### As a Command2D factory
 
 ```fsharp
-let cmd = Command2D.drawImmediate 0<RenderLayer> (fun () ->
+let cmd =
+  Command2D.drawImmediate 0<RenderLayer> (fun () ->
     Rlgl.Begin(DrawMode.Quads)
     Rlgl.Color4f(0f, 1f, 0f, 1f)
     Rlgl.Vertex2f(0f, 0f)
@@ -84,52 +86,53 @@ This is implemented in `Renderer2D.fs` at the `drawImmediate` helper (line 142).
 ```fsharp
 let drawCustomQuad (texture: Texture2D) (layer: int<RenderLayer>) (buffer: RenderBuffer2D) =
   buffer
-  |> Draw.drawImmediate layer (fun () ->
-      Rlgl.SetTexture(int texture.Id)
-      Rlgl.Begin(DrawMode.Quads)
-      Rlgl.Color4ub(255uy, 255uy, 255uy, 255uy)
-      Rlgl.TexCoord2f(0f, 0f); Rlgl.Vertex2f(0f, 0f)
-      Rlgl.TexCoord2f(1f, 0f); Rlgl.Vertex2f(200f, 0f)
-      Rlgl.TexCoord2f(1f, 1f); Rlgl.Vertex2f(200f, 200f)
-      Rlgl.TexCoord2f(0f, 1f); Rlgl.Vertex2f(0f, 200f)
-      Rlgl.End()
-      Rlgl.SetTexture(0u)
+    .drawImmediate(
+      (fun () ->
+        Rlgl.SetTexture(int texture.Id)
+        Rlgl.Begin(DrawMode.Quads)
+        Rlgl.Color4ub(255uy, 255uy, 255uy, 255uy)
+        Rlgl.TexCoord2f(0f, 0f); Rlgl.Vertex2f(0f, 0f)
+        Rlgl.TexCoord2f(1f, 0f); Rlgl.Vertex2f(200f, 0f)
+        Rlgl.TexCoord2f(1f, 1f); Rlgl.Vertex2f(200f, 200f)
+        Rlgl.TexCoord2f(0f, 1f); Rlgl.Vertex2f(0f, 200f)
+        Rlgl.End()
+        Rlgl.SetTexture(0u)),
+      layer = layer
     )
+    .drop()
 ```
 
 > _**IMPORTANT**_: Each `DrawImmediate` call forces a batch flush before and after. If you call it in a loop (e.g., once per entity), you pay the flush cost every time. Batch your custom work into a single `DrawImmediate` call where possible.
 
 ## Full pipeline example
 
-Mix `Draw.*` commands and `DrawImmediate` in the same buffer. Commands execute in layer order.
+Mix fluent members and `.drawImmediate(...)` in the same buffer. Commands execute in layer order.
 
 ```fsharp
 let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
-  let layer0 = 0<RenderLayer>
   let layer10 = 10<RenderLayer>
 
   buffer
-  |> Draw.fillRect (layer0, Color.DarkGray) (Rectangle(0f, 0f, 800f, 600f))
-  |> Draw.sprite (SpriteState.create(model.Tex, model.Dest, model.Src))
-  |> Draw.drawImmediate layer10 (fun () ->
-      Rlgl.Begin(DrawMode.Quads)
-      Rlgl.Color4f(1f, 1f, 0f, 0.5f)
-      Rlgl.Vertex2f(300f, 300f)
-      Rlgl.Vertex2f(400f, 300f)
-      Rlgl.Vertex2f(400f, 400f)
-      Rlgl.Vertex2f(300f, 400f)
-      Rlgl.End()
+    .fillRect(0f, 0f, 800f, 600f, Color.DarkGray)
+    .sprite(SpriteState.create(model.Tex, model.Dest, model.Src))
+    .drawImmediate(
+      (fun () ->
+        Rlgl.Begin(DrawMode.Quads)
+        Rlgl.Color4f(1f, 1f, 0f, 0.5f)
+        Rlgl.Vertex2f(300f, 300f)
+        Rlgl.Vertex2f(400f, 300f)
+        Rlgl.Vertex2f(400f, 400f)
+        Rlgl.Vertex2f(300f, 400f)
+        Rlgl.End()),
+      layer = layer10
     )
-  |> Draw.text (
-      TextState.create(model.Font, "Overlay", Vector2(10f, 10f))
-      |> TextState.withLayer layer10
-    )
-  |> Draw.drop
+    .text(model.Font, "Overlay", Vector2(10f, 10f), 20f, layer = layer10)
+    .drop()
 ```
 
-> _**TIP**_: Use `Draw.drop` at the end of your view function to discard the buffer reference and silence unused-value warnings.
+> _**TIP**_: Use `.drop()` at the end of your view function to discard the buffer reference and silence unused-value warnings.
 
 ## See also:
 
-- [Buffer & Commands](buffer-and-commands.html) — the `Draw.*` DSL and command reference.
+- [Buffer & Commands](buffer-and-commands.html) — the fluent DSL and command reference.
 - [Overview](overview.html) — 2D rendering pipeline architecture.

--- a/docs/graphics2d/lighting.md
+++ b/docs/graphics2d/lighting.md
@@ -16,7 +16,7 @@ Mibo includes a GPU-driven 2D lighting system with soft shadows using analytic S
 - **Ambient light** — Base illumination for the entire scene.
 - **Shadows** — Per-light toggle. Soft shadows via SDF sphere tracing in the pixel shader. Penumbra softness is configurable.
 - **Occluders** — Line segments that block light, cast from grid-based levels or placed manually.
-- **Lit sprites** — Textured sprites that receive lighting. Unlit sprites (`Draw.sprite`) render at full brightness.
+- **Lit sprites** — Textured sprites that receive lighting. Unlit sprites (`.sprite(...)`) render at full brightness.
 
 Everything runs on the GPU via a custom lit-sprite shader. Light data is uploaded once per frame as shader uniforms.
 
@@ -25,8 +25,8 @@ Everything runs on the GPU via a custom lit-sprite shader. Light data is uploade
 1. Create `LightContext2D` in `init`, store in your model
 2. Each frame: `ctx.Reset()` at the start of your view
 3. Set ambient light, add lights and occluders
-4. Draw lit sprites via `LightDraw.litSprite`
-5. End the lighting pass via `LightDraw.endLighting` (sprites after this are unlit)
+4. Draw lit sprites via `.litSprite(...)`
+5. End the lighting pass via `.endLighting(...)` (sprites after this are unlit)
 
 ## Setup
 
@@ -62,45 +62,44 @@ let myView (ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
     model.Lighting.Reset()
 
     buffer
-    // 2. Set ambient light
-    |> LightDraw.setAmbient model.Lighting (5<RenderLayer>, { Color = Color(30, 30, 30, 255) })
+      // 2. Set ambient light
+      .setAmbient(model.Lighting, Color.rgb 30uy 30uy 30uy, layer = 5<RenderLayer>)
 
-    // 3. Add directional light (sun)
-    |> LightDraw.addDirectionalLight model.Lighting 6<RenderLayer> {
-        Direction = Vector2(0.3f, -0.7f)
-        Color = Color.White
-        Intensity = 0.8f
-        CastsShadows = true
-    }
+      // 3. Add a directional light (sun) — from parts...
+      .addDirectionalLight(
+        model.Lighting,
+        Vector2(0.3f, -0.7f),
+        Color.White,
+        intensity = 0.8f,
+        castsShadows = true,
+        layer = 6<RenderLayer>
+      )
 
-    // 4. Add point lights
-    |> LightDraw.addPointLight model.Lighting 7<RenderLayer> {
-        Position = torchPos
-        Color = Color.Orange
-        Intensity = 1.0f
-        Radius = 200f
-        Falloff = 2.0f
-        CastsShadows = false
-    }
+      // 4. Add point lights — as light records...
+      .addPointLight(
+        model.Lighting,
+        { Position = torchPos
+          Color = Color.Orange
+          Intensity = 1.0f
+          Radius = 200f
+          Falloff = 2.0f
+          CastsShadows = false },
+        layer = 7<RenderLayer>
+      )
+    |> ignore
 
     // 5. Add occluders for shadow casting
     for o in model.Occluders do
-        buffer |> LightDraw.addOccluder model.Lighting 8<RenderLayer> o
+      buffer.addOccluder(model.Lighting, o, layer = 8<RenderLayer>).drop()
 
-    // 6. Draw lit sprites
-    |> LightDraw.litSprite model.Lighting {
-        Texture = tex
-        Dest = r (int x) (int y) 32 32
-        Source = r 0 0 32 32
-        Origin = Vector2.Zero; Rotation = 0f
-        Color = Color.White; Layer = 10<RenderLayer>
-    }
-
-    // 7. End lighting pass (sprites after this are unlit)
-    |> LightDraw.endLighting model.Lighting 999<RenderLayer>
-
-    // 8. Unlit HUD
-    |> Draw.text { ... with Layer = 1000<RenderLayer> }
+    buffer
+      // 6. Draw lit sprites
+      .litSprite(model.Lighting, tileSprite)
+      // 7. End lighting pass (sprites after this are unlit)
+      .endLighting(model.Lighting, layer = 999<RenderLayer>)
+      // 8. Unlit HUD
+      .text(font, "HUD", Vector2(10f, 10f), 20f, layer = 1000<RenderLayer>)
+      .drop()
 ```
 
 ## Light types
@@ -111,7 +110,7 @@ let myView (ctx: GameContext) (model: Model) (buffer: RenderBuffer2D) =
 { Color = Color(30, 30, 30, 255) }  // dim base illumination
 ```
 
-Applied uniformly to all lit sprites. Use a low value so directional/point lights add visible contrast.
+Applied uniformly to all lit sprites. Use a low value so directional/point lights add visible contrast. (Or skip the record and pass the color straight to `.setAmbient(...)`, as above.)
 
 ### PointLight2D
 
@@ -147,7 +146,7 @@ Shadows use **SDF raymarching** in the pixel shader. Each shadow-casting light s
 
 ### Occluders
 
-Occluders are 2D line segments. Add them individually via `LightDraw.addOccluder` or auto-generate from a grid:
+Occluders are 2D line segments. Add them individually via `.addOccluder(...)` or auto-generate from a grid:
 
 ```fsharp
 open Mibo.Layout
@@ -161,7 +160,7 @@ let occluders =
 
 // In your view:
 for o in occluders do
-    buffer |> LightDraw.addOccluder model.Lighting 8<RenderLayer> o
+    buffer.addOccluder(model.Lighting, o, layer = 8<RenderLayer>).drop()
 ```
 
 The `GridOccluders.Edge` flags control which cell edges produce occluders:
@@ -187,7 +186,7 @@ Point light shadows are bounded by the light's radius, so they're cheaper than d
 
 ## Unlit rendering
 
-Sprites drawn with `Draw.sprite` (instead of `LightDraw.litSprite`) render at full brightness, ignoring lighting. This is useful for UI, minimaps, or any element that shouldn't be affected by scene lighting.
+Sprites drawn with `.sprite(...)` (instead of `.litSprite(...)`) render at full brightness, ignoring lighting. This is useful for UI, minimaps, or any element that shouldn't be affected by scene lighting.
 
 ## Shadow toggle
 
@@ -199,9 +198,10 @@ model.Lighting.ShadowsEnabled <- false
 
 // Or use commands in the render buffer
 buffer
-|> LightDraw.disableShadows model.Lighting 90<RenderLayer>
-|> // ... sprites drawn here won't cast/receive shadows ...
-|> LightDraw.enableShadows model.Lighting 100<RenderLayer>
+  .disableShadows(model.Lighting, layer = 90<RenderLayer>)
+  // ... sprites drawn here won't cast/receive shadows ...
+  .enableShadows(model.Lighting, layer = 100<RenderLayer>)
+  .drop()
 ```
 
 `Reset()` re-enables shadows automatically each frame.
@@ -212,7 +212,7 @@ When to disable shadows:
 - **Stylized look** — Flat lighting without shadows suits certain art styles (e.g., retro pixel art).
 - **Interior scenes** — Disable directional shadows in small rooms where they add little visual value.
 
-> _**TIP**_: Disable shadows per-section rather than globally. Use `disableShadows`/`enableShadows` to skip shadows only for specific layers (e.g., background tiles) while keeping them for foreground objects.
+> _**TIP**_: Disable shadows per-section rather than globally. Use `.disableShadows(...)`/`.enableShadows(...)` to skip shadows only for specific layers (e.g., background tiles) while keeping them for foreground objects.
 
 ## See Also
 

--- a/docs/graphics2d/overview.md
+++ b/docs/graphics2d/overview.md
@@ -14,8 +14,8 @@ The 2D rendering pipeline is a **deferred command system**: each frame, your vie
 A deferred renderer means you describe *what to draw* without worrying about *when to draw it*. The renderer handles:
 
 - **Layer ordering** — Commands are sorted by `int<RenderLayer>` so backgrounds draw before foregrounds.
-- **Camera transforms** — `Draw.beginCamera` / `Draw.endCamera` bracket world-space content.
-- **Shader modes** — `Draw.beginShader` / `Draw.endShader` enable per-section effects.
+- **Camera transforms** — `.beginCamera()` / `.endCamera()` bracket world-space content.
+- **Shader modes** — `.beginShader()` / `.endShader()` enable per-section effects.
 - **Post-processing** — Screen-space shader passes applied after the scene renders.
 - **GPU batching** — the backend auto-batches standard draw calls; the renderer never interferes.
 
@@ -30,8 +30,8 @@ This is especially useful for:
 
 | Situation | Approach |
 |-----------|----------|
-| Sprites, text, shapes, tiles | Use `Draw.*` commands (deferred) |
-| Custom GPU work (e.g. raw rlgl meshes, instancing) | Use `Draw.drawImmediate` (escape hatch) |
+| Sprites, text, shapes, tiles | Use the fluent Draw members (deferred) |
+| Custom GPU work (e.g. raw rlgl meshes, instancing) | Use `.drawImmediate(...)` (escape hatch) |
 | One-off GPU operations | Prefer deferred; use immediate only when the backend lacks the API |
 
 ## How it works
@@ -48,14 +48,9 @@ Each frame, the runtime calls `myView ctx model buffer`. Your view adds commands
 3. `buffer.Sort()` — sort by layer (ascending)
 4. Execute in order, managing camera/shader state transitions
 
-## Command API layers
+## Adding commands
 
-Two ways to add commands to the buffer:
-
-| Layer | When to use |
-|-------|-------------|
-| `Draw.*` DSL | Everyday use — pipe-friendly, supports partial application |
-| `Command2D.*` factories | When you need to store or reuse commands without a buffer |
+Everyday view code chains members of the fluent Draw DSL on the buffer — see [Draw DSL](../draw-dsl.html) for the full surface.
 
 ## Lighting
 
@@ -63,11 +58,12 @@ The 2D lighting system (`Mibo.Elmish.Graphics2D.Lighting`) provides point lights
 
 ```fsharp
 buffer
-|> LightDraw.setAmbient lightingCtx (5<RenderLayer>, { Color = gray })
-|> LightDraw.addDirectionalLight lightingCtx 6<RenderLayer> { Direction = sunDir; ... }
-|> LightDraw.addPointLight lightingCtx 7<RenderLayer> { Position = torchPos; ... }
-|> LightDraw.litSprite lightingCtx playerSprite
-|> LightDraw.endLighting lightingCtx 999<RenderLayer>
+  .setAmbient(lightingCtx, gray, layer = 5<RenderLayer>)
+  .addDirectionalLight(lightingCtx, sunDir, sunColor, intensity = 1.5f, layer = 6<RenderLayer>)
+  .addPointLight(lightingCtx, torchLight, layer = 7<RenderLayer>)
+  .litSprite(lightingCtx, playerSprite)
+  .endLighting(lightingCtx, layer = 999<RenderLayer>)
+  .drop()
 ```
 
 See [Lighting & Shadows](lighting.html) for details.
@@ -82,18 +78,20 @@ let left = Camera2D.splitScreenLeft cam1 Color.CornflowerBlue
 let right = Camera2D.splitScreenRight cam2 Color.DarkGreen
 
 buffer
-|> Draw.beginCameraWith 0<RenderLayer> left
-|> // ... left viewport ...
-|> Draw.endCamera 100<RenderLayer>
-|> Draw.beginCameraWith 200<RenderLayer> right
-|> // ... right viewport ...
-|> Draw.endCamera 300<RenderLayer>
+  .beginCameraWith(left)
+  // ... left viewport ...
+  .endCamera(layer = 100<RenderLayer>)
+  .beginCameraWith(right, layer = 200<RenderLayer>)
+  // ... right viewport ...
+  .endCamera(layer = 300<RenderLayer>)
+  .drop()
 ```
 
 `Camera2DConfig` controls viewport (normalized 0–1 coordinates) and clear color. See [Camera](../camera.html) for the full API.
 
 ## Next steps
 
+- [Draw DSL](../draw-dsl.html) — The fluent, backend-neutral draw surface (2D and 3D)
 - [Buffer & Commands](buffer-and-commands.html) — How to build every type of draw command
 - [Lighting & Shadows](lighting.html) — Point, directional, ambient lights + SDF shadows
 - [Particles](particles.html) — Batched textured quads

--- a/docs/graphics2d/particles.md
+++ b/docs/graphics2d/particles.md
@@ -7,14 +7,14 @@ index: 19
 
 # 2D Particles
 
-The particle system renders textured quads in bulk. It is independent of lighting — particles can be lit (`LightDraw.litSprite`) or unlit (`ParticleDraw.particles`).
+The particle system renders textured quads in bulk. It is independent of lighting — particles can be lit (`.litSprite(...)`) or unlit (`.particles(...)`).
 
 ## Separation of concerns
 
 Particle rendering is split into two layers:
 
 1. **Simulation** — your update function handles velocities, lifetimes, physics
-2. **Render** — writes `Particle2D` snapshots, `ParticleDraw.particles` adds them to the buffer
+2. **Render** — writes `Particle2D` snapshots, `.particles(...)` adds them to the buffer
 
 ## Particle2D
 
@@ -38,10 +38,11 @@ let mutable particleCount = 0
 
 // Each frame, write active particles into the array, then draw:
 buffer
-|> ParticleDraw.particles particleTexture particles particleCount 10<RenderLayer>
+  .particles(particleTexture, particles, particleCount, layer = 10<RenderLayer>)
+  .drop()
 ```
 
-`ParticleDraw.particles` adds a single command to the buffer that draws all particles in a loop. All particles share one texture.
+`.particles(...)` adds a single command to the buffer that draws all particles in a loop. All particles share one texture.
 
 ## Simulation helpers
 
@@ -64,9 +65,9 @@ Particles with alpha ≤ 0 are removed in a single pass. The array is compacted 
 
 - All particles share one texture and one draw call — efficient for hundreds of particles.
 - Pre-allocate your array to max expected count. `fadeAndCompact` reuses slots.
-- Particles don't interact with the lighting system by default. For lit particles, draw them individually via `LightDraw.litSprite` (see [Lighting](lighting.html)).
+- Particles don't interact with the lighting system by default. For lit particles, draw them individually via `.litSprite(...)` (see [Lighting](lighting.html)).
 
 ## See Also
 
-- [Lighting & Shadows](lighting.html) — Lit particles via `LightDraw.litSprite`
+- [Lighting & Shadows](lighting.html) — Lit particles via `.litSprite(...)`
 - [Buffer & Commands](buffer-and-commands.html) — General drawing reference

--- a/docs/graphics2d/performance.md
+++ b/docs/graphics2d/performance.md
@@ -7,20 +7,25 @@ index: 17
 
 # 2D Rendering Performance
 
-## 1. Prefer `Draw.*` over `DrawImmediate`
+## 1. Prefer fluent members over `.drawImmediate(...)`
 
-The `Draw.*` DSL compiles to struct commands that the backend batches into GPU draw calls automatically. Every `DrawImmediate` call forces a batch flush (costly):
+The fluent DSL compiles to struct commands that the backend batches into GPU draw calls automatically. Every `.drawImmediate(...)` call forces a batch flush (costly):
 
 ```fsharp
 // Good: batched by the backend
 for i = 0 to 999 do
-    buffer |> Draw.fillCircle (10<RenderLayer>, Color.Red) (positions[i], 5f)
+    buffer.fillCircle(positions[i], 5f, Color.Red, layer = 10<RenderLayer>).drop()
 
 // Bad: one batch flush per call
 for i = 0 to 999 do
-    buffer |> Draw.drawImmediate 10<RenderLayer> (fun () ->
-        // raw backend draw (e.g. raylib Raylib.DrawCircleV, or MonoGame device draw)
-        ())
+    buffer
+      .drawImmediate(
+        (fun () ->
+          // raw backend draw (e.g. raylib Raylib.DrawCircleV, or MonoGame device draw)
+          ()),
+        layer = 10<RenderLayer>
+      )
+      .drop()
 ```
 
 ## 2. Group commands by layer
@@ -38,31 +43,24 @@ let groundLayer2 = 11<RenderLayer>
 let groundLayer3 = 12<RenderLayer>
 ```
 
-## 3. Use partial application for repeated styling
+## 3. Bind common arguments for repeated draws
 
-Bind style parameters once rather than passing them repeatedly:
+Bind a partially-applied call once rather than passing every argument repeatedly:
 
 ```fsharp
-// Good: partial application
-let drawHealthBar = Draw.fillRect (10<RenderLayer>, Color.Red)
-for hp in healthBars do
-    buffer |> drawHealthBar hp.Rect
+// Good: bind texture once, reuse across the batch
+let tile = fun dest -> buffer.sprite(SpriteState.create(atlas, dest, src))
+for t in visibleTiles do
+    tile t.Dest |> ignore
 
-// Less good: repeated tuples
-for hp in healthBars do
-    buffer |> Draw.fillRect (10<RenderLayer>, Color.Red) hp.Rect
+// Less good: rebuild the record every iteration
+for t in visibleTiles do
+    buffer.sprite(SpriteState.create(atlas, t.Dest, src)) |> ignore
 ```
 
 ## 4. Struct commands are already zero-allocation
 
-`Command2D` is a `[<Struct>]` discriminated union — every command is stack-allocated with no heap pressure. For custom rendering logic, use `DrawImmediate` which is also zero-allocation:
-
-```fsharp
-// Good: DrawImmediate is zero-allocation
-buffer |> Draw.drawImmediate 10<RenderLayer> (fun () ->
-    // raw backend draw (e.g. raylib Raylib.DrawCircleV, or a MonoGame device draw)
-    ())
-```
+`Command2D` is a `[<Struct>]` discriminated union — every command is stack-allocated with no heap pressure. The fluent chain itself also erases at compile time: optional parameters are struct optionals, so a chain like `.fillRect(...).sprite(...).endCamera()` leaves no trace at runtime beyond the commands it writes.
 
 ## 5. Minimize state-switching commands
 
@@ -71,10 +69,11 @@ Commands like `setBlend`, `setSamplerState`, `setScissor`, `beginCamera`, and `b
 ```fsharp
 // Good: one blend switch for all additive particles
 buffer
-|> Draw.setBlend 0<RenderLayer> BlendMode.Additive
-|> Draw.fillCircle (10<RenderLayer>, Color.Yellow) (p1, 5f)
-|> Draw.fillCircle (10<RenderLayer>, Color.Yellow) (p2, 5f)
-|> Draw.setBlend 0<RenderLayer> BlendMode.Alpha
+  .setBlend(BlendMode.Additive)
+  .fillCircle(p1, 5f, Color.Yellow, layer = 10<RenderLayer>)
+  .fillCircle(p2, 5f, Color.Yellow, layer = 10<RenderLayer>)
+  .setBlend(BlendMode.AlphaBlend)
+  .drop()
 ```
 
 ## 6. Share textures and fonts
@@ -85,14 +84,14 @@ The backend's internal batching is most efficient when consecutive draw calls us
 
 Tiles sampled from a gutterless spritesheet (no padding between tiles) bleed at the edges under linear filtering, producing dark seams between abutting tiles.
 
-**MonoGame:** use `Draw.setSamplerState layer SamplerState.PointClamp` for the tile draws — point filtering reads exact texels, so there's no bleed. Note it flushes the batch, so group tile draws together. Alternatively, inset each tile's source rectangle by 1px.
+**MonoGame:** use `.setSamplerState(SamplerState.PointClamp)` for the tile draws — point filtering reads exact texels, so there's no bleed. Note it flushes the batch, so group tile draws together. Alternatively, inset each tile's source rectangle by 1px.
 
 ```fsharp
 // Point filtering stops adjacent tiles from bleeding into each other.
-buffer |> Draw.setSamplerState 0<RenderLayer> SamplerState.PointClamp
+buffer.setSamplerState(SamplerState.PointClamp).drop()
 
 for tile in visibleTiles do
-    buffer |> Draw.sprite (SpriteState.create (atlas, tile.Dest, tile.Src)) |> ignore
+    buffer.sprite(SpriteState.create(atlas, tile.Dest, tile.Src)).drop()
 ```
 
 **raylib:** there is no per-draw sampler — a texture's filter is set on the texture itself. Use the `Texture.filter` helper once at load time (e.g. `assets.Texture "tiles.png" |> Texture.filter TextureFilter.Point`), or inset source rectangles by 1px.
@@ -110,7 +109,7 @@ let viewBounds = Camera2D.viewportBounds camera viewportWidth viewportHeight
 
 for entity in entities do
     if Culling.isVisible2D viewBounds entity.Bounds then
-        buffer |> Draw.sprite { ... }
+        buffer.sprite(entity.Sprite).drop()
 ```
 
 See [Culling](../culling.html).
@@ -120,6 +119,6 @@ See [Culling](../culling.html).
 If you suspect a rendering bottleneck:
 
 - Reduce command count to isolate the issue
-- Check for unintended `DrawImmediate` calls
+- Check for unintended `.drawImmediate(...)` calls
 - Verify layer count is reasonable
 - Use your backend's built-in profiling or a GPU debugger to check draw-call count

--- a/docs/graphics3d/buffer-and-commands.md
+++ b/docs/graphics3d/buffer-and-commands.md
@@ -7,7 +7,7 @@ index: 21
 
 # 3D Buffer & Commands
 
-Your view function receives a `RenderBuffer3D` each frame. You populate it with drawing commands using the `Draw3D` module. The renderer dispatches them in order.
+Your view function receives a `RenderBuffer3D` each frame and populates it with drawing commands via the fluent Draw DSL. The renderer dispatches them in order.
 
 ## What and Why
 
@@ -28,93 +28,89 @@ The buffer is **pre-cleared** each frame. Just add commands:
 ```fsharp
 let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer3D) =
     buffer
-    |> Draw3D.beginCamera camera
-    |> Draw3D.drawModel model.PlayerModel model.PlayerTransform
-    |> Draw3D.endCamera
-    |> Draw3D.drop
+      .beginCamera(camera)
+      .model(model.PlayerModel, model.PlayerTransform)
+      .endCamera()
+      .drop()
 ```
 
-`Draw3D.drop` at the end silences the unused-value warning. It does nothing.
+`.drop()` at the end silences the unused-value warning. It does nothing.
 
 ## Pipeline pattern
 
 Every 3D view follows the same structure:
 
-```
+```fsharp
 buffer
-|> Draw3D.beginCamera camera       // start camera transform
-|> Draw3D.setAmbientLight ...      // lighting setup
-|> Draw3D.addDirectionalLight ...
-|> Draw3D.drawModel ...            // geometry
-|> Draw3D.endCamera                // end camera transform
-|> Draw3D.drop                     // terminal
+  .beginCamera(camera)       // start camera transform
+  .setAmbientLight ...       // lighting setup
+  .addDirectionalLight ...
+  .model ...                 // geometry
+  .endCamera()               // end camera transform
+  .drop()                    // terminal
 ```
 
-> _**IMPORTANT**_: Geometry drawn outside `beginCamera` / `endCamera` renders in screen space. This is rarely what you want.
+> _**IMPORTANT**_: Geometry drawn outside `.beginCamera(...)` / `.endCamera()` renders in screen space. This is rarely what you want.
 
 ## Geometry commands
 
-The lighting/camera/shadow commands are identical across backends. The **geometry** commands
-differ where the mesh type differs (raylib `Mesh` / MonoGame `PrimitiveMesh`):
+One member set covers both backends — the buffer takes your backend's own mesh (`Mesh` / `PrimitiveMesh`), model, material, and transform types:
 
-| Function | raylib | MonoGame |
-|----------|--------|----------|
-| `Draw3D.drawMesh` / `drawPrimitive` | `drawMesh mesh transform material` | `drawPrimitive mesh transform material` |
-| `Draw3D.drawModel` | `drawModel model transform` | `drawModel model transform` |
-| `Draw3D.modelWith` / `modelWithPerMesh` | `modelWith model transform material` · `modelWithPerMesh model transform resolver` | same (overrides a model's baked material, whole or per-sub-mesh) |
-| `Draw3D.drawBillboard` | `drawBillboard texture position size color` | `drawBillboard texture position size color` |
-| `Draw3D.drawBillboardBatch` | batched billboards | batched billboards |
-| `Draw3D.drawLine3D` | `drawLine3D start finish color` | `drawLine3D start finish color` |
-| Skinned/animated | `drawSkinnedMesh mesh transform material bones` (material supplied directly) | `drawAnimatedModel animatedModel transform` · `animatedModelWith` / `animatedModelWithPerMesh` to override its material |
-| Instanced | `drawMeshInstanced mesh transforms material count` | `drawInstanced mesh transforms material count` |
+| Member | What it draws |
+|--------|---------------|
+| `.mesh(mesh, transform, material)` | Single primitive mesh |
+| `.model(model, transform)` | A loaded model with authored materials |
+| `.modelWith(model, transform, material)` | Model with whole-model material override |
+| `.modelWithPerMesh(model, transform, resolver)` | Model with per-mesh-part material override |
+| `.animatedModel(animModel, transform)` | Skeletal animation — bone palette derived for you |
+| `.animatedModelWith(...)` / `.animatedModelWithPerMesh(...)` | Animated model + material override |
+| `.skinnedMesh(mesh, transform, material, bones)` | Explicit bone palette (**raylib only**) |
+| `.instanced(mesh, transforms, material, count)` | Many copies of one mesh in one draw call |
+| `.billboard(tex, position, size, color)` | Camera-facing quad |
+| `.billboardBatch(...)` | Batched billboards |
+| `.line3D(start, finish, color)` | Debug line |
 
 > _**TIP**_: Use the instanced/batched variants when drawing many copies of the same thing. One draw call is faster than many.
 
 ## Camera commands
 
-| Function | Description |
-|----------|-------------|
-| `Draw3D.beginCamera camera` | Start 3D camera transform |
-| `Draw3D.beginCameraWith config` | Start camera with explicit viewport/clear/post-process |
-| `Draw3D.endCamera` | End camera transform |
+| Member | Description |
+|--------|-------------|
+| `.beginCamera(camera)` | Start 3D camera transform |
+| `.beginCameraWith(config)` | Start camera with explicit viewport/clear/post-process |
+| `.endCamera()` | End camera transform |
 
 ## Lighting commands
 
-| Function | Description |
-|----------|-------------|
-| `Draw3D.setAmbientLight light` | Set scene ambient light |
-| `Draw3D.addDirectionalLight light` | Add a directional light |
-| `Draw3D.addPointLight light` | Add a point light |
-| `Draw3D.addSpotLight light` | Add a spot light |
+| Member | Description |
+|--------|-------------|
+| `.setAmbientLight(light)` | Set scene ambient light |
+| `.addDirectionalLight(light)` | Add a directional light |
+| `.addPointLight(light)` | Add a point light |
+| `.addSpotLight(light)` | Add a spot light |
 
 ## Shadow commands
 
-| Function | Description |
-|----------|-------------|
-| `Draw3D.setShadowOrigin origin` | Set shadow map origin for this frame |
-| `Draw3D.enableShadows` | Enable shadow casting for subsequent geometry |
-| `Draw3D.disableShadows` | Disable shadow casting for subsequent geometry |
+| Member | Description |
+|--------|-------------|
+| `.setShadowOrigin(origin)` | Set shadow map origin for this frame |
+| `.enableShadows()` | Enable shadow casting for subsequent geometry |
+| `.disableShadows()` | Disable shadow casting for subsequent geometry |
 
 ## Escape hatches
 
-| Function | Description |
-|----------|-------------|
-| `Draw3D.drawImmediate action` | Flush batch, run raw backend calls (rlgl/raylib, or MonoGame device access via `SceneContext`), restore state |
-
-On MonoGame, also see `Draw3D.beginEffect`/`endEffect` (custom shading scope that inherits scene data) and `Draw3D.drawMeshEffect` (fully user-owned effect). See [Overview](overview.html#escape-hatches).
+`.drawImmediate(...)` flushes the batch, runs raw backend calls (rlgl/raylib, or MonoGame device access via `SceneContext`), and restores state. On MonoGame, also see `.beginEffect(...)`/`.endEffect()` (custom shading scope that inherits scene data). See [Overview](overview.html#escape-hatches).
 
 ## Camera config
 
-Use `beginCameraWith` when you need viewport control, clear color, or post-process pass selection:
+Use `.beginCameraWith(...)` when you need viewport control, clear color, or post-process pass selection:
 
 ```fsharp
 buffer
-|> Draw3D.beginCameraWith(
-    Camera3D.render camera |> Camera3D.withClear Color.SkyBlue
-)
-|> Draw3D.drawModel model transform
-|> Draw3D.endCamera
-|> Draw3D.drop
+  .beginCameraWith(Camera3D.render camera |> Camera3D.withClear Color.SkyBlue)
+  .model(model, transform)
+  .endCamera()
+  .drop()
 ```
 
 `Camera3DConfig` fields:
@@ -131,49 +127,32 @@ Add lights before geometry. Lights affect all subsequent draws:
 
 ```fsharp
 buffer
-|> Draw3D.beginCamera camera
-|> Draw3D.setAmbientLight { Color = Color.White; Intensity = 0.3f }
-|> Draw3D.addDirectionalLight {
+  .beginCamera(camera)
+  .setAmbientLight { Color = Color.White; Intensity = 0.3f }
+  .addDirectionalLight {
     Direction = Vector3(-1f, -1f, -1f)
     Color = Color.White
     Intensity = 0.8f
     CastsShadows = true
-}
-|> Draw3D.addPointLight {
+  }
+  .addPointLight {
     Position = Vector3(5f, 3f, 0f)
     Color = Color.Yellow
     Intensity = 1f
     Radius = 10f
     CastsShadows = false
     ShadowBias = ValueNone
-}
-|> Draw3D.drawModel model transform
-|> Draw3D.endCamera
-|> Draw3D.drop
+  }
+  .model(model, transform)
+  .endCamera()
+  .drop()
 ```
 
-> _**TIP**_: You can call `addPointLight` in a loop for dynamic lights. The sample does this for visible lights each frame.
-
-## Two ways to build commands
-
-| Layer | When to use |
-|-------|-------------|
-| `Draw3D.*` DSL | Everyday use — pipe-friendly, buffer-last for chaining |
-| `Command3D.*` factories | When you need to store or reuse commands without a buffer |
-
-```fsharp
-// DSL — pipe-friendly
-buffer
-|> Draw3D.drawMesh mesh transform material
-|> Draw3D.drawModel model transform
-
-// Factory — store for later
-let cmd = Command3D.drawMesh mesh transform material
-buffer.Add(cmd)
-```
+> _**TIP**_: You can call `.addPointLight(...)` in a loop for dynamic lights.
 
 ## See also
 
+- [Draw DSL](../draw-dsl.html) — the full fluent draw surface (2D and 3D)
 - [Overview](overview.html) — Architecture and pipeline setup
 - [Lighting](lighting.html) — Light types and configuration
 - [Materials](materials.html) — PBR material system

--- a/docs/graphics3d/instancing.md
+++ b/docs/graphics3d/instancing.md
@@ -19,13 +19,13 @@ This is the key to rendering voxel worlds, forests, or any scene with high objec
 
 | Situation | Approach |
 |-----------|----------|
-| < 50 identical objects | `Draw3D.drawMesh` per object (simpler) |
-| 50–10,000+ identical objects | `Draw3D.drawMeshInstanced` (one draw call) |
+| < 50 identical objects | `.mesh(...)` per object (simpler) |
+| 50–10,000+ identical objects | `.instanced(...)` (one draw call) |
 | Cell grid (voxels, tiles) | `CellGridRenderer3D.renderInstanced` (automatic grouping) |
 
-## Draw3D.drawMeshInstanced
+## Instanced draws
 
-The low-level instanced draw command. You provide the mesh, an array of transforms, material, and count:
+The low-level instanced draw member. You provide the mesh, an array of transforms, material, and count:
 
 ```fsharp
 let transforms =
@@ -34,14 +34,15 @@ let transforms =
     |]
 
 buffer
-|> Draw3D.drawMeshInstanced Primitive3D.cube transforms material 100
+  .instanced(Primitive3D.cube, transforms, material, 100)
+  .drop()
 ```
 
-One draw call renders all 100 cubes.
+One draw call renders all 100 cubes. (On MonoGame, pass `prims.Cube` and `Matrix[]` transforms — the member takes your backend's mesh and matrix types.)
 
 ## InstancedRenderContext for cell grids
 
-For grid-based worlds (voxels, tile maps), `InstancedRenderContext<'T, 'K>` handles grouping and batching automatically. It groups cells by a key function, then emits one `DrawMeshInstanced` per group per sub-mesh.
+For grid-based worlds (voxels, tile maps), `InstancedRenderContext<'T, 'K>` handles grouping and batching automatically. It groups cells by a key function, then emits one instanced draw per group per sub-mesh.
 
 ### Create the context
 
@@ -77,9 +78,7 @@ Three lambda parameters:
 
 ```fsharp
 let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer3D) =
-    buffer
-    |> Draw3D.beginCamera camera
-    |> Draw3D.setAmbientLight (AmbientLight3D.create (Color(40, 40, 40, 255)))
+    buffer.beginCamera(camera).setAmbientLight(AmbientLight3D.create (Color(40, 40, 40, 255))).drop()
     // ... lights ...
 
     // Reset pooled buffers before rendering
@@ -92,8 +91,7 @@ let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer3D) =
     CellGridRenderer3D.renderVolumeInstanced instancedCtx viewBounds model.World buffer
 
     // ... other geometry ...
-    |> Draw3D.endCamera
-    |> Draw3D.drop
+    buffer.endCamera().drop()
 ```
 
 > _**IMPORTANT**_: Call `instancedCtx.ResetFrameBuffers()` once per frame **before** rendering. This returns pooled arrays to `ArrayPool` and prevents memory leaks.
@@ -116,7 +114,7 @@ CellGridRenderer3D.renderVolumeInstanced instancedCtx bounds model.World buffer
 1. `renderInstanced` iterates all cells in the grid.
 2. Each cell's key is computed via `getKey`.
 3. Transforms are accumulated into per-key `ResizeArray<Matrix4x4>`.
-4. After iteration, each group emits one `Command3D.DrawMeshInstanced` per sub-mesh.
+4. After iteration, each group emits one instanced draw command per sub-mesh.
 5. Arrays are rented from `ArrayPool<Matrix4x4>.Shared` to avoid GC pressure.
 
 The pipeline renders all instances of a mesh type in a single GPU draw call using the instanced shader.
@@ -125,7 +123,7 @@ The pipeline renders all instances of a mesh type in a single GPU draw call usin
 
 Instanced draws normally use the built-in PBR instanced shader. To shade them
 with your own effect — for a toon, water, fog, or other stylized look — wrap
-the instanced draw in a `Draw3D.beginEffect` / `endEffect` scope and have your
+the instanced draw in a `.beginEffect(...)` / `.endEffect()` scope and have your
 shader opt into instancing.
 
 The opt-in is by declaration, and the declaration differs by backend because
@@ -180,5 +178,5 @@ Air cells produce no draw calls. Stone, dirt, and grass each batch into one inst
 ## See also
 
 - [Overview](overview.html) — Architecture and pipeline setup
-- [Buffer & Commands](buffer-and-commands.html) — All `Draw3D.*` functions
+- [Draw DSL](../draw-dsl.html) — The fluent draw surface
 - [Materials](materials.html) — PBR material system

--- a/docs/graphics3d/lighting.md
+++ b/docs/graphics3d/lighting.md
@@ -5,9 +5,10 @@ categoryindex: 5
 index: 22
 ---
 
+
 # 3D Lighting
 
-The built-in forward pipelines support four light types with Cook-Torrance PBR shading. Lights are added per-frame via `Draw3D.*` commands inside your view function. (On raylib the pipeline is `ForwardPbrPipeline`; on MonoGame it is `ForwardPipeline`.)
+The built-in forward pipelines support four light types with Cook-Torrance PBR shading. Lights are added per-frame via fluent members inside your view function. (On raylib the pipeline is `ForwardPbrPipeline`; on MonoGame it is `ForwardPipeline`.)
 
 ## What and Why
 
@@ -23,29 +24,29 @@ All lights are struct types with builder functions. The pipeline uploads them as
 ```fsharp
 let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer3D) =
     buffer
-    |> Draw3D.beginCamera camera
-    // Ambient
-    |> Draw3D.setAmbientLight (AmbientLight3D.create (Color(30, 30, 30, 255)))
-    // Directional (sun)
-    |> Draw3D.addDirectionalLight (
+      .beginCamera(camera)
+      // Ambient
+      .setAmbientLight(AmbientLight3D.create (Color(30, 30, 30, 255)))
+      // Directional (sun)
+      .addDirectionalLight(
         DirectionalLight3D.create (Vector3(0.3f, -0.7f, -0.5f))
         |> DirectionalLight3D.withIntensity 0.8f
-    )
-    // Point light (torch)
-    |> Draw3D.addPointLight (
+      )
+      // Point light (torch)
+      .addPointLight(
         PointLight3D.create (torchPos, 10f)
         |> PointLight3D.withColor Color.Orange
         |> PointLight3D.withIntensity 1.5f
         |> PointLight3D.withCastsShadows true
-    )
-    // Spot light (flashlight)
-    |> Draw3D.addSpotLight (
+      )
+      // Spot light (flashlight)
+      .addSpotLight(
         SpotLight3D.create (camPos, camDir, 20f)
         |> SpotLight3D.withIntensity 2.0f
-    )
-    |> Draw3D.drawModel model.PlayerModel model.PlayerTransform
-    |> Draw3D.endCamera
-    |> Draw3D.drop
+      )
+      .model(model.PlayerModel, model.PlayerTransform)
+      .endCamera()
+      .drop()
 ```
 
 ## Light types
@@ -248,5 +249,5 @@ let pipeline = ForwardPipeline(
 ## See also
 
 - [Overview](overview.html) — Architecture and pipeline setup
-- [Buffer & Commands](buffer-and-commands.html) — All `Draw3D.*` functions
+- [Buffer & Commands](buffer-and-commands.html) — The buffer pipeline pattern
 - [Materials](materials.html) — PBR material system

--- a/docs/graphics3d/materials.md
+++ b/docs/graphics3d/materials.md
@@ -41,9 +41,10 @@ let woodMat =
     { Material3D.defaults with Roughness = 0.8f }
     |> Material3D.withAlbedoMap woodTexture
 
-// In your view:
+// In your view (MonoGame shown; raylib passes its own Mesh):
 buffer
-|> Draw3D.drawMesh Primitive3D.cube transform metalMat
+  .mesh(prims.Cube, transform, metalMat)
+  .drop()
 ```
 
 ## Material3D fields
@@ -129,7 +130,7 @@ for mesh in model.Meshes do
         let mat = Material3D.fromModelMeshPart part
 ```
 
-In both cases the `Draw3D.drawModel` function does this conversion automatically for all
+In both cases the `.model(...)` member does this conversion automatically for all
 sub-meshes — use it when you don't need per-mesh control. On MonoGame only the albedo color,
 albedo map, and opacity are extracted from native effects (normal/roughness/metallic maps are
 not carried by MonoGame's standard effects); assign the remaining PBR maps explicitly if needed.
@@ -146,8 +147,8 @@ Use for UI elements, debug markers, or anything that should appear at full brigh
 
 ## Primitive meshes
 
-Use the backend's primitive meshes with `Draw3D` for basic shapes. The mesh type differs by
-backend (raylib `Mesh` / MonoGame `PrimitiveMesh`), so the access and draw call differ:
+The backend provides primitive meshes for basic shapes. The mesh type differs by
+backend (raylib `Mesh` / MonoGame `PrimitiveMesh`), and `.mesh(...)` takes whichever yours has:
 
 | Shape | raylib | MonoGame |
 |-------|--------|----------|
@@ -161,39 +162,39 @@ backend (raylib `Mesh` / MonoGame `PrimitiveMesh`), so the access and draw call 
 ```fsharp
 // raylib:
 let transform = Matrix4x4.CreateScale(2f, 1f, 3f) * Matrix4x4.CreateTranslation(pos)
-buffer |> Draw3D.drawMesh Primitive3D.cube transform mat
+buffer.mesh(Primitive3D.cube, transform, mat).drop()
 
 // MonoGame — build the primitive set once (needs the GraphicsDevice), then draw:
 let prims = Primitive3D.create gd
 let transform = Matrix.CreateScale(2f, 1f, 3f) * Matrix.CreateTranslation(pos)
-buffer |> Draw3D.drawPrimitive prims.Cube transform mat
+buffer.mesh(prims.Cube, transform, mat).drop()
 ```
 
-> _**IMPORTANT**_: Use the pipeline's draw functions (`drawMesh`/`drawPrimitive`) instead of
-> backend-native immediate draws (e.g. `Raylib.DrawCube`). Direct native draws bypass the
-> pipeline's shader and won't receive PBR lighting or shadows.
-
-> _**IMPORTANT**_: Use `Draw3D.drawMesh` with `Primitive3D.*` instead of `Raylib.DrawCube` etc. Direct raylib draws bypass the pipeline's shader and won't receive PBR lighting or shadows.
+> _**IMPORTANT**_: Use `.mesh(...)` with these primitives instead of backend-native immediate
+> draws (e.g. `Raylib.DrawCube`). Direct native draws bypass the pipeline's shader and won't
+> receive PBR lighting or shadows.
 
 ## Overriding a model's material
 
-`Draw3D.drawModel` always renders with the material baked into the file (auto-extracted per
+`.model(...)` always renders with the material baked into the file (auto-extracted per
 sub-mesh, as described above). When you want a different material — the authored values look
 wrong, you want to reuse one mesh for several looks (gold/silver/bronze variants of the same
-model), or you need a flat/debug material — use the override helpers instead of iterating the
+model), or you need a flat/debug material — use the override members instead of iterating the
 model's meshes by hand:
 
 ```fsharp
 // Whole-model override — every sub-mesh uses the supplied material
-buffer |> Draw3D.modelWith model transform (Material3D.colored Color.Gold)
+buffer.modelWith(model, transform, Material3D.colored Color.Gold).drop()
 
 // Per-sub-mesh override — a resolver returns the material for each sub-mesh
-buffer |> Draw3D.modelWithPerMesh model transform (fun i ->
+buffer
+  .modelWithPerMesh(model, transform, fun i ->
     if i = 0 then Material3D.colored Color.Gold else Material3D.defaults)
+  .drop()
 ```
 
 The override goes through the normal PBR and shadow path, so it is lit and shadowed just like
-an authored material. The default `Draw3D.drawModel` path is unchanged — overriding is opt-in
+an authored material. The default `.model(...)` path is unchanged — overriding is opt-in
 and costs nothing when you don't use it.
 
 **Resolver index.** The `int -> Material3D` resolver is indexed by the pipeline's sub-mesh
@@ -204,20 +205,20 @@ iteration order, which differs by backend because the native model types differ:
 
 Write the resolver against your specific model's structure; it is not portable across backends.
 
-**Animated models (MonoGame only).** MonoGame's `Draw3D.drawAnimatedModel` carries no material
-(it auto-extracts per part, like `drawModel`), so the same override pair exists for it:
+**Animated models.** MonoGame's animated draw carries no material (it auto-extracts per part,
+like `.model(...)`), so the same override pair exists for it:
 
 ```fsharp
-buffer |> Draw3D.animatedModelWith animatedModel transform material
-buffer |> Draw3D.animatedModelWithPerMesh animatedModel transform resolver
+buffer.animatedModelWith(animatedModel, transform, material).drop()
+buffer.animatedModelWithPerMesh(animatedModel, transform, resolver).drop()
 ```
 
-On raylib, animated meshes are drawn with `Draw3D.drawSkinnedMesh`, which already takes a
+On raylib, explicit-palette skinned draws go through `.skinnedMesh(...)`, which already takes a
 `Material3D` directly — supply the material you want there; no separate override helper is
 needed.
 
 ## See also
 
 - [Overview](overview.html) — Architecture and pipeline setup
-- [Buffer & Commands](buffer-and-commands.html) — All `Draw3D.*` functions
+- [Draw DSL](../draw-dsl.html) — The fluent draw surface
 - [Lighting](lighting.html) — Light types and shadow configuration

--- a/docs/graphics3d/overview.md
+++ b/docs/graphics3d/overview.md
@@ -7,7 +7,7 @@ index: 12
 
 # 3D Rendering
 
-The 3D rendering pipeline is a **deferred command system** with a pluggable `IRenderPipeline3D`. Each frame, your view function populates a `RenderBuffer3D` with `Command3D` values, and the pipeline executes them. The architecture is identical on both backends; only the pipeline class name, the shader language, and some geometry-command names differ (see below).
+The 3D rendering pipeline is a **deferred command system** with a pluggable `IRenderPipeline3D`. Each frame, your view function populates a `RenderBuffer3D` with commands, and the pipeline executes them. The architecture is identical on both backends; only the pipeline class name and the shader language differ.
 
 ## What and Why
 
@@ -18,8 +18,8 @@ The 3D renderer provides:
   - **raylib:** `ForwardPbrPipeline` (GLSL shaders)
   - **MonoGame:** `ForwardPipeline` (HLSL `.fx` → `.mgfx`, compiled for DirectX 11 and OpenGL)
 - **3D lighting** — Ambient, directional, point, and spot lights with shadow mapping.
-- **Instanced rendering** — One draw call for many copies of the same geometry (`drawMeshInstanced` on raylib; `drawInstanced` on MonoGame), plus batched billboards.
-- **Custom shading opt-in** — raylib via `Draw3D.drawImmediate` (raw rlgl/raylib); MonoGame via `Draw3D.beginEffect`/`endEffect` (a user `Effect` that inherits the gathered scene data) or `Draw3D.drawMeshEffect`.
+- **Instanced rendering** — One draw call for many copies of the same geometry (`.instanced(...)`), plus batched billboards.
+- **Custom shading opt-in** — `.beginEffect(...)`/`.endEffect()` scopes (a user shader/effect that inherits the gathered scene data), `.drawImmediate(...)` for raw access, and MonoGame's per-mesh-part effect draw.
 - **Camera configs** — `Camera3DConfig` with viewport, clear color, and post-process control.
 
 ## Quick start
@@ -35,51 +35,41 @@ Program.mkProgram init update
 |> Program.withRenderer (fun () -> Renderer3D.create pipeline view)
 ````
 
-Your view function receives a `RenderBuffer3D`:
+Your view function receives a `RenderBuffer3D` and chains members of the fluent Draw DSL (see [Draw DSL](../draw-dsl.html)):
 
 ```fsharp
 let view (ctx: GameContext) (model: Model) (buffer: RenderBuffer3D) =
     buffer
-    |> Draw3D.beginCamera worldCamera
-    |> Draw3D.setAmbientLight { Color = Color(40, 40, 40); Intensity = 1f }
-    |> Draw3D.addDirectionalLight {
+      .beginCamera(worldCamera)
+      .setAmbientLight { Color = Color(40, 40, 40); Intensity = 1f }
+      .addDirectionalLight {
         Direction = Vector3(0.3f, -0.7f, 0.2f)
         Color = Color.White
         Intensity = 0.8f
         CastsShadows = true
         ShadowBias = ValueNone
-    }
-    |> Draw3D.drawModel playerModel playerTransform
-    |> Draw3D.endCamera
-    |> Draw3D.drop
+      }
+      .model(playerModel, playerTransform)
+      .endCamera()
+      .drop()
 ```
-
-## Command API
-
-Two ways to add commands to the buffer:
-
-| Layer | When to use |
-|-------|-------------|
-| `Draw3D.*` DSL | Everyday use — pipe-friendly, supports partial application |
-| `Command3D.*` factories | When you need to store or reuse commands without a buffer |
 
 ## Geometry commands
 
-The lighting/camera/shadow commands are identical across backends. The **geometry** commands share most names but differ where the underlying mesh type differs:
+One member set covers both backends — the buffer takes your backend's own mesh/model/material types, and the transform type (`System.Numerics.Matrix4x4` on raylib, `Microsoft.Xna.Framework.Matrix` on MonoGame):
 
-| Command | raylib | MonoGame |
-|---------|--------|----------|
-| Draw a loaded model | `drawModel model transform` | `drawModel model transform` |
-| Single primitive mesh | `drawMesh mesh transform material` (`Mesh`) | `drawPrimitive mesh transform material` (`PrimitiveMesh`) |
-| Instanced mesh | `drawMeshInstanced mesh transforms material count` | `drawInstanced mesh transforms material count` |
-| Skeletal/animated | `drawSkinnedMesh mesh transform material bones` | `drawAnimatedModel animatedModel transform` (bones derived internally) |
-| Billboard | `drawBillboard texture position size color` | `drawBillboard texture position size color` |
-| Batched billboards | `drawBillboardBatch ...` | `drawBillboardBatch ...` |
-| Debug line | `drawLine3D start finish color` | `drawLine3D start finish color` |
-
-> _**NOTE**_: On raylib the transform is `System.Numerics.Matrix4x4`; on MonoGame it is
-> `Microsoft.Xna.Framework.Matrix`. The `Draw3D.*` DSL takes whichever your backend uses; the
-> Core layout geometry converts at the boundary.
+| Member | What it draws |
+|--------|---------------|
+| `.model(model, transform)` | A loaded model with its authored materials |
+| `.modelWith(model, transform, material)` | Model with a whole-model material override |
+| `.modelWithPerMesh(model, transform, resolver)` | Model with a per-mesh-part material resolver |
+| `.mesh(mesh, transform, material)` | Single primitive mesh (raylib `Mesh` / MonoGame `PrimitiveMesh`) |
+| `.instanced(mesh, transforms, material, count)` | Many copies of one mesh in one draw call |
+| `.animatedModel(animModel, transform)` | Skeletal animation (bone palette derived for you) |
+| `.skinnedMesh(mesh, transform, material, bones)` | Explicit bone palette (**raylib only**) |
+| `.billboard(tex, position, size, color)` | Camera-facing quad |
+| `.billboardBatch(textures, positions, sizes, colors, count)` | Batched billboards |
+| `.line3D(start, finish, color)` | Debug line |
 
 ## Lighting
 
@@ -88,25 +78,26 @@ The lighting/camera/shadow commands are identical across backends. The **geometr
 
 ```fsharp
 buffer
-|> Draw3D.setAmbientLight { Color = Color(30, 30, 30); Intensity = 1f }
-|> Draw3D.addDirectionalLight {
+  .setAmbientLight { Color = Color(30, 30, 30); Intensity = 1f }
+  .addDirectionalLight {
     Direction = Vector3(0f, -1f, 0f)
     Color = Color.White; Intensity = 0.8f
     CastsShadows = true
-}
-|> Draw3D.addPointLight {
+  }
+  .addPointLight {
     Position = Vector3(5f, 3f, 0f)
     Color = Color.Orange; Intensity = 1f
     Radius = 10f; Falloff = 2f
     CastsShadows = false; ShadowBias = ValueNone
-}
-|> Draw3D.addSpotLight {
+  }
+  .addSpotLight {
     Position = Vector3(0f, 5f, 0f)
     Direction = Vector3(0f, -1f, 0f)
     Color = Color.White; Intensity = 1f
     Radius = 15f; InnerCutoff = 0.5f; OuterCutoff = 0.7f
     CastsShadows = true; ShadowBias = ValueNone
-}
+  }
+  .drop()
 ```
 
 See [Lighting](lighting.html) for the light-type fields and shadow configuration.
@@ -117,10 +108,11 @@ Enable or disable shadow casting per-section:
 
 ```fsharp
 buffer
-|> Draw3D.enableShadows
-|> Draw3D.drawModel groundModel groundTransform   // casts shadows
-|> Draw3D.disableShadows
-|> Draw3D.drawModel skyboxModel skyboxTransform   // no shadows
+  .enableShadows()
+  .model(groundModel, groundTransform)   // casts shadows
+  .disableShadows()
+  .model(skyboxModel, skyboxTransform)   // no shadows
+  .drop()
 ```
 
 ## Post-processing
@@ -132,10 +124,10 @@ passes ping-pong through pooled render targets.
 
 Two entry points:
 
-| Function | Depth available? | When to use |
-|----------|-----------------|-------------|
-| `Draw3D.postProcess action` | No (`Context.Depth = ValueNone`) | Color-only effects: desaturation, vignette, tone mapping, blur |
-| `Draw3D.postProcessWithDepth action` | Yes (`Context.Depth = ValueSome`) | Distance effects: fog, depth-of-field, SSAO |
+| Member | Depth available? | When to use |
+|--------|-----------------|-------------|
+| `.postProcess(action)` | No (`Context.Depth = ValueNone`) | Color-only effects: desaturation, vignette, tone mapping, blur |
+| `.postProcessWithDepth(action)` | Yes (`Context.Depth = ValueSome`) | Distance effects: fog, depth-of-field, SSAO |
 
 Use plain `postProcess` when you don't sample depth — the pipeline skips the
 depth-production cost entirely. Emit passes conditionally from the view (e.g. only
@@ -145,22 +137,22 @@ while a hit-flash is active).
 // Color-only: desaturate the scene while a hit-flash is active
 if isHitFlash model then
     buffer
-    |> Draw3D.postProcess (fun ctx ->
+      .postProcess(fun ctx ->
         // ctx.Source is the scene render target (or the previous pass's output)
         // Draw a fullscreen quad of it with your shader...
         drawFullscreenQuad ctx.Source myShader)
-    |> Draw3D.drop
+      .drop()
 ```
 
 ### Depth-aware post-processing
 
-`postProcessWithDepth` gives the action a `PostProcessContext3D` whose `Depth`
+`.postProcessWithDepth(...)` gives the action a `PostProcessContext3D` whose `Depth`
 field is a camera-POV depth texture. Sample it and linearize with the camera's
 near/far planes to get view-space distance:
 
 ```fsharp
 buffer
-|> Draw3D.postProcessWithDepth (fun ctx ->
+  .postProcessWithDepth(fun ctx ->
     // ctx.Source — the scene color (Texture2D / RenderTarget2D)
     // ctx.Depth — camera-POV depth (ValueSome Texture2D, NDC z in [0,1])
     // ctx.Width, ctx.Height — dimensions
@@ -169,7 +161,7 @@ buffer
     | ValueSome depthTex -> // bind depthTex, apply distance effect
     | ValueNone ->          // no depth — draw the scene through unchanged
     ())
-|> Draw3D.drop
+  .drop()
 ```
 
 ### Depth texture contract
@@ -236,12 +228,13 @@ let minimapConfig =
     |> Camera3D.withClear Color.Black
 
 buffer
-|> Draw3D.beginCameraWith mainConfig
-|> // ... main scene ...
-|> Draw3D.endCamera
-|> Draw3D.beginCameraWith minimapConfig
-|> // ... minimap ...
-|> Draw3D.endCamera
+  .beginCameraWith(mainConfig)
+  // ... main scene ...
+  .endCamera()
+  .beginCameraWith(minimapConfig)
+  // ... minimap ...
+  .endCamera()
+  .drop()
 ```
 
 > _**NOTE — viewport coordinates differ by backend.**_ On raylib, `Camera3DConfig.Viewport`
@@ -270,34 +263,36 @@ The 2D renderer clears with `ValueNone` to preserve the 3D scene underneath.
 
 Each backend exposes a way to run custom GPU work outside the deferred command buffer:
 
-**raylib** — `drawImmediate` runs raw rlgl/raylib calls (the batch is flushed and state restored):
+**raylib** — `.drawImmediate(...)` runs raw rlgl/raylib calls (the batch is flushed and state restored):
 
 ```fsharp
 buffer
-|> Draw3D.drawImmediate (fun () ->
+  .drawImmediate(fun () ->
     Raylib.DrawCube(Vector3.Zero, 1f, 1f, 1f, Color.Red))
+  .drop()
 ```
 
 **MonoGame** — two options:
-- `beginEffect` / `endEffect` open a **shading scope**: draws inside are shaded by a user
+- `.beginEffect(...)` / `.endEffect()` open a **shading scope**: draws inside are shaded by a user
   `Effect` that *inherits* the gathered scene data (camera matrices, lights, the shadow pass
   output, material, bones, frame time) — you only declare the uniforms your effect consumes
   (e.g. `dirLightDir`, `boneMatrices`, `shadowViewProjs`, `time`). Ideal for toon/cel/wireframe
-  without re-implementing the scene gather. The scope closes at `endEffect` or the next `endCamera`.
+  without re-implementing the scene gather. The scope closes at `.endEffect()` or the next
+  `.endCamera()`.
 
   ```fsharp
   buffer
-  |> Draw3D.beginCamera camera
-  |> Draw3D.beginEffect toonEffect
-  |> Draw3D.drawModel model transform
-  |> Draw3D.endEffect
-  |> Draw3D.endCamera
+    .beginCamera(camera)
+    .beginEffect(toonEffect)
+    .model(model, transform)
+    .endEffect()
+    .endCamera()
+    .drop()
   ```
 
-- `drawMeshEffect meshPart transform effect` is a fully user-owned effect (the pipeline only
-  sets World/View/Projection); the caller owns all lighting/material parameters.
-- `drawImmediate` (callback receives a `SceneContext` with the graphics device + gathered scene
-  data) for raw device access.
+- A per-mesh-part effect draw (the pipeline only sets World/View/Projection; the caller owns
+  all lighting/material parameters), and `.drawImmediate(...)` (the callback receives a
+  `SceneContext` with the graphics device + gathered scene data) for raw device access.
 
 See [Shaders](../shaders.html) for loading custom shaders/effects per backend, and the
 [Shader Uniform Reference](../shader-uniforms.html) for the exact uniform names the
@@ -305,6 +300,7 @@ See [Shaders](../shaders.html) for loading custom shaders/effects per backend, a
 
 ## See also
 
+- [Draw DSL](../draw-dsl.html) — the full fluent draw surface (2D and 3D)
 - [Camera](../camera.html) — Camera3D helpers, Camera3DConfig, multi-camera patterns
 - [Shaders](../shaders.html) — Custom shader loading and parameters
 - [Rendering Overview](../rendering.html) — 2D + 3D pipeline architecture

--- a/docs/monogame-types.md
+++ b/docs/monogame-types.md
@@ -57,14 +57,15 @@ let grid =
 ```
 
 **Rule of thumb:** for any `Mibo.Core`/`Mibo.Layout`/`Mibo.Layout3D` call, spell
-out `System.Numerics.Vector2`/`Vector3`. Backend-specific APIs (each backend's
-`Camera2D.create`/`Camera3D`, `SpriteState`, `TextState`, `Draw.*` geometry) take
-that backend's native type, so a bare `Vector2(...)` is correct there as long as
-the matching namespace is open.
+out `System.Numerics.Vector2`/`Vector3`. The fluent draw DSL takes
+`System.Numerics` vectors and `Mibo.Color` on both backends (the buffer
+converts for you). Only backend-owned records — `SpriteState`, `TextState`,
+2D light records, camera structs — take the backend's native type, so a bare
+`Vector2(...)` is correct *there* as long as the matching namespace is open.
 
-`Mibo.Core` also ships a backend-neutral `Mibo.Color` (byte RGBA) used by the 3D
-light records; convert it to the backend color at the draw edge if you need a
-native `Color`.
+`Mibo.Color` (byte RGBA) is the fluent DSL's color vocabulary. Where you still
+need a backend color (building backend records), convert with `op_Implicit` /
+`.ToMiboColor()` in either direction.
 
 ## `Rectangle` is float on raylib, int on MonoGame
 
@@ -81,9 +82,12 @@ let dest = Rectangle(100, 100, 32, 32)
 SpriteState.create(tex, dest, Rectangle(0, 0, 32, 32))
 ```
 
-This affects every `Draw.*` geometry argument and `SpriteState`/`TextState`
-destination rectangle on the 2D stack. If a snippet uses `100f`/`32f` literals
-inside a `Rectangle(...)`, it is raylib-only — drop the `f` suffixes on MonoGame.
+The fluent DSL sidesteps this for **shape** draws — rect members take plain
+`x, y, w, h` floats on both backends (rounded to pixels on MonoGame). It only
+surfaces in backend-owned records: `SpriteState`/`TextState` destinations and
+lit-sprite `dest` rectangles use the backend `Rectangle`. If a snippet uses
+`100f`/`32f` literals inside a `Rectangle(...)`, it is raylib-only — drop the
+`f` suffixes on MonoGame.
 
 ## `Color` literals
 
@@ -144,7 +148,7 @@ read `ctx.GraphicsDevice.Viewport`; that is no longer how you get the size.)
 | Input mapper | `RaylibProgram.withInputMapper` | `MonoGameProgram.withInputMapper` |
 | Content pipeline | none — load raw files | `.mgcb` → `.xnb` content pipeline |
 | Custom shaders | GLSL | HLSL (`.fx` compiled to `.mgfx`) |
-| Texture filtering | property of the texture: `Texture.filter TextureFilter.Point` | property of the draw: `Draw.setSamplerState layer SamplerState.PointClamp` |
+| Texture filtering | property of the texture: `Texture.filter TextureFilter.Point` | property of the draw: `.setSamplerState(SamplerState.PointClamp)` |
 | Default font | `Raylib.GetFontDefault()` | none — load `assets.Font "..."` |
 | `Camera3D` FOV | **degrees**, no explicit near/far | **radians**, defaulted near/far planes (override via `withNearFar`) |
 | 3D animated model | load `.glb` once (animations included) | double-load: `assets.Model` (XNB mesh) + `assets.AnimatedMesh`/`ModelAnimations` (raw `.glb` via Assimp) |

--- a/docs/patterns/precomputed-state.md
+++ b/docs/patterns/precomputed-state.md
@@ -61,9 +61,10 @@ The view reads pre-computed values — zero computation:
 let view (ctx: GameContext) (model: GameModel) (buffer: RenderBuffer3D) =
   let l = model.Lighting
   buffer
-  |> Draw3D.beginCameraWith (Camera3D.render camera |> Camera3D.withClear l.SkyColor)
-  |> Draw3D.setAmbientLight { Color = l.SkyColor; Intensity = l.AmbientIntensity }
-  |> Draw3D.addDirectionalLight { Direction = l.LightDirection; ... }
+    .beginCameraWith(Camera3D.render camera |> Camera3D.withClear l.SkyColor)
+    .setAmbientLight { Color = l.SkyColor; Intensity = l.AmbientIntensity }
+    .addDirectionalLight { Direction = l.LightDirection; ... }
+    .drop()
 ```
 
 Systems run in order, so derived systems run after their inputs:

--- a/docs/program.md
+++ b/docs/program.md
@@ -126,7 +126,7 @@ The `Program` builder is in `Mibo.Core`, but a few pieces are backend-specific:
 
 `withInputMapper` is the only builder that cannot live in Core, because it instantiates the backend's `IInputMapper` implementation. If you prefer to stay fully "Elmish" (no service access), use the backend-neutral `InputMapper.subscribe` instead and handle a single message.
 
-> _**TIP**_: The `Draw.drawImmediate` escape hatch (raylib) and custom `IRenderCommand2D` serve the same role as raw backend integration points when you need GPU work outside the deferred command buffer.
+> _**TIP**_: The `.drawImmediate(...)` escape hatch and custom render commands serve the same role as raw backend integration points when you need GPU work outside the deferred command buffer.
 
 ---
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -45,9 +45,10 @@ let update msg model =
     | Teleport pos -> { model with Position = pos }, Cmd.none
 
 let view ctx model (buffer: RenderBuffer2D) =
-    // Deferred sprite draw via the Draw.* DSL (same shape on every backend)
+    // Deferred sprite draw via the fluent DSL (same shape on every backend)
     buffer
-    |> Draw.sprite (SpriteState.create(texture, Rectangle(model.Position.X, model.Position.Y, 32f, 32f), Rectangle(0f, 0f, 32f, 32f)))
+      .sprite(SpriteState.create(texture, Rectangle(model.Position.X, model.Position.Y, 32f, 32f), Rectangle(0f, 0f, 32f, 32f)))
+      .drop()
 ```
 
 ## Level 1 — Add semantic input

--- a/docs/shader-uniforms.md
+++ b/docs/shader-uniforms.md
@@ -22,11 +22,11 @@ How custom shading gets into the pipeline, per backend:
 
 | Escape hatch | raylib | MonoGame | Uniforms you receive |
 |---|---|---|---|
-| `Draw3D.beginEffect` / `endEffect` | ✓ (`Shader`) | ✓ (`Effect`) | Scene data **by name** — declare only what you use; absent ones are skipped. Instanced draws are shaded by your shader when it opts in (see [Instancing](#instancing-opt-in)). |
-| `Draw3D.drawMeshEffect` | — | ✓ | `World`/`View`/`Projection` only (via `IEffectMatrices`); you own lighting/material |
-| `Draw3D.drawImmediate` | ✓ | ✓ | None — the pipeline shader is bypassed; you get a `SceneContext` with raw device + gathered scene fields |
+| `.beginEffect(...)` / `.endEffect()` | ✓ (`Shader`) | ✓ (`Effect`) | Scene data **by name** — declare only what you use; absent ones are skipped. Instanced draws are shaded by your shader when it opts in (see [Instancing](#instancing-opt-in)). |
+| Per-mesh-part effect draw | — | ✓ | `World`/`View`/`Projection` only (via `IEffectMatrices`); you own lighting/material |
+| `.drawImmediate(...)` | ✓ | ✓ | None — the pipeline shader is bypassed; you get a `SceneContext` with raw device + gathered scene fields |
 
-## `beginEffect` / `endEffect` — the inherited uniform contract
+## `.beginEffect(...)` / `.endEffect()` — the inherited uniform contract
 
 Both backends resolve the **same uniform names** (mirrored `SceneUpload`
 modules). Declare a subset in your shader; the pipeline uploads only what's
@@ -124,7 +124,7 @@ none of these renders unshadowed at no cost.
 
 ### Instancing (opt-in)
 
-A `Draw3D.drawMeshInstanced` inside a `beginEffect` scope is shaded by your
+An `.instanced(...)` draw inside a `.beginEffect(...)` scope is shaded by your
 shader when it declares the instancing input; otherwise it falls back to the
 built-in PBR instanced path. The opt-in convention differs by backend because
 each engine feeds per-instance data differently — raylib uses a single vertex
@@ -323,12 +323,12 @@ technique Toon {
 
 ```fsharp
 buffer
-|> Draw3D.beginCamera camera
-|> Draw3D.beginEffect toonEffect
-|> Draw3D.drawModel model transform
-|> Draw3D.endEffect
-|> Draw3D.endCamera
-|> Draw3D.drop
+  .beginCamera(camera)
+  .beginEffect(toonEffect)
+  .model(model, transform)
+  .endEffect()
+  .endCamera()
+  .drop()
 ```
 
 ### raylib — minimal GLSL for `beginEffect`
@@ -367,12 +367,12 @@ void main() {
 ```fsharp
 // Fragment shader declares the same uniforms it consumes; load both, then:
 buffer
-|> Draw3D.beginCamera camera
-|> Draw3D.beginEffect toonShader
-|> Draw3D.drawModel model transform
-|> Draw3D.endEffect
-|> Draw3D.endCamera
-|> Draw3D.drop
+  .beginCamera(camera)
+  .beginEffect(toonShader)
+  .model(model, transform)
+  .endEffect()
+  .endCamera()
+  .drop()
 ```
 
 ## Convention notes

--- a/docs/shaders.md
+++ b/docs/shaders.md
@@ -143,11 +143,11 @@ myEffect.Parameters.["world"].SetValue(worldMatrix)
 
 How you opt in with your own shading depends on the backend:
 
-**raylib (3D)** — `Draw3D.drawImmediate` runs raw rlgl/raylib calls (the pipeline's shader is bypassed for those draws). For a full custom pipeline, implement `IRenderPipeline3D`.
+**Shading scopes (both backends)** — `.beginEffect(shader)` / `.endEffect()` opens a scope where draws are shaded by your shader (raylib `Shader` / MonoGame `Effect`) instead of the default PBR shader, *inheriting* the scene data the pipeline gathered (camera matrices, lights, the shadow pass output, material, bones, frame time). Your shader only needs to declare the uniforms it consumes (e.g. `dirLightDir`, `boneMatrices`, `shadowViewProjs`, `shadowAtlas`, `time`); absent uniforms are skipped. Ideal for toon/cel/wireframe without re-implementing the gather.
 
-**MonoGame (3D)** — two opt-in paths (no raylib equivalent):
-- `Draw3D.beginEffect effect` / `Draw3D.endEffect` — a **shading scope**: draws inside are shaded by your `Effect`, which *inherits* the scene data the pipeline gathered (camera matrices, lights, the shadow pass output, material, bones, frame time). Your effect only needs to declare the uniforms it consumes (e.g. `dirLightDir`, `boneMatrices`, `shadowViewProjs`, `shadowAtlas`, `time`); absent uniforms are skipped. Ideal for toon/cel/wireframe without re-implementing the gather.
-- `Draw3D.drawMeshEffect meshPart transform effect` — a fully user-owned effect (the pipeline sets only World/View/Projection; you own all lighting/material params).
+**MonoGame only** — a per-mesh-part effect draw: the pipeline sets only World/View/Projection; you own all lighting/material params.
+
+**Raw access** — `.drawImmediate(...)` runs raw backend calls (rlgl/raylib, or MonoGame device access via `SceneContext`); the pipeline's shader is bypassed for those draws. For a full custom pipeline, implement `IRenderPipeline3D`.
 
 See [3D Rendering Overview](graphics3d/overview.html#escape-hatches) for examples.
 
@@ -204,7 +204,7 @@ let setShaderVec4 (shader: Shader) (loc: int) (value: Vector4) =
 
 ## Post-process shaders
 
-Post-process passes (`Draw3D.postProcess` / `Draw3D.postProcessWithDepth`) run after
+Post-process passes (`.postProcess(...)` / `.postProcessWithDepth(...)`) run after
 the scene renders to an offscreen target. Your action receives a
 `PostProcessContext3D` and must draw a fullscreen quad of `ctx.Source`. See
 [3D Rendering → Post-processing](graphics3d/overview.html#post-processing) for the

--- a/src/Mibo.Core/Graphics/Draw.fs
+++ b/src/Mibo.Core/Graphics/Draw.fs
@@ -1,0 +1,1348 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// The fluent Draw DSL — one backend-neutral surface for 2D and 3D.
+//
+// Every member is an [<Extension>] static member inline with SRTP constraints:
+// the DSL itself is defined ONCE here in Core, and each backend satisfies the
+// constraints with small `member inline` witnesses on its render buffer (see
+// Graphics2D/DrawWitnesses.fs and Graphics3D/DrawWitnesses.fs in Mibo.Raylib
+// and Mibo.MonoGame). At the call site the whole chain erases to direct
+// buffer.Add(...) calls — zero dispatch, zero closure allocation.
+//
+// Conventions:
+//   * Parameters are sorted by common usage; anything with a sensible default
+//     is optional (`layer` defaults to 0<RenderLayer>).
+//   * Colors are Mibo.Color (backend-neutral; converts at the boundary).
+//   * Vectors are System.Numerics (raylib-native; MonoGame converts).
+//   * Backend-typed things (textures, fonts, cameras, shaders, models, state
+//     records) are generic handles — the witness takes the backend's own type.
+//   * Members that exist on only one backend (e.g. SetSamplerState) simply
+//     have a witness on one buffer — calling them on the other backend is a
+//     compile error naming the missing witness.
+//   * Members spanning 2D and 3D (cameras, post-process, DrawImmediate) share
+//     one name; the buffer type selects the witness. 3D has no layer concept —
+//     its witnesses accept and ignore `layer`.
+// ─────────────────────────────────────────────────────────────────────────────
+namespace Mibo.Elmish.Graphics
+
+open System.Numerics
+open System.Runtime.CompilerServices
+open Mibo
+open Mibo.Elmish.Graphics2D
+open Mibo.Elmish.Graphics3D
+
+/// <summary>Rectangle witnesses (fills, outlines, rounded, gradients).</summary>
+type WithRects2D<'T
+  when 'T: (member AddFillRect:
+    float32 * float32 * float32 * float32 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddRectOutline:
+    float32 * float32 * float32 * float32 * Color * float32 * int<RenderLayer> ->
+      unit)
+  and 'T: (member AddFillRectRounded:
+    float32 *
+    float32 *
+    float32 *
+    float32 *
+    Color *
+    float32 *
+    int *
+    int<RenderLayer> ->
+      unit)
+  and 'T: (member AddRectRoundedOutline:
+    float32 *
+    float32 *
+    float32 *
+    float32 *
+    Color *
+    float32 *
+    int *
+    float32 *
+    int<RenderLayer> ->
+      unit)
+  and 'T: (member AddRectGradientV:
+    int * int * int * int * Color * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddRectGradientH:
+    int * int * int * int * Color * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddRectGradient:
+    float32 *
+    float32 *
+    float32 *
+    float32 *
+    Color *
+    Color *
+    Color *
+    Color *
+    int<RenderLayer> ->
+      unit)> = 'T
+
+/// <summary>Circle, sector, and radial-gradient witnesses.</summary>
+type WithCircles2D<'T
+  when 'T: (member AddFillCircle:
+    Vector2 * float32 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddCircleOutline:
+    Vector2 * float32 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddCircleSector:
+    Vector2 * float32 * float32 * float32 * Color * int * int<RenderLayer> ->
+      unit)
+  and 'T: (member AddCircleSectorOutline:
+    Vector2 * float32 * float32 * float32 * Color * int * int<RenderLayer> ->
+      unit)
+  and 'T: (member AddCircleGradient:
+    int * int * float32 * Color * Color * int<RenderLayer> -> unit)> = 'T
+
+/// <summary>Ring / arc witnesses.</summary>
+type WithRings2D<'T
+  when 'T: (member AddFillRing:
+    Vector2 *
+    float32 *
+    float32 *
+    float32 *
+    float32 *
+    Color *
+    int *
+    int<RenderLayer> ->
+      unit)
+  and 'T: (member AddRingOutline:
+    Vector2 *
+    float32 *
+    float32 *
+    float32 *
+    float32 *
+    Color *
+    int *
+    int<RenderLayer> ->
+      unit)> = 'T
+
+/// <summary>Ellipse witnesses.</summary>
+type WithEllipses2D<'T
+  when 'T: (member AddFillEllipse:
+    int * int * float32 * float32 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddEllipseOutline:
+    int * int * float32 * float32 * Color * int<RenderLayer> -> unit)> = 'T
+
+/// <summary>Line &amp; curve witnesses.</summary>
+type WithLines2D<'T
+  when 'T: (member AddLine: Vector2 * Vector2 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddLineThick:
+    Vector2 * Vector2 * Color * float32 * int<RenderLayer> -> unit)
+  and 'T: (member AddBezier:
+    Vector2 * Vector2 * Vector2 * Color * float32 * int<RenderLayer> -> unit)> =
+  'T
+
+/// <summary>Triangle &amp; polygon witnesses.</summary>
+type WithPolygons2D<'T
+  when 'T: (member AddTriangle:
+    Vector2 * Vector2 * Vector2 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddFillPoly:
+    Vector2 * int * float32 * float32 * Color * int<RenderLayer> -> unit)
+  and 'T: (member AddPolyOutline:
+    Vector2 * int * float32 * float32 * Color * float32 * int<RenderLayer> ->
+      unit)> = 'T
+
+/// <summary>All 2D shape witnesses, composed from the per-family aliases above.</summary>
+type WithShapes2D<'T
+  when WithRects2D<'T>
+  and WithCircles2D<'T>
+  and WithRings2D<'T>
+  and WithEllipses2D<'T>
+  and WithLines2D<'T>
+  and WithPolygons2D<'T>> = 'T
+
+/// <summary>
+/// The unified fluent draw DSL. Chain members on the render buffer:
+/// <code lang="fsharp">
+/// buffer
+///   .BeginCamera(camera)
+///   .FillCircle(400f, 300f, 48f, Color.Blue)
+///   .Sprite(playerSprite)
+///   .EndCamera()
+///   .Text(font, "HP 100", Vector2(10f, 10f), 20f, layer = 1001&lt;RenderLayer&gt;)
+/// |&gt; ignore
+/// </code>
+/// </summary>
+[<Extension>]
+type Draw =
+
+  // ──────────────────────────────────────────────
+  // 2D — Sprites & Text (backend state records, pass-through)
+  // ──────────────────────────────────────────────
+
+  /// <summary>Draws a sprite from the backend's SpriteState record.</summary>
+  [<Extension>]
+  static member inline sprite<'B, 'S
+    when 'B: (member AddSpriteState: 'S -> unit)>
+    (buffer: 'B, state: 'S)
+    : 'B =
+    buffer.AddSpriteState state
+    buffer
+
+  /// <summary>Draws text from the backend's TextState record.</summary>
+  [<Extension>]
+  static member inline text<'B, 'S when 'B: (member AddTextState: 'S -> unit)>
+    (buffer: 'B, state: 'S)
+    : 'B =
+    buffer.AddTextState state
+    buffer
+
+  /// <summary>
+  /// Draws text from parts. <paramref name="size"/> maps to the backend's
+  /// sizing model (raylib: font size in pixels; MonoGame: uniform scale).
+  /// <paramref name="spacing"/> is used by raylib and ignored by MonoGame.
+  /// </summary>
+  [<Extension>]
+  static member inline text<'B, 'F
+    when 'B: (member AddText:
+      'F * string * Vector2 * float32 * float32 * Color * int<RenderLayer> ->
+        unit)>
+    (
+      buffer: 'B,
+      font: 'F,
+      text: string,
+      position: Vector2,
+      size: float32,
+      [<Struct>] ?tint: Color,
+      [<Struct>] ?spacing: float32,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddText(
+      font,
+      text,
+      position,
+      size,
+      defaultValueArg spacing 1.0f,
+      defaultValueArg tint Color.White,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Rectangles
+  // ──────────────────────────────────────────────
+
+  /// <summary>Filled rectangle. Coordinates are float pixels (rounded on MonoGame).</summary>
+  [<Extension>]
+  static member inline fillRect<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddFillRect(x, y, w, h, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Rectangle outline.</summary>
+  [<Extension>]
+  static member inline rectOutline<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      [<Struct>] ?thickness: float32,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddRectOutline(
+      x,
+      y,
+      w,
+      h,
+      color,
+      defaultValueArg thickness 1.0f,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Filled rounded rectangle.</summary>
+  [<Extension>]
+  static member inline fillRectRounded<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      [<Struct>] ?roundness: float32,
+      [<Struct>] ?segments: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddFillRectRounded(
+      x,
+      y,
+      w,
+      h,
+      color,
+      defaultValueArg roundness 0.5f,
+      defaultValueArg segments 8,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Rounded rectangle outline.</summary>
+  [<Extension>]
+  static member inline rectRoundedOutline<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      [<Struct>] ?roundness: float32,
+      [<Struct>] ?segments: int,
+      [<Struct>] ?thickness: float32,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddRectRoundedOutline(
+      x,
+      y,
+      w,
+      h,
+      color,
+      defaultValueArg roundness 0.5f,
+      defaultValueArg segments 8,
+      defaultValueArg thickness 1.0f,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Vertical gradient rectangle (int pixel coords, matching the existing API).</summary>
+  [<Extension>]
+  static member inline rectGradientV<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      top: Color,
+      bottom: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddRectGradientV(
+      x,
+      y,
+      w,
+      h,
+      top,
+      bottom,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Horizontal gradient rectangle (int pixel coords, matching the existing API).</summary>
+  [<Extension>]
+  static member inline rectGradientH<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      left: Color,
+      right: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddRectGradientH(
+      x,
+      y,
+      w,
+      h,
+      left,
+      right,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>4-corner gradient rectangle.</summary>
+  [<Extension>]
+  static member inline rectGradient<'B when WithRects2D<'B>>
+    (
+      buffer: 'B,
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      topLeft: Color,
+      bottomLeft: Color,
+      topRight: Color,
+      bottomRight: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddRectGradient(
+      x,
+      y,
+      w,
+      h,
+      topLeft,
+      bottomLeft,
+      topRight,
+      bottomRight,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Circles, Rings, Ellipses
+  // ──────────────────────────────────────────────
+
+  /// <summary>Filled circle.</summary>
+  [<Extension>]
+  static member inline fillCircle<'B when WithCircles2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      radius: float32,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddFillCircle(
+      center,
+      radius,
+      color,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Circle outline.</summary>
+  [<Extension>]
+  static member inline circleOutline<'B when WithCircles2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      radius: float32,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddCircleOutline(
+      center,
+      radius,
+      color,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Filled circle sector (pie slice).</summary>
+  [<Extension>]
+  static member inline circleSector<'B when WithCircles2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      radius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      [<Struct>] ?segments: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddCircleSector(
+      center,
+      radius,
+      startAngle,
+      endAngle,
+      color,
+      defaultValueArg segments 16,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Circle sector outline.</summary>
+  [<Extension>]
+  static member inline circleSectorOutline<'B when WithCircles2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      radius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      [<Struct>] ?segments: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddCircleSectorOutline(
+      center,
+      radius,
+      startAngle,
+      endAngle,
+      color,
+      defaultValueArg segments 16,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Radial gradient circle (int pixel center, matching the existing API).</summary>
+  [<Extension>]
+  static member inline circleGradient<'B when WithCircles2D<'B>>
+    (
+      buffer: 'B,
+      centerX: int,
+      centerY: int,
+      radius: float32,
+      inner: Color,
+      outer: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddCircleGradient(
+      centerX,
+      centerY,
+      radius,
+      inner,
+      outer,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Filled ring / arc.</summary>
+  [<Extension>]
+  static member inline fillRing<'B when WithRings2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      innerRadius: float32,
+      outerRadius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      [<Struct>] ?segments: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddFillRing(
+      center,
+      innerRadius,
+      outerRadius,
+      startAngle,
+      endAngle,
+      color,
+      defaultValueArg segments 16,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Ring / arc outline.</summary>
+  [<Extension>]
+  static member inline ringOutline<'B when WithRings2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      innerRadius: float32,
+      outerRadius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      [<Struct>] ?segments: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddRingOutline(
+      center,
+      innerRadius,
+      outerRadius,
+      startAngle,
+      endAngle,
+      color,
+      defaultValueArg segments 16,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Filled ellipse (int pixel center, matching the existing API).</summary>
+  [<Extension>]
+  static member inline fillEllipse<'B when WithEllipses2D<'B>>
+    (
+      buffer: 'B,
+      centerX: int,
+      centerY: int,
+      radiusH: float32,
+      radiusV: float32,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddFillEllipse(
+      centerX,
+      centerY,
+      radiusH,
+      radiusV,
+      color,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Ellipse outline (int pixel center, matching the existing API).</summary>
+  [<Extension>]
+  static member inline ellipseOutline<'B when WithEllipses2D<'B>>
+    (
+      buffer: 'B,
+      centerX: int,
+      centerY: int,
+      radiusH: float32,
+      radiusV: float32,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddEllipseOutline(
+      centerX,
+      centerY,
+      radiusH,
+      radiusV,
+      color,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Lines & Curves
+  // ──────────────────────────────────────────────
+
+  /// <summary>1-pixel line.</summary>
+  [<Extension>]
+  static member inline line<'B when WithLines2D<'B>>
+    (
+      buffer: 'B,
+      start: Vector2,
+      finish: Vector2,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddLine(start, finish, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Line with custom thickness.</summary>
+  [<Extension>]
+  static member inline lineThick<'B when WithLines2D<'B>>
+    (
+      buffer: 'B,
+      start: Vector2,
+      finish: Vector2,
+      color: Color,
+      [<Struct>] ?thickness: float32,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddLineThick(
+      start,
+      finish,
+      color,
+      defaultValueArg thickness 1.0f,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Connected line segments. The point array is a backend handle
+  /// (System.Numerics on raylib, XNA on MonoGame) — no per-frame conversion.
+  /// Single-point members take System.Numerics and convert for free.</summary>
+  [<Extension>]
+  static member inline lineStrip<'B, 'P
+    when 'B: (member AddLineStrip: 'P[] * Color * int<RenderLayer> -> unit)>
+    (buffer: 'B, points: 'P[], color: Color, [<Struct>] ?layer: int<RenderLayer>) : 'B =
+    buffer.AddLineStrip(points, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Quadratic bezier curve.</summary>
+  [<Extension>]
+  static member inline bezier<'B when WithLines2D<'B>>
+    (
+      buffer: 'B,
+      start: Vector2,
+      control: Vector2,
+      finish: Vector2,
+      color: Color,
+      [<Struct>] ?thickness: float32,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddBezier(
+      start,
+      control,
+      finish,
+      color,
+      defaultValueArg thickness 1.0f,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Triangles & Polygons
+  // ──────────────────────────────────────────────
+
+  /// <summary>Filled triangle from 3 vertices.</summary>
+  [<Extension>]
+  static member inline triangle<'B when WithPolygons2D<'B>>
+    (
+      buffer: 'B,
+      v1: Vector2,
+      v2: Vector2,
+      v3: Vector2,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddTriangle(v1, v2, v3, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Filled triangle fan. Points array is a backend handle (see LineStrip).</summary>
+  [<Extension>]
+  static member inline triangleFan<'B, 'P
+    when 'B: (member AddTriangleFan: 'P[] * Color * int<RenderLayer> -> unit)>
+    (buffer: 'B, points: 'P[], color: Color, [<Struct>] ?layer: int<RenderLayer>) : 'B =
+    buffer.AddTriangleFan(points, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Filled triangle strip. Points array is a backend handle (see LineStrip).</summary>
+  [<Extension>]
+  static member inline triangleStrip<'B, 'P
+    when 'B: (member AddTriangleStrip: 'P[] * Color * int<RenderLayer> -> unit)>
+    (buffer: 'B, points: 'P[], color: Color, [<Struct>] ?layer: int<RenderLayer>) : 'B =
+    buffer.AddTriangleStrip(points, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Filled regular polygon.</summary>
+  [<Extension>]
+  static member inline fillPoly<'B when WithPolygons2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      sides: int,
+      radius: float32,
+      rotation: float32,
+      color: Color,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddFillPoly(
+      center,
+      sides,
+      radius,
+      rotation,
+      color,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Regular polygon outline.</summary>
+  [<Extension>]
+  static member inline polyOutline<'B when WithPolygons2D<'B>>
+    (
+      buffer: 'B,
+      center: Vector2,
+      sides: int,
+      radius: float32,
+      rotation: float32,
+      color: Color,
+      [<Struct>] ?thickness: float32,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddPolyOutline(
+      center,
+      sides,
+      radius,
+      rotation,
+      color,
+      defaultValueArg thickness 1.0f,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  // ──────────────────────────────────────────────
+  // Shared — Camera (2D and 3D buffers, same witness names)
+  // ──────────────────────────────────────────────
+
+  /// <summary>Begins a camera transform (2D or 3D — the buffer selects the witness).</summary>
+  [<Extension>]
+  static member inline beginCamera<'B, 'C
+    when 'B: (member AddBeginCamera: 'C * int<RenderLayer> -> unit)>
+    (buffer: 'B, camera: 'C, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddBeginCamera(camera, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Begins a camera with explicit rendering config (viewport, clear).</summary>
+  [<Extension>]
+  static member inline beginCameraWith<'B, 'C
+    when 'B: (member AddBeginCameraConfig: 'C * int<RenderLayer> -> unit)>
+    (buffer: 'B, config: 'C, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddBeginCameraConfig(config, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Ends the current camera transform.</summary>
+  [<Extension>]
+  static member inline endCamera<'B
+    when 'B: (member AddEndCamera: int<RenderLayer> -> unit)>
+    (buffer: 'B, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddEndCamera(defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Shader, Render Target
+  // ──────────────────────────────────────────────
+
+  /// <summary>Begins a 2D shader/effect block.</summary>
+  [<Extension>]
+  static member inline beginShader<'B, 'S
+    when 'B: (member AddBeginShader: 'S * int<RenderLayer> -> unit)>
+    (buffer: 'B, shader: 'S, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddBeginShader(shader, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Ends the current 2D shader block.</summary>
+  [<Extension>]
+  static member inline endShader<'B
+    when 'B: (member AddEndShader: int<RenderLayer> -> unit)>
+    (buffer: 'B, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddEndShader(defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Begins rendering to a render target.</summary>
+  [<Extension>]
+  static member inline beginTarget<'B, 'T
+    when 'B: (member AddBeginTarget: 'T * int<RenderLayer> -> unit)>
+    (buffer: 'B, target: 'T, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddBeginTarget(target, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Ends rendering to a render target.</summary>
+  [<Extension>]
+  static member inline endTarget<'B
+    when 'B: (member AddEndTarget: int<RenderLayer> -> unit)>
+    (buffer: 'B, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddEndTarget(defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Render State
+  // ──────────────────────────────────────────────
+
+  /// <summary>Sets the blending mode (backend handle: raylib BlendMode enum or MonoGame BlendMode DU).</summary>
+  [<Extension>]
+  static member inline setBlend<'B, 'M
+    when 'B: (member AddSetBlend: 'M * int<RenderLayer> -> unit)>
+    (buffer: 'B, mode: 'M, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddSetBlend(mode, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>
+  /// Sets the sampler state (e.g. SamplerState.PointClamp) — stops tile-atlas
+  /// bleeding. <b>MonoGame only</b>: the raylib buffer has no witness, so
+  /// calling this there is a compile error.
+  /// </summary>
+  [<Extension>]
+  static member inline setSamplerState<'B, 'S
+    when 'B: (member AddSamplerState: 'S * int<RenderLayer> -> unit)>
+    (buffer: 'B, sampler: 'S, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddSamplerState(sampler, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Enables scissor testing.</summary>
+  [<Extension>]
+  static member inline setScissor<'B
+    when 'B: (member AddSetScissor:
+      int * int * int * int * int<RenderLayer> -> unit)>
+    (
+      buffer: 'B,
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddSetScissor(x, y, w, h, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Disables scissor testing.</summary>
+  [<Extension>]
+  static member inline clearScissor<'B
+    when 'B: (member AddClearScissor: int<RenderLayer> -> unit)>
+    (buffer: 'B, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddClearScissor(defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Sets the line width for subsequent line draws.</summary>
+  [<Extension>]
+  static member inline setLineWidth<'B
+    when 'B: (member AddSetLineWidth: float32 * int<RenderLayer> -> unit)>
+    (buffer: 'B, width: float32, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddSetLineWidth(width, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Sets the viewport rectangle.</summary>
+  [<Extension>]
+  static member inline setViewport<'B
+    when 'B: (member AddSetViewport:
+      int * int * int * int * int<RenderLayer> -> unit)>
+    (
+      buffer: 'B,
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddSetViewport(x, y, w, h, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  // ──────────────────────────────────────────────
+  // Shared — Escape Hatches
+  // ──────────────────────────────────────────────
+
+  /// <summary>
+  /// Runs a fully-custom draw. 2D: action is <c>unit -&gt; unit</c> (batch is
+  /// flushed, state restored). 3D: action receives the frame's SceneContext.
+  /// The 3D witness ignores <paramref name="layer"/> (3D has no layers).
+  /// </summary>
+  [<Extension>]
+  static member inline drawImmediate<'B, 'Ctx
+    when 'B: (member AddDrawImmediate: ('Ctx -> unit) * int<RenderLayer> -> unit)>
+    (
+      buffer: 'B,
+      [<InlineIfLambda>] action: 'Ctx -> unit,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddDrawImmediate(action, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Clears the current framebuffer to the given color.</summary>
+  [<Extension>]
+  static member inline clear<'B
+    when 'B: (member AddClear: Color * int<RenderLayer> -> unit)>
+    (buffer: 'B, color: Color, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddClear(color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>
+  /// Enqueues a post-process pass. The action receives the backend's
+  /// post-process context (2D or 3D) and runs once after the scene renders.
+  /// </summary>
+  [<Extension>]
+  static member inline postProcess<'B, 'Ctx
+    when 'B: (member AddPostProcess: ('Ctx -> unit) -> unit)>
+    (buffer: 'B, [<InlineIfLambda>] action: 'Ctx -> unit)
+    : 'B =
+    buffer.AddPostProcess action
+    buffer
+
+  /// <summary>
+  /// Enqueues a post-process pass that needs camera-POV scene depth.
+  /// <b>3D only</b> — the 2D buffer has no witness.
+  /// </summary>
+  [<Extension>]
+  static member inline postProcessWithDepth<'B, 'Ctx
+    when 'B: (member AddPostProcessWithDepth: ('Ctx -> unit) -> unit)>
+    (buffer: 'B, [<InlineIfLambda>] action: 'Ctx -> unit)
+    : 'B =
+    buffer.AddPostProcessWithDepth action
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Particles
+  // ──────────────────────────────────────────────
+
+  /// <summary>Adds a batched particle render command.</summary>
+  [<Extension>]
+  static member inline particles<'B, 'T, 'P
+    when 'B: (member AddParticles: 'T * 'P[] * int * int<RenderLayer> -> unit)>
+    (
+      buffer: 'B,
+      texture: 'T,
+      particles: 'P[],
+      count: int,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddParticles(
+      texture,
+      particles,
+      count,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 2D — Lighting (context handle + light records, pass-through)
+  // ──────────────────────────────────────────────
+
+  /// <summary>Sets the ambient light color for this frame.</summary>
+  [<Extension>]
+  static member inline setAmbient<'B, 'C
+    when 'B: (member AddSetAmbient: 'C * Color * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, color: Color, [<Struct>] ?layer: int<RenderLayer>) : 'B =
+    buffer.AddSetAmbient(lightCtx, color, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Adds a 2D point light for this frame.</summary>
+  [<Extension>]
+  static member inline addPointLight<'B, 'C, 'L
+    when 'B: (member AddPointLight: 'C * 'L * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, light: 'L, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddPointLight(lightCtx, light, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Adds a 2D directional light from the backend's light record.</summary>
+  [<Extension>]
+  static member inline addDirectionalLight<'B, 'C, 'L
+    when 'B: (member AddDirectionalLightState:
+      'C * 'L * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, light: 'L, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddDirectionalLightState(
+      lightCtx,
+      light,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Adds a 2D directional light from parts.</summary>
+  [<Extension>]
+  static member inline addDirectionalLight<'B, 'C
+    when 'B: (member AddDirectionalLight:
+      'C * Vector2 * Color * float32 * bool * int<RenderLayer> -> unit)>
+    (
+      buffer: 'B,
+      lightCtx: 'C,
+      direction: Vector2,
+      color: Color,
+      [<Struct>] ?intensity: float32,
+      [<Struct>] ?castsShadows: bool,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddDirectionalLight(
+      lightCtx,
+      direction,
+      color,
+      defaultValueArg intensity 1.0f,
+      defaultValueArg castsShadows false,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Adds a shadow-casting occluder segment for this frame.</summary>
+  [<Extension>]
+  static member inline addOccluder<'B, 'C, 'O
+    when 'B: (member AddOccluder: 'C * 'O * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, occluder: 'O, [<Struct>] ?layer: int<RenderLayer>) : 'B =
+    buffer.AddOccluder(lightCtx, occluder, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Draws a sprite with the current lighting state.</summary>
+  [<Extension>]
+  static member inline litSprite<'B, 'C, 'S
+    when 'B: (member AddLitSprite: 'C * 'S -> unit)>
+    (buffer: 'B, lightCtx: 'C, sprite: 'S)
+    : 'B =
+    buffer.AddLitSprite(lightCtx, sprite)
+    buffer
+
+  /// <summary>Draws an animated sprite with the current lighting state.</summary>
+  [<Extension>]
+  static member inline litAnimatedSprite<'B, 'C, 'R, 'A
+    when 'B: (member AddLitAnimatedSprite:
+      'C * 'R * 'A * int<RenderLayer> -> unit)>
+    (
+      buffer: 'B,
+      lightCtx: 'C,
+      dest: 'R,
+      animSprite: 'A,
+      [<Struct>] ?layer: int<RenderLayer>
+    ) : 'B =
+    buffer.AddLitAnimatedSprite(
+      lightCtx,
+      dest,
+      animSprite,
+      defaultValueArg layer 0<RenderLayer>
+    )
+
+    buffer
+
+  /// <summary>Ends the current lighting pass; sprites after this point are unlit.</summary>
+  [<Extension>]
+  static member inline endLighting<'B, 'C
+    when 'B: (member AddEndLighting: 'C * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddEndLighting(lightCtx, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Enables 2D shadow casting for subsequent draws.</summary>
+  [<Extension>]
+  static member inline enableShadows<'B, 'C
+    when 'B: (member AddEnableShadows: 'C * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddEnableShadows(lightCtx, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  /// <summary>Disables 2D shadow casting for subsequent draws.</summary>
+  [<Extension>]
+  static member inline disableShadows<'B, 'C
+    when 'B: (member AddDisableShadows: 'C * int<RenderLayer> -> unit)>
+    (buffer: 'B, lightCtx: 'C, [<Struct>] ?layer: int<RenderLayer>)
+    : 'B =
+    buffer.AddDisableShadows(lightCtx, defaultValueArg layer 0<RenderLayer>)
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 3D — Geometry
+  // ──────────────────────────────────────────────
+
+  /// <summary>Draws a mesh (raylib Mesh / MonoGame PrimitiveMesh) with a material.</summary>
+  [<Extension>]
+  static member inline mesh<'B, 'M, 'X, 'Mat
+    when 'B: (member AddDrawMesh: 'M * 'X * 'Mat -> unit)>
+    (buffer: 'B, mesh: 'M, transform: 'X, material: 'Mat)
+    : 'B =
+    buffer.AddDrawMesh(mesh, transform, material)
+    buffer
+
+  /// <summary>Draws many instances of the same mesh. Prefer over repeated Mesh calls.</summary>
+  [<Extension>]
+  static member inline instanced<'B, 'M, 'X, 'Mat
+    when 'B: (member AddDrawInstanced: 'M * 'X[] * 'Mat * int -> unit)>
+    (buffer: 'B, mesh: 'M, transforms: 'X[], material: 'Mat, instanceCount: int)
+    : 'B =
+    buffer.AddDrawInstanced(mesh, transforms, material, instanceCount)
+    buffer
+
+  /// <summary>Draws a model with a world transform and its authored materials.</summary>
+  [<Extension>]
+  static member inline model<'B, 'M, 'X
+    when 'B: (member AddDrawModel: 'M * 'X -> unit)>
+    (buffer: 'B, model: 'M, transform: 'X)
+    : 'B =
+    buffer.AddDrawModel(model, transform)
+    buffer
+
+  /// <summary>Draws a model with a whole-model material override.</summary>
+  [<Extension>]
+  static member inline modelWith<'B, 'M, 'X, 'Mat
+    when 'B: (member AddDrawModelWith: 'M * 'X * 'Mat -> unit)>
+    (buffer: 'B, model: 'M, transform: 'X, material: 'Mat)
+    : 'B =
+    buffer.AddDrawModelWith(model, transform, material)
+    buffer
+
+  /// <summary>Draws a model with a per-sub-mesh material resolver.</summary>
+  [<Extension>]
+  static member inline modelWithPerMesh<'B, 'M, 'X, 'Mat
+    when 'B: (member AddDrawModelWithPerMesh: 'M * 'X * (int -> 'Mat) -> unit)>
+    (
+      buffer: 'B,
+      model: 'M,
+      transform: 'X,
+      [<InlineIfLambda>] resolver: int -> 'Mat
+    ) : 'B =
+    buffer.AddDrawModelWithPerMesh(model, transform, resolver)
+    buffer
+
+  /// <summary>
+  /// Draws an animated (skinned) model from the backend's animation state
+  /// record. The witness derives the bone palette (MonoGame: from the state;
+  /// raylib: applies it to the model).
+  /// </summary>
+  [<Extension>]
+  static member inline animatedModel<'B, 'A, 'X
+    when 'B: (member AddAnimatedModel: 'A * 'X -> unit)>
+    (buffer: 'B, animModel: 'A, transform: 'X)
+    : 'B =
+    buffer.AddAnimatedModel(animModel, transform)
+    buffer
+
+  /// <summary>Draws an animated model with a whole-model material override.</summary>
+  [<Extension>]
+  static member inline animatedModelWith<'B, 'A, 'X, 'Mat
+    when 'B: (member AddAnimatedModelWith: 'A * 'X * 'Mat -> unit)>
+    (buffer: 'B, animModel: 'A, transform: 'X, material: 'Mat)
+    : 'B =
+    buffer.AddAnimatedModelWith(animModel, transform, material)
+    buffer
+
+  /// <summary>Draws an animated model with a per-sub-mesh material resolver.</summary>
+  [<Extension>]
+  static member inline animatedModelWithPerMesh<'B, 'A, 'X, 'Mat
+    when 'B: (member AddAnimatedModelWithPerMesh:
+      'A * 'X * (int -> 'Mat) -> unit)>
+    (
+      buffer: 'B,
+      animModel: 'A,
+      transform: 'X,
+      [<InlineIfLambda>] resolver: int -> 'Mat
+    ) : 'B =
+    buffer.AddAnimatedModelWithPerMesh(animModel, transform, resolver)
+    buffer
+
+  /// <summary>
+  /// Draws a skinned mesh with an explicit bone palette and material.
+  /// <b>raylib only</b> — MonoGame's skinned path goes through AnimatedModel.
+  /// </summary>
+  [<Extension>]
+  static member inline skinnedMesh<'B, 'M, 'X, 'Mat, 'Bones
+    when 'B: (member AddSkinnedMesh: 'M * 'X * 'Mat * 'Bones -> unit)>
+    (buffer: 'B, mesh: 'M, transform: 'X, material: 'Mat, bones: 'Bones)
+    : 'B =
+    buffer.AddSkinnedMesh(mesh, transform, material, bones)
+    buffer
+
+  /// <summary>Draws a billboard (camera-facing quad) with a texture.</summary>
+  [<Extension>]
+  static member inline billboard<'B, 'T
+    when 'B: (member AddBillboard: 'T * Vector3 * Vector2 * Color -> unit)>
+    (buffer: 'B, texture: 'T, position: Vector3, size: Vector2, color: Color)
+    : 'B =
+    buffer.AddBillboard(texture, position, size, color)
+    buffer
+
+  /// <summary>Draws multiple billboards in a single batch. All arrays are
+  /// backend handles (XNA arrays on MonoGame) — no per-frame conversion.</summary>
+  [<Extension>]
+  static member inline billboardBatch<'B, 'T, 'P, 'S, 'C
+    when 'B: (member AddBillboardBatch: 'T[] * 'P[] * 'S[] * 'C[] * int -> unit)>
+    (
+      buffer: 'B,
+      textures: 'T[],
+      positions: 'P[],
+      sizes: 'S[],
+      colors: 'C[],
+      count: int
+    ) : 'B =
+    buffer.AddBillboardBatch(textures, positions, sizes, colors, count)
+    buffer
+
+  /// <summary>Draws a 3D line between two points.</summary>
+  [<Extension>]
+  static member inline line3D<'B
+    when 'B: (member AddLine3D: Vector3 * Vector3 * Color -> unit)>
+    (buffer: 'B, start: Vector3, finish: Vector3, color: Color)
+    : 'B =
+    buffer.AddLine3D(start, finish, color)
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 3D — Shadows & Effect Scopes
+  // ──────────────────────────────────────────────
+
+  /// <summary>Sets the shadow origin for this frame's shadow pass.</summary>
+  [<Extension>]
+  static member inline setShadowOrigin<'B
+    when 'B: (member AddSetShadowOrigin: Vector3 -> unit)>
+    (buffer: 'B, origin: Vector3)
+    : 'B =
+    buffer.AddSetShadowOrigin origin
+    buffer
+
+  /// <summary>Enables 3D shadow casting for subsequent geometry.</summary>
+  [<Extension>]
+  static member inline enableShadows<'B
+    when 'B: (member AddEnableShadows3D: unit -> unit)>
+    (buffer: 'B)
+    : 'B =
+    buffer.AddEnableShadows3D()
+    buffer
+
+  /// <summary>Disables 3D shadow casting for subsequent geometry.</summary>
+  [<Extension>]
+  static member inline disableShadows<'B
+    when 'B: (member AddDisableShadows3D: unit -> unit)>
+    (buffer: 'B)
+    : 'B =
+    buffer.AddDisableShadows3D()
+    buffer
+
+  /// <summary>
+  /// Opens a per-group shading scope: draws until EndEffect are shaded by
+  /// <paramref name="shader"/> instead of the default PBR shader, inheriting
+  /// the gathered scene data (camera, lights, shadow pass, bones, time).
+  /// </summary>
+  [<Extension>]
+  static member inline beginEffect<'B, 'S
+    when 'B: (member AddBeginEffect: 'S -> unit)>
+    (buffer: 'B, shader: 'S)
+    : 'B =
+    buffer.AddBeginEffect shader
+    buffer
+
+  /// <summary>Closes the shading scope opened by BeginEffect.</summary>
+  [<Extension>]
+  static member inline endEffect<'B when 'B: (member AddEndEffect: unit -> unit)>
+    (buffer: 'B)
+    : 'B =
+    buffer.AddEndEffect()
+    buffer
+
+  // ──────────────────────────────────────────────
+  // 3D — Lights (backend-neutral Core types)
+  // ──────────────────────────────────────────────
+
+  /// <summary>Sets the ambient light for the scene.</summary>
+  [<Extension>]
+  static member inline setAmbientLight<'B
+    when 'B: (member AddSetAmbientLight: AmbientLight3D -> unit)>
+    (buffer: 'B, light: AmbientLight3D)
+    : 'B =
+    buffer.AddSetAmbientLight light
+    buffer
+
+  /// <summary>Adds a directional light to the scene.</summary>
+  [<Extension>]
+  static member inline addDirectionalLight<'B
+    when 'B: (member AddDirectionalLight: DirectionalLight3D -> unit)>
+    (buffer: 'B, light: DirectionalLight3D)
+    : 'B =
+    buffer.AddDirectionalLight light
+    buffer
+
+  /// <summary>Adds a point light to the scene.</summary>
+  [<Extension>]
+  static member inline addPointLight<'B
+    when 'B: (member AddPointLight: PointLight3D -> unit)>
+    (buffer: 'B, light: PointLight3D)
+    : 'B =
+    buffer.AddPointLight light
+    buffer
+
+  /// <summary>Adds a spot light to the scene.</summary>
+  [<Extension>]
+  static member inline addSpotLight<'B
+    when 'B: (member AddSpotLight: SpotLight3D -> unit)>
+    (buffer: 'B, light: SpotLight3D)
+    : 'B =
+    buffer.AddSpotLight light
+    buffer
+
+  // ──────────────────────────────────────────────
+  // Terminal
+  // ──────────────────────────────────────────────
+
+  /// <summary>Terminal function that discards the buffer, silencing the unused-value warning.</summary>
+  [<Extension>]
+  static member inline drop<'B>(buffer: 'B) : unit = ()

--- a/src/Mibo.Core/Graphics/Draw.fs
+++ b/src/Mibo.Core/Graphics/Draw.fs
@@ -219,7 +219,7 @@ type Draw =
   // 2D — Rectangles
   // ──────────────────────────────────────────────
 
-  /// <summary>Filled rectangle. Coordinates are float pixels (rounded on MonoGame).</summary>
+  /// <summary>Filled rectangle. Coordinates are float pixels (truncated toward zero on MonoGame).</summary>
   [<Extension>]
   static member inline fillRect<'B when WithRects2D<'B>>
     (

--- a/src/Mibo.Core/Graphics2D/Types.fs
+++ b/src/Mibo.Core/Graphics2D/Types.fs
@@ -1,0 +1,14 @@
+namespace Mibo.Elmish.Graphics2D
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared 2D render vocabulary.
+//
+// RenderLayer previously lived in each backend's Command2D.fs (identical
+// copies). Units of measure cannot be generic type parameters, so the fluent
+// Draw DSL in Core needs ONE definition both backends can reference. It now
+// lives here — same namespace, so existing code is unaffected.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// <summary>Unit of measure for 2D render layer ordering.</summary>
+[<Measure>]
+type RenderLayer

--- a/src/Mibo.Core/Mibo.Core.fsproj
+++ b/src/Mibo.Core/Mibo.Core.fsproj
@@ -40,7 +40,9 @@
     <Compile Include="Layout3D/LayeredGrid3D.fs" />
     <Compile Include="Layout3D/Interior.fs" />
     <Compile Include="Layout3D/Terrain.fs" />
-  <Compile Include="Graphics3D/Light3D.fs" />
+    <Compile Include="Graphics3D/Light3D.fs" />
+    <Compile Include="Graphics2D/Types.fs" />
+    <Compile Include="Graphics/Draw.fs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mibo.MonoGame/Graphics2D/Command2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/Command2D.fs
@@ -5,10 +5,6 @@ open Microsoft.Xna.Framework.Graphics
 open Mibo.Elmish
 open Mibo.Elmish.Graphics2D.Lighting
 
-/// <summary>Unit of measure for 2D render layer ordering.</summary>
-[<Measure>]
-type RenderLayer
-
 /// <summary>State required to render a 2D sprite via SpriteBatch.Draw.</summary>
 [<Struct>]
 type SpriteState = {

--- a/src/Mibo.MonoGame/Graphics2D/RenderBuffer2D.fs
+++ b/src/Mibo.MonoGame/Graphics2D/RenderBuffer2D.fs
@@ -157,3 +157,739 @@ type RenderBuffer2D
         keys <- Array.empty<int64>
         ArrayPool<Command2D>.Shared.Return(toReturnItems, true)
         ArrayPool<int64>.Shared.Return(toReturnKeys)
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fluent Draw DSL witnesses (backing Mibo.Elmish.Graphics.Draw).
+//
+// One `member inline` per Core Draw member: convert neutral types (Mibo.Color,
+// System.Numerics vectors, float rects) to XNA types and construct the
+// Command2D case directly — no dependency on the piped DSL or the Command2D
+// builder module. Everything is inline — the layer erases at the call site.
+// Augmentations must live in the buffer's own file: the SRTP solver only
+// considers extension members in the type's declaration group.
+// ─────────────────────────────────────────────────────────────────────────────
+
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Graphics
+open System.Numerics
+open Mibo.Animation
+open Mibo.Elmish
+open Mibo.Elmish.Graphics2D.Lighting
+open Mibo
+
+/// <summary>Inline XNA conversions for the witness surface.</summary>
+module internal DrawWitnessConvert =
+
+  let inline v2(v: Vector2) =
+    Microsoft.Xna.Framework.Vector2.op_Implicit v
+
+  let inline rect (x: float32) (y: float32) (w: float32) (h: float32) =
+    Microsoft.Xna.Framework.Rectangle(int x, int y, int w, int h)
+
+  let inline color(c: Color) = MonoGameColor.toMonoGameColor c
+
+/// <summary>SRTP witnesses backing <see cref="T:Mibo.Elmish.Graphics.Draw"/> on the MonoGame 2D buffer.</summary>
+type RenderBuffer2D with
+
+  // ── Sprites & Text ──
+
+  member inline b.AddSpriteState(state: SpriteState) =
+    b.Add(
+      Command2D.Sprite(
+        state.Texture,
+        state.Dest,
+        state.Source,
+        state.Origin,
+        state.Rotation,
+        state.Color,
+        state.Layer
+      )
+    )
+
+  member inline b.AddTextState(state: TextState) =
+    b.Add(
+      Command2D.Text(
+        state.Font,
+        state.Text,
+        state.Position,
+        state.Scale,
+        state.Color,
+        state.Layer
+      )
+    )
+
+  /// size→Scale; spacing DROPPED (SpriteBatch has no per-draw spacing) — the
+  /// documented semantic adaptation for the differing TextState shapes.
+  member inline b.AddText
+    (
+      font: SpriteFont,
+      text: string,
+      position: Vector2,
+      size: float32,
+      _spacing: float32,
+      tint: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.Text(
+        font,
+        text,
+        DrawWitnessConvert.v2 position,
+        size,
+        DrawWitnessConvert.color tint,
+        layer
+      )
+    )
+
+  // ── Rectangles ──
+
+  member inline b.AddFillRect
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillRect(
+        DrawWitnessConvert.rect x y w h,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddRectOutline
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectOutline(
+        DrawWitnessConvert.rect x y w h,
+        thickness,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddFillRectRounded
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      roundness: float32,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillRectRounded(
+        DrawWitnessConvert.rect x y w h,
+        roundness,
+        segments,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddRectRoundedOutline
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      roundness: float32,
+      segments: int,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectRoundedOutline(
+        DrawWitnessConvert.rect x y w h,
+        roundness,
+        segments,
+        thickness,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddRectGradientV
+    (
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      top: Color,
+      bottom: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectGradientV(
+        x,
+        y,
+        w,
+        h,
+        DrawWitnessConvert.color top,
+        DrawWitnessConvert.color bottom,
+        layer
+      )
+    )
+
+  member inline b.AddRectGradientH
+    (
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      left: Color,
+      right: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectGradientH(
+        x,
+        y,
+        w,
+        h,
+        DrawWitnessConvert.color left,
+        DrawWitnessConvert.color right,
+        layer
+      )
+    )
+
+  member inline b.AddRectGradient
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      tl: Color,
+      bl: Color,
+      tr: Color,
+      br: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectGradient(
+        DrawWitnessConvert.rect x y w h,
+        DrawWitnessConvert.color tl,
+        DrawWitnessConvert.color bl,
+        DrawWitnessConvert.color tr,
+        DrawWitnessConvert.color br,
+        layer
+      )
+    )
+
+  // ── Circles, Rings, Ellipses ──
+
+  member inline b.AddFillCircle
+    (center: Vector2, radius: float32, color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(
+      Command2D.FillCircle(
+        DrawWitnessConvert.v2 center,
+        radius,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleOutline
+    (center: Vector2, radius: float32, color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(
+      Command2D.CircleOutline(
+        DrawWitnessConvert.v2 center,
+        radius,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleSector
+    (
+      center: Vector2,
+      radius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.CircleSector(
+        DrawWitnessConvert.v2 center,
+        radius,
+        startAngle,
+        endAngle,
+        segments,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleSectorOutline
+    (
+      center: Vector2,
+      radius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.CircleSectorOutline(
+        DrawWitnessConvert.v2 center,
+        radius,
+        startAngle,
+        endAngle,
+        segments,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleGradient
+    (
+      centerX: int,
+      centerY: int,
+      radius: float32,
+      inner: Color,
+      outer: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.CircleGradient(
+        centerX,
+        centerY,
+        radius,
+        DrawWitnessConvert.color inner,
+        DrawWitnessConvert.color outer,
+        layer
+      )
+    )
+
+  member inline b.AddFillRing
+    (
+      center: Vector2,
+      innerR: float32,
+      outerR: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillRing(
+        DrawWitnessConvert.v2 center,
+        innerR,
+        outerR,
+        startAngle,
+        endAngle,
+        segments,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddRingOutline
+    (
+      center: Vector2,
+      innerR: float32,
+      outerR: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RingOutline(
+        DrawWitnessConvert.v2 center,
+        innerR,
+        outerR,
+        startAngle,
+        endAngle,
+        segments,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddFillEllipse
+    (
+      centerX: int,
+      centerY: int,
+      radiusH: float32,
+      radiusV: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillEllipse(
+        centerX,
+        centerY,
+        radiusH,
+        radiusV,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddEllipseOutline
+    (
+      centerX: int,
+      centerY: int,
+      radiusH: float32,
+      radiusV: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.EllipseOutline(
+        centerX,
+        centerY,
+        radiusH,
+        radiusV,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  // ── Lines & Curves ──
+
+  member inline b.AddLine
+    (start: Vector2, finish: Vector2, color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(
+      Command2D.Line(
+        DrawWitnessConvert.v2 start,
+        DrawWitnessConvert.v2 finish,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddLineThick
+    (
+      start: Vector2,
+      finish: Vector2,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.LineThick(
+        DrawWitnessConvert.v2 start,
+        DrawWitnessConvert.v2 finish,
+        thickness,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddLineStrip
+    (
+      points: Microsoft.Xna.Framework.Vector2[],
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(Command2D.LineStrip(points, DrawWitnessConvert.color color, layer))
+
+  member inline b.AddBezier
+    (
+      start: Vector2,
+      control: Vector2,
+      finish: Vector2,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.Bezier(
+        DrawWitnessConvert.v2 start,
+        DrawWitnessConvert.v2 control,
+        DrawWitnessConvert.v2 finish,
+        thickness,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  // ── Triangles & Polygons ──
+
+  member inline b.AddTriangle
+    (
+      v1: Vector2,
+      v2: Vector2,
+      v3: Vector2,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.Triangle(
+        DrawWitnessConvert.v2 v1,
+        DrawWitnessConvert.v2 v2,
+        DrawWitnessConvert.v2 v3,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddTriangleFan
+    (
+      points: Microsoft.Xna.Framework.Vector2[],
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(Command2D.TriangleFan(points, DrawWitnessConvert.color color, layer))
+
+  member inline b.AddTriangleStrip
+    (
+      points: Microsoft.Xna.Framework.Vector2[],
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.TriangleStrip(points, DrawWitnessConvert.color color, layer)
+    )
+
+  member inline b.AddFillPoly
+    (
+      center: Vector2,
+      sides: int,
+      radius: float32,
+      rotation: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillPoly(
+        DrawWitnessConvert.v2 center,
+        sides,
+        radius,
+        rotation,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  member inline b.AddPolyOutline
+    (
+      center: Vector2,
+      sides: int,
+      radius: float32,
+      rotation: float32,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.PolyOutline(
+        DrawWitnessConvert.v2 center,
+        sides,
+        radius,
+        rotation,
+        thickness,
+        DrawWitnessConvert.color color,
+        layer
+      )
+    )
+
+  // ── Camera, Shader, Target ──
+
+  member inline b.AddBeginCamera(camera: Camera2D, layer: int<RenderLayer>) =
+    b.Add(Command2D.BeginCamera(camera, layer))
+
+  member inline b.AddBeginCameraConfig
+    (config: Camera2DConfig, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.BeginCameraConfig(config, layer))
+
+  member inline b.AddEndCamera(layer: int<RenderLayer>) =
+    b.Add(Command2D.EndCamera layer)
+
+  member inline b.AddBeginShader(shader: Effect, layer: int<RenderLayer>) =
+    b.Add(Command2D.BeginShader(shader, layer))
+
+  member inline b.AddEndShader(layer: int<RenderLayer>) =
+    b.Add(Command2D.EndShader layer)
+
+  member inline b.AddBeginTarget
+    (target: RenderTarget2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.BeginTarget(target, layer))
+
+  member inline b.AddEndTarget(layer: int<RenderLayer>) =
+    b.Add(Command2D.EndTarget layer)
+
+  // ── Render State ──
+
+  member inline b.AddSetBlend(mode: BlendMode, layer: int<RenderLayer>) =
+    b.Add(Command2D.SetBlend(mode, layer))
+
+  /// MonoGame-only witness — the Core Draw.SetSamplerState member has no
+  /// raylib counterpart; capability gating via witness presence.
+  member inline b.AddSamplerState
+    (sampler: SamplerState, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.SetSamplerState(sampler, layer))
+
+  member inline b.AddSetScissor
+    (x: int, y: int, w: int, h: int, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.SetScissor(x, y, w, h, layer))
+
+  member inline b.AddClearScissor(layer: int<RenderLayer>) =
+    b.Add(Command2D.ClearScissor layer)
+
+  member inline b.AddSetLineWidth(width: float32, layer: int<RenderLayer>) =
+    b.Add(Command2D.SetLineWidth(width, layer))
+
+  member inline b.AddSetViewport
+    (x: int, y: int, w: int, h: int, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.SetViewport(x, y, w, h, layer))
+
+  // ── Escape Hatches ──
+
+  member inline b.AddDrawImmediate
+    ([<InlineIfLambda>] action: unit -> unit, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.DrawImmediate(action, layer))
+
+  member inline b.AddClear(color: Color, layer: int<RenderLayer>) =
+    b.Add(Command2D.Clear(DrawWitnessConvert.color color, layer))
+
+  member inline b.AddPostProcess
+    ([<InlineIfLambda>] action: PostProcessContext2D -> unit)
+    =
+    b.Add(Command2D.PostProcess action)
+
+  // ── Particles ──
+
+  member inline b.AddParticles
+    (
+      texture: Texture2D,
+      particles: Particle2D[],
+      count: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(Command2D.Particle(texture, particles, count, layer))
+
+  // ── Lighting ──
+  // LightCommands.fs compiles AFTER this file (LightDraw needs the buffer),
+  // so the witnesses inline the (small, stable) light-command bodies instead.
+
+  member inline b.AddSetAmbient
+    (lightCtx: LightContext2D, color: Color, layer: int<RenderLayer>)
+    =
+    lightCtx.Ambient <- DrawWitnessConvert.color color
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddPointLight
+    (lightCtx: LightContext2D, light: PointLight2D, layer: int<RenderLayer>)
+    =
+    lightCtx.PointLights.Add light
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddDirectionalLightState
+    (
+      lightCtx: LightContext2D,
+      light: DirectionalLight2D,
+      layer: int<RenderLayer>
+    ) =
+    lightCtx.DirLights.Add light
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddDirectionalLight
+    (
+      lightCtx: LightContext2D,
+      direction: Vector2,
+      color: Color,
+      intensity: float32,
+      castsShadows: bool,
+      layer: int<RenderLayer>
+    ) =
+    lightCtx.DirLights.Add {
+      Direction = DrawWitnessConvert.v2 direction
+      Color = DrawWitnessConvert.color color
+      Intensity = intensity
+      CastsShadows = castsShadows
+    }
+
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddOccluder
+    (lightCtx: LightContext2D, occluder: Occluder2D, layer: int<RenderLayer>)
+    =
+    lightCtx.Occluders.Add occluder
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddLitSprite(lightCtx: LightContext2D, sprite: SpriteState) =
+    b.Add(Command2D.LitSprite(lightCtx, sprite))
+
+  member inline b.AddLitAnimatedSprite
+    (
+      lightCtx: LightContext2D,
+      dest: Microsoft.Xna.Framework.Rectangle,
+      animSprite: AnimatedSprite,
+      layer: int<RenderLayer>
+    ) =
+    let src = AnimatedSprite.currentSource animSprite
+
+    let src =
+      if animSprite.FlipX then
+        Rectangle(src.X, src.Y, -src.Width, src.Height)
+      else
+        src
+
+    let src =
+      if animSprite.FlipY then
+        Rectangle(src.X, src.Y, src.Width, -src.Height)
+      else
+        src
+
+    b.Add(
+      Command2D.LitSprite(
+        lightCtx,
+        {
+          Texture = animSprite.Sheet.Texture
+          Dest = dest
+          Source = src
+          Origin = animSprite.Sheet.Origin
+          Rotation = animSprite.Rotation
+          Color = animSprite.Color
+          Layer = layer
+          NormalMap = animSprite.Sheet.NormalMap
+        }
+      )
+    )
+
+  member inline b.AddEndLighting
+    (lightCtx: LightContext2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.EndLighting(lightCtx, layer))
+
+  member inline b.AddEnableShadows
+    (lightCtx: LightContext2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.EnableShadows(lightCtx, layer))
+
+  member inline b.AddDisableShadows
+    (lightCtx: LightContext2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.DisableShadows(lightCtx, layer))

--- a/src/Mibo.MonoGame/Graphics3D/RenderBuffer3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/RenderBuffer3D.fs
@@ -114,3 +114,206 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
       ArrayPool<Command3D>.Shared.Return(items, clearArray = true)
       items <- Array.empty
       count <- 0
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fluent Draw DSL witnesses (backing Mibo.Elmish.Graphics.Draw).
+//
+// One `member inline` per Core Draw member: forward to the existing Command3D
+// builders, converting System.Numerics vectors to XNA at the boundary via the
+// existing internal Conversions module. 3D has no layer concept — camera and
+// immediate witnesses accept and ignore the layer the shared Draw members
+// pass. Augmentations must live in the buffer's own file: the SRTP solver
+// only considers extension members in the type's declaration group.
+// ─────────────────────────────────────────────────────────────────────────────
+
+open Microsoft.Xna.Framework
+open Microsoft.Xna.Framework.Graphics
+open System.Numerics
+open Mibo.Animation
+open Mibo.Elmish
+open Mibo.Elmish.Graphics2D
+open Mibo.Elmish.Graphics3D.Pipelines
+open Mibo
+
+/// <summary>SRTP witnesses backing <see cref="T:Mibo.Elmish.Graphics.Draw"/> on the MonoGame 3D buffer.</summary>
+type RenderBuffer3D with
+
+  // ── Geometry ──
+
+  /// MonoGame's mesh-level draw is the effectless PrimitiveMesh.
+  member inline b.AddDrawMesh
+    (mesh: PrimitiveMesh, transform: Matrix, material: Material3D)
+    =
+    b.Add(Command3D.DrawPrimitive(mesh, transform, material))
+
+  member inline b.AddDrawInstanced
+    (
+      mesh: PrimitiveMesh,
+      transforms: Matrix[],
+      material: Material3D,
+      instanceCount: int
+    ) =
+    b.Add(Command3D.DrawInstanced(mesh, transforms, material, instanceCount))
+
+  member inline b.AddDrawModel(model: Model, transform: Matrix) =
+    b.Add(Command3D.DrawModel(model, transform))
+
+  member inline b.AddDrawModelWith
+    (model: Model, transform: Matrix, material: Material3D)
+    =
+    b.Add(
+      Command3D.DrawModelWith(model, transform, MaterialOverride.All material)
+    )
+
+  member inline b.AddDrawModelWithPerMesh
+    (
+      model: Model,
+      transform: Matrix,
+      [<InlineIfLambda>] resolver: int -> Material3D
+    ) =
+    b.Add(
+      Command3D.DrawModelWith(
+        model,
+        transform,
+        MaterialOverride.PerMesh resolver
+      )
+    )
+
+  /// MonoGame animated draw: derives the bone palette from the state.
+  member inline b.AddAnimatedModel(am: AnimatedModel, transform: Matrix) =
+    let bones =
+      match am.Mesh with
+      | ValueSome mesh -> Animation3DState.computeBonePalette mesh am.State
+      | ValueNone -> [||]
+
+    b.Add(Command3D.DrawAnimatedModel(am.Model, transform, bones))
+
+  member inline b.AddAnimatedModelWith
+    (am: AnimatedModel, transform: Matrix, material: Material3D)
+    =
+    let bones =
+      match am.Mesh with
+      | ValueSome mesh -> Animation3DState.computeBonePalette mesh am.State
+      | ValueNone -> [||]
+
+    b.Add(
+      Command3D.DrawAnimatedModelWith(
+        am.Model,
+        transform,
+        bones,
+        MaterialOverride.All material
+      )
+    )
+
+  member inline b.AddAnimatedModelWithPerMesh
+    (
+      am: AnimatedModel,
+      transform: Matrix,
+      [<InlineIfLambda>] resolver: int -> Material3D
+    ) =
+    let bones =
+      match am.Mesh with
+      | ValueSome mesh -> Animation3DState.computeBonePalette mesh am.State
+      | ValueNone -> [||]
+
+    b.Add(
+      Command3D.DrawAnimatedModelWith(
+        am.Model,
+        transform,
+        bones,
+        MaterialOverride.PerMesh resolver
+      )
+    )
+
+  // ── Billboards & Lines ──
+
+  member inline b.AddBillboard
+    (texture: Texture2D, position: Vector3, size: Vector2, color: Color)
+    =
+    b.Add(
+      Command3D.DrawBillboard(
+        texture,
+        Conversions.fromNumericsVector3 position,
+        Conversions.fromNumericsVector2 size,
+        MonoGameColor.toMonoGameColor color
+      )
+    )
+
+  member inline b.AddBillboardBatch
+    (
+      textures: Texture2D[],
+      positions: Microsoft.Xna.Framework.Vector3[],
+      sizes: Microsoft.Xna.Framework.Vector2[],
+      colors: Microsoft.Xna.Framework.Color[],
+      count: int
+    ) =
+    b.Add(
+      Command3D.DrawBillboardBatch(textures, positions, sizes, colors, count)
+    )
+
+  member inline b.AddLine3D(start: Vector3, finish: Vector3, color: Color) =
+    b.Add(
+      Command3D.DrawLine3D(
+        Conversions.fromNumericsVector3 start,
+        Conversions.fromNumericsVector3 finish,
+        MonoGameColor.toMonoGameColor color
+      )
+    )
+
+  // ── Camera (layer ignored — 3D has no layers) ──
+
+  member inline b.AddBeginCamera(camera: Camera3D, _layer: int<RenderLayer>) =
+    b.Add(Command3D.BeginCamera camera)
+
+  member inline b.AddBeginCameraConfig
+    (config: Camera3DConfig, _layer: int<RenderLayer>)
+    =
+    b.Add(Command3D.BeginCameraConfig config)
+
+  member inline b.AddEndCamera(_layer: int<RenderLayer>) =
+    b.Add Command3D.EndCamera
+
+  // ── Shadows & Effect Scopes ──
+
+  member inline b.AddSetShadowOrigin(origin: Vector3) =
+    b.Add(Command3D.SetShadowOrigin(Conversions.fromNumericsVector3 origin))
+
+  member inline b.AddEnableShadows3D() = b.Add Command3D.EnableShadows
+
+  member inline b.AddDisableShadows3D() = b.Add Command3D.DisableShadows
+
+  member inline b.AddBeginEffect(effect: Effect) =
+    b.Add(Command3D.BeginEffect effect)
+
+  member inline b.AddEndEffect() = b.Add Command3D.EndEffect
+
+  // ── Lights (Core types, pass-through) ──
+
+  member inline b.AddSetAmbientLight(light: AmbientLight3D) =
+    b.Add(Command3D.SetAmbientLight light)
+
+  member inline b.AddDirectionalLight(light: DirectionalLight3D) =
+    b.Add(Command3D.AddDirectionalLight light)
+
+  member inline b.AddPointLight(light: PointLight3D) =
+    b.Add(Command3D.AddPointLight light)
+
+  member inline b.AddSpotLight(light: SpotLight3D) =
+    b.Add(Command3D.AddSpotLight light)
+
+  // ── Escape Hatches ──
+
+  member inline b.AddDrawImmediate
+    ([<InlineIfLambda>] action: SceneContext -> unit, _layer: int<RenderLayer>)
+    =
+    b.Add(Command3D.DrawImmediate action)
+
+  member inline b.AddPostProcess
+    ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
+    =
+    b.Add(Command3D.PostProcess action)
+
+  member inline b.AddPostProcessWithDepth
+    ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
+    =
+    b.Add(Command3D.PostProcessWithDepth action)

--- a/src/Mibo.Raylib/Graphics2D/Command2D.fs
+++ b/src/Mibo.Raylib/Graphics2D/Command2D.fs
@@ -6,10 +6,6 @@ open Raylib_cs
 open Mibo.Elmish
 open Mibo.Elmish.Graphics2D.Lighting
 
-/// <summary>Unit of measure for 2D render layer ordering.</summary>
-[<Measure>]
-type RenderLayer
-
 /// <summary>State required to render a 2D sprite via DrawTexturePro.</summary>
 [<Struct>]
 type SpriteState = {

--- a/src/Mibo.Raylib/Graphics2D/RenderBuffer.fs
+++ b/src/Mibo.Raylib/Graphics2D/RenderBuffer.fs
@@ -138,3 +138,699 @@ type RenderBuffer2D
   /// and population, before iteration.
   /// </summary>
   member _.Sort() = Array.Sort(keys, items, 0, count)
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fluent Draw DSL witnesses (backing Mibo.Elmish.Graphics.Draw).
+//
+// One `member inline` per Core Draw member: convert neutral types (Mibo.Color,
+// System.Numerics vectors, float rects) to raylib types and construct the
+// Command2D case directly — no dependency on the piped DSL or the Command2D
+// builder module. Everything is inline — the entire layer erases at the call
+// site. Augmentations must live in the buffer's own file: the SRTP solver
+// only considers extension members in the type's declaration group.
+// ─────────────────────────────────────────────────────────────────────────────
+
+open System.Numerics
+open Raylib_cs
+open Mibo.Animation
+open Mibo.Elmish
+open Mibo.Elmish.Graphics2D.Lighting
+open Mibo
+
+/// <summary>SRTP witnesses backing <see cref="T:Mibo.Elmish.Graphics.Draw"/> on the raylib 2D buffer.</summary>
+type RenderBuffer2D with
+
+  // ── Sprites & Text ──
+
+  member inline b.AddSpriteState(state: SpriteState) =
+    b.Add(
+      Command2D.Sprite(
+        state.Texture,
+        state.Dest,
+        state.Source,
+        state.Origin,
+        state.Rotation,
+        state.Color,
+        state.Layer
+      )
+    )
+
+  member inline b.AddTextState(state: Command2D.TextState) =
+    b.Add(
+      Command2D.Text(
+        state.Font,
+        state.Text,
+        state.Position,
+        state.FontSize,
+        state.Spacing,
+        state.Color,
+        state.Layer
+      )
+    )
+
+  /// size→FontSize, spacing used directly (raylib DrawTextEx semantics).
+  member inline b.AddText
+    (
+      font: Font,
+      text: string,
+      position: Vector2,
+      size: float32,
+      spacing: float32,
+      tint: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.Text(
+        font,
+        text,
+        position,
+        size,
+        spacing,
+        RaylibColor.toRaylibColor tint,
+        layer
+      )
+    )
+
+  // ── Rectangles ──
+
+  member inline b.AddFillRect
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillRect(
+        Rectangle(x, y, w, h),
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddRectOutline
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectOutline(
+        Rectangle(x, y, w, h),
+        thickness,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddFillRectRounded
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      roundness: float32,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillRectRounded(
+        Rectangle(x, y, w, h),
+        roundness,
+        segments,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddRectRoundedOutline
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      color: Color,
+      roundness: float32,
+      segments: int,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectRoundedOutline(
+        Rectangle(x, y, w, h),
+        roundness,
+        segments,
+        thickness,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddRectGradientV
+    (
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      top: Color,
+      bottom: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectGradientV(
+        x,
+        y,
+        w,
+        h,
+        RaylibColor.toRaylibColor top,
+        RaylibColor.toRaylibColor bottom,
+        layer
+      )
+    )
+
+  member inline b.AddRectGradientH
+    (
+      x: int,
+      y: int,
+      w: int,
+      h: int,
+      left: Color,
+      right: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectGradientH(
+        x,
+        y,
+        w,
+        h,
+        RaylibColor.toRaylibColor left,
+        RaylibColor.toRaylibColor right,
+        layer
+      )
+    )
+
+  member inline b.AddRectGradient
+    (
+      x: float32,
+      y: float32,
+      w: float32,
+      h: float32,
+      tl: Color,
+      bl: Color,
+      tr: Color,
+      br: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RectGradient(
+        Rectangle(x, y, w, h),
+        RaylibColor.toRaylibColor tl,
+        RaylibColor.toRaylibColor bl,
+        RaylibColor.toRaylibColor tr,
+        RaylibColor.toRaylibColor br,
+        layer
+      )
+    )
+
+  // ── Circles, Rings, Ellipses ──
+
+  member inline b.AddFillCircle
+    (center: Vector2, radius: float32, color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(
+      Command2D.FillCircle(
+        center,
+        radius,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleOutline
+    (center: Vector2, radius: float32, color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(
+      Command2D.CircleOutline(
+        center,
+        radius,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleSector
+    (
+      center: Vector2,
+      radius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.CircleSector(
+        center,
+        radius,
+        startAngle,
+        endAngle,
+        segments,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleSectorOutline
+    (
+      center: Vector2,
+      radius: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.CircleSectorOutline(
+        center,
+        radius,
+        startAngle,
+        endAngle,
+        segments,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddCircleGradient
+    (
+      centerX: int,
+      centerY: int,
+      radius: float32,
+      inner: Color,
+      outer: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.CircleGradient(
+        centerX,
+        centerY,
+        radius,
+        RaylibColor.toRaylibColor inner,
+        RaylibColor.toRaylibColor outer,
+        layer
+      )
+    )
+
+  member inline b.AddFillRing
+    (
+      center: Vector2,
+      innerR: float32,
+      outerR: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillRing(
+        center,
+        innerR,
+        outerR,
+        startAngle,
+        endAngle,
+        segments,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddRingOutline
+    (
+      center: Vector2,
+      innerR: float32,
+      outerR: float32,
+      startAngle: float32,
+      endAngle: float32,
+      color: Color,
+      segments: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.RingOutline(
+        center,
+        innerR,
+        outerR,
+        startAngle,
+        endAngle,
+        segments,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddFillEllipse
+    (
+      centerX: int,
+      centerY: int,
+      radiusH: float32,
+      radiusV: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillEllipse(
+        centerX,
+        centerY,
+        radiusH,
+        radiusV,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddEllipseOutline
+    (
+      centerX: int,
+      centerY: int,
+      radiusH: float32,
+      radiusV: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.EllipseOutline(
+        centerX,
+        centerY,
+        radiusH,
+        radiusV,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  // ── Lines & Curves ──
+
+  member inline b.AddLine
+    (start: Vector2, finish: Vector2, color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.Line(start, finish, RaylibColor.toRaylibColor color, layer))
+
+  member inline b.AddLineThick
+    (
+      start: Vector2,
+      finish: Vector2,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.LineThick(
+        start,
+        finish,
+        thickness,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddLineStrip
+    (points: Vector2[], color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.LineStrip(points, RaylibColor.toRaylibColor color, layer))
+
+  member inline b.AddBezier
+    (
+      start: Vector2,
+      control: Vector2,
+      finish: Vector2,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.Bezier(
+        start,
+        control,
+        finish,
+        thickness,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  // ── Triangles & Polygons ──
+
+  member inline b.AddTriangle
+    (
+      v1: Vector2,
+      v2: Vector2,
+      v3: Vector2,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.Triangle(v1, v2, v3, RaylibColor.toRaylibColor color, layer)
+    )
+
+  member inline b.AddTriangleFan
+    (points: Vector2[], color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.TriangleFan(points, RaylibColor.toRaylibColor color, layer))
+
+  member inline b.AddTriangleStrip
+    (points: Vector2[], color: Color, layer: int<RenderLayer>)
+    =
+    b.Add(
+      Command2D.TriangleStrip(points, RaylibColor.toRaylibColor color, layer)
+    )
+
+  member inline b.AddFillPoly
+    (
+      center: Vector2,
+      sides: int,
+      radius: float32,
+      rotation: float32,
+      color: Color,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.FillPoly(
+        center,
+        sides,
+        radius,
+        rotation,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  member inline b.AddPolyOutline
+    (
+      center: Vector2,
+      sides: int,
+      radius: float32,
+      rotation: float32,
+      color: Color,
+      thickness: float32,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(
+      Command2D.PolyOutline(
+        center,
+        sides,
+        radius,
+        rotation,
+        thickness,
+        RaylibColor.toRaylibColor color,
+        layer
+      )
+    )
+
+  // ── Camera, Shader, Target ──
+
+  member inline b.AddBeginCamera(camera: Camera2D, layer: int<RenderLayer>) =
+    b.Add(Command2D.BeginCamera(camera, layer))
+
+  member inline b.AddBeginCameraConfig
+    (config: Camera2DConfig, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.BeginCameraConfig(config, layer))
+
+  member inline b.AddEndCamera(layer: int<RenderLayer>) =
+    b.Add(Command2D.EndCamera layer)
+
+  member inline b.AddBeginShader(shader: Shader, layer: int<RenderLayer>) =
+    b.Add(Command2D.BeginShader(shader, layer))
+
+  member inline b.AddEndShader(layer: int<RenderLayer>) =
+    b.Add(Command2D.EndShader layer)
+
+  member inline b.AddBeginTarget
+    (target: RenderTexture2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.BeginTarget(target, layer))
+
+  member inline b.AddEndTarget(layer: int<RenderLayer>) =
+    b.Add(Command2D.EndTarget layer)
+
+  // ── Render State ──
+
+  member inline b.AddSetBlend(mode: BlendMode, layer: int<RenderLayer>) =
+    b.Add(Command2D.SetBlend(mode, layer))
+
+  member inline b.AddSetScissor
+    (x: int, y: int, w: int, h: int, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.SetScissor(x, y, w, h, layer))
+
+  member inline b.AddClearScissor(layer: int<RenderLayer>) =
+    b.Add(Command2D.ClearScissor layer)
+
+  member inline b.AddSetLineWidth(width: float32, layer: int<RenderLayer>) =
+    b.Add(Command2D.SetLineWidth(width, layer))
+
+  member inline b.AddSetViewport
+    (x: int, y: int, w: int, h: int, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.SetViewport(x, y, w, h, layer))
+
+  // ── Escape Hatches ──
+
+  member inline b.AddDrawImmediate
+    ([<InlineIfLambda>] action: unit -> unit, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.DrawImmediate(action, layer))
+
+  member inline b.AddClear(color: Color, layer: int<RenderLayer>) =
+    b.Add(Command2D.Clear(RaylibColor.toRaylibColor color, layer))
+
+  member inline b.AddPostProcess
+    ([<InlineIfLambda>] action: PostProcessContext2D -> unit)
+    =
+    b.Add(Command2D.PostProcess action)
+
+  // ── Particles ──
+
+  member inline b.AddParticles
+    (
+      texture: Texture2D,
+      particles: Particle2D[],
+      count: int,
+      layer: int<RenderLayer>
+    ) =
+    b.Add(Command2D.Particle(texture, particles, count, layer))
+
+  // ── Lighting ──
+  // LightCommands.fs compiles AFTER this file (LightDraw needs the buffer),
+  // so the witnesses inline the (small, stable) light-command bodies instead.
+
+  member inline b.AddSetAmbient
+    (lightCtx: LightContext2D, color: Color, layer: int<RenderLayer>)
+    =
+    lightCtx.Ambient <- RaylibColor.toRaylibColor color
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddPointLight
+    (lightCtx: LightContext2D, light: PointLight2D, layer: int<RenderLayer>)
+    =
+    lightCtx.PointLights.Add light
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddDirectionalLightState
+    (
+      lightCtx: LightContext2D,
+      light: DirectionalLight2D,
+      layer: int<RenderLayer>
+    ) =
+    lightCtx.DirLights.Add light
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddDirectionalLight
+    (
+      lightCtx: LightContext2D,
+      direction: Vector2,
+      color: Color,
+      intensity: float32,
+      castsShadows: bool,
+      layer: int<RenderLayer>
+    ) =
+    lightCtx.DirLights.Add {
+      Direction = direction
+      Color = RaylibColor.toRaylibColor color
+      Intensity = intensity
+      CastsShadows = castsShadows
+    }
+
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddOccluder
+    (lightCtx: LightContext2D, occluder: Occluder2D, layer: int<RenderLayer>)
+    =
+    lightCtx.Occluders.Add occluder
+    b.Add(Command2D.NoopLight layer)
+
+  member inline b.AddLitSprite(lightCtx: LightContext2D, sprite: SpriteState) =
+    b.Add(Command2D.LitSprite(lightCtx, sprite))
+
+  member inline b.AddLitAnimatedSprite
+    (
+      lightCtx: LightContext2D,
+      dest: Rectangle,
+      animSprite: AnimatedSprite,
+      layer: int<RenderLayer>
+    ) =
+    let src = AnimatedSprite.currentSource animSprite
+
+    let src =
+      if animSprite.FlipX then
+        Rectangle(src.X, src.Y, -src.Width, src.Height)
+      else
+        src
+
+    let src =
+      if animSprite.FlipY then
+        Rectangle(src.X, src.Y, src.Width, -src.Height)
+      else
+        src
+
+    b.Add(
+      Command2D.LitSprite(
+        lightCtx,
+        {
+          Texture = animSprite.Sheet.Texture
+          Dest = dest
+          Source = src
+          Origin = animSprite.Sheet.Origin
+          Rotation = animSprite.Rotation
+          Color = animSprite.Color
+          Layer = layer
+          NormalMap = animSprite.Sheet.NormalMap
+        }
+      )
+    )
+
+  member inline b.AddEndLighting
+    (lightCtx: LightContext2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.EndLighting(lightCtx, layer))
+
+  member inline b.AddEnableShadows
+    (lightCtx: LightContext2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.EnableShadows(lightCtx, layer))
+
+  member inline b.AddDisableShadows
+    (lightCtx: LightContext2D, layer: int<RenderLayer>)
+    =
+    b.Add(Command2D.DisableShadows(lightCtx, layer))

--- a/src/Mibo.Raylib/Graphics3D/RenderBuffer3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderBuffer3D.fs
@@ -101,3 +101,198 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
       ArrayPool<Command3D>.Shared.Return(items, clearArray = true)
       items <- Array.empty
       count <- 0
+
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fluent Draw DSL witnesses (backing Mibo.Elmish.Graphics.Draw).
+//
+// One `member inline` per Core Draw member: construct the Command3D case
+// directly (converting Mibo.Color where a command carries a color) — no
+// dependency on the piped DSL or the Command3D builder module. 3D has no
+// layer concept — camera/immediate witnesses accept and ignore the layer the
+// shared Draw members pass. Augmentations must live in the buffer's own file:
+// the SRTP solver only considers extension members in the type's declaration
+// group. Everything is inline; the layer erases.
+// ─────────────────────────────────────────────────────────────────────────────
+
+open System.Numerics
+open Raylib_cs
+open Mibo.Animation
+open Mibo.Elmish
+open Mibo.Elmish.Graphics2D
+open Mibo.Elmish.Graphics3D.Pipelines
+open Mibo
+
+/// <summary>SRTP witnesses backing <see cref="T:Mibo.Elmish.Graphics.Draw"/> on the raylib 3D buffer.</summary>
+type RenderBuffer3D with
+
+  // ── Geometry ──
+
+  member inline b.AddDrawMesh
+    (mesh: Mesh, transform: Matrix4x4, material: Material3D)
+    =
+    b.Add(Command3D.DrawMesh(mesh, transform, material))
+
+  member inline b.AddDrawInstanced
+    (
+      mesh: Mesh,
+      transforms: Matrix4x4[],
+      material: Material3D,
+      instanceCount: int
+    ) =
+    b.Add(
+      Command3D.DrawMeshInstanced(mesh, transforms, material, instanceCount)
+    )
+
+  member inline b.AddDrawModel(model: Model, transform: Matrix4x4) =
+    b.Add(Command3D.DrawModel(model, transform))
+
+  member inline b.AddDrawModelWith
+    (model: Model, transform: Matrix4x4, material: Material3D)
+    =
+    b.Add(
+      Command3D.DrawModelWith(model, transform, MaterialOverride.All material)
+    )
+
+  member inline b.AddDrawModelWithPerMesh
+    (
+      model: Model,
+      transform: Matrix4x4,
+      [<InlineIfLambda>] resolver: int -> Material3D
+    ) =
+    b.Add(
+      Command3D.DrawModelWith(
+        model,
+        transform,
+        MaterialOverride.PerMesh resolver
+      )
+    )
+
+  /// raylib animated draw: applies the state's bone pose to its embedded model
+  /// (raylib's UpdateModelAnimation path), then draws the model.
+  member inline b.AddAnimatedModel
+    (state: Animation3DState, transform: Matrix4x4)
+    =
+    Animation3DState.applyToModel state
+    b.Add(Command3D.DrawModel(state.Model, transform))
+
+  member inline b.AddAnimatedModelWith
+    (state: Animation3DState, transform: Matrix4x4, material: Material3D)
+    =
+    Animation3DState.applyToModel state
+
+    b.Add(
+      Command3D.DrawModelWith(
+        state.Model,
+        transform,
+        MaterialOverride.All material
+      )
+    )
+
+  member inline b.AddAnimatedModelWithPerMesh
+    (
+      state: Animation3DState,
+      transform: Matrix4x4,
+      [<InlineIfLambda>] resolver: int -> Material3D
+    ) =
+    Animation3DState.applyToModel state
+
+    b.Add(
+      Command3D.DrawModelWith(
+        state.Model,
+        transform,
+        MaterialOverride.PerMesh resolver
+      )
+    )
+
+  member inline b.AddSkinnedMesh
+    (mesh: Mesh, transform: Matrix4x4, material: Material3D, bones: Matrix4x4[])
+    =
+    b.Add(Command3D.DrawSkinnedMesh(mesh, transform, material, bones))
+
+  // ── Billboards & Lines ──
+
+  member inline b.AddBillboard
+    (texture: Texture2D, position: Vector3, size: Vector2, color: Color)
+    =
+    b.Add(
+      Command3D.DrawBillboard(
+        texture,
+        position,
+        size,
+        RaylibColor.toRaylibColor color
+      )
+    )
+
+  member inline b.AddBillboardBatch
+    (
+      textures: Texture2D[],
+      positions: Vector3[],
+      sizes: Vector2[],
+      colors: Raylib_cs.Color[],
+      count: int
+    ) =
+    b.Add(
+      Command3D.DrawBillboardBatch(textures, positions, sizes, colors, count)
+    )
+
+  member inline b.AddLine3D(start: Vector3, finish: Vector3, color: Color) =
+    b.Add(Command3D.DrawLine3D(start, finish, RaylibColor.toRaylibColor color))
+
+  // ── Camera (layer ignored — 3D has no layers) ──
+
+  member inline b.AddBeginCamera(camera: Camera3D, _layer: int<RenderLayer>) =
+    b.Add(Command3D.BeginCamera camera)
+
+  member inline b.AddBeginCameraConfig
+    (config: Camera3DConfig, _layer: int<RenderLayer>)
+    =
+    b.Add(Command3D.BeginCameraConfig config)
+
+  member inline b.AddEndCamera(_layer: int<RenderLayer>) =
+    b.Add Command3D.EndCamera
+
+  // ── Shadows & Effect Scopes ──
+
+  member inline b.AddSetShadowOrigin(origin: Vector3) =
+    b.Add(Command3D.SetShadowOrigin origin)
+
+  member inline b.AddEnableShadows3D() = b.Add Command3D.EnableShadows
+
+  member inline b.AddDisableShadows3D() = b.Add Command3D.DisableShadows
+
+  member inline b.AddBeginEffect(shader: Shader) =
+    b.Add(Command3D.BeginEffect shader)
+
+  member inline b.AddEndEffect() = b.Add Command3D.EndEffect
+
+  // ── Lights (Core types, pass-through) ──
+
+  member inline b.AddSetAmbientLight(light: AmbientLight3D) =
+    b.Add(Command3D.SetAmbientLight light)
+
+  member inline b.AddDirectionalLight(light: DirectionalLight3D) =
+    b.Add(Command3D.AddDirectionalLight light)
+
+  member inline b.AddPointLight(light: PointLight3D) =
+    b.Add(Command3D.AddPointLight light)
+
+  member inline b.AddSpotLight(light: SpotLight3D) =
+    b.Add(Command3D.AddSpotLight light)
+
+  // ── Escape Hatches ──
+
+  member inline b.AddDrawImmediate
+    ([<InlineIfLambda>] action: SceneContext -> unit, _layer: int<RenderLayer>)
+    =
+    b.Add(Command3D.DrawImmediate action)
+
+  member inline b.AddPostProcess
+    ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
+    =
+    b.Add(Command3D.PostProcess action)
+
+  member inline b.AddPostProcessWithDepth
+    ([<InlineIfLambda>] action: PostProcessContext3D -> unit)
+    =
+    b.Add(Command3D.PostProcessWithDepth action)


### PR DESCRIPTION
# Unified fluent draw DSL for 2D and 3D

## Summary

One fluent draw API for **2D and 3D**, identical on **both backends** (raylib + MonoGame). View code chains calls on the render buffer with optional parameters for anything that has a sensible default:

```fsharp
buffer
  .beginCamera(model.Camera)
  .fillCircle(Vector2(400f, 300f), 48f, Color.Blue)
  .sprite(model.PlayerSprite)
  .endCamera()
  .text(model.Font, "HP 100", Vector2(10f, 10f), 20f, layer = 1001<RenderLayer>)
  .drop()
```

The whole chain is **erased at compile time**: members are inline SRTP extension members in `Mibo.Core`, resolved against small `member inline` witnesses on each backend's render buffer, which construct the command DU cases directly. No dispatch, no closure allocation, no wrapper types — the emitted code is the same as hand-written `buffer.Add(Command...)`.

## What's included

- **`Mibo.Elmish.Graphics.Draw` (Core)** — 78 members covering the full 2D + 3D surface of both existing DSLs, lowercase, with `[<Struct>]` optional parameters (`layer`, `tint`, `thickness`, `roundness`/`segments`, `intensity`, `castsShadows`, `spacing`) and `[<InlineIfLambda>]` on all callbacks.
- **Neutral inputs, no new abstractions** — colors use the existing `Mibo.Color`, vectors/matrices use `System.Numerics` (MonoGame converts at the boundary via its existing `op_Implicit`/`.ToNumerics()`), rect shapes take plain `x, y, w, h` floats. Backend values — textures, fonts, cameras, shaders, models, materials, sprite/text/animation state records — pass through unchanged as the backend's own types.
- **Capability gating** — backend-only features live in the same surface and simply don't compile on the other backend: `setSamplerState` (MonoGame only), `skinnedMesh` (raylib only). The error names the missing operation.
- **Per-family constraint aliases** — `WithRects2D`, `WithCircles2D`, `WithRings2D`, `WithEllipses2D`, `WithLines2D`, `WithPolygons2D`, composed into `WithShapes2D`, so SRTP errors name the specific missing family.
- **`RenderLayer` moved to Core** — same namespace (`Mibo.Elmish.Graphics2D`); transparent to existing code (measures are compile-time only).
- **Docs** — new `docs/draw-dsl.md` usage guide (parameters/defaults, shared vocabulary, backend handles, 2D/3D tours, backend-specific members, migration table); all existing docs pages migrated to fluent examples. **Piped modules (`Draw`/`Draw3D`/`LightDraw`/`ParticleDraw`) are documented as deprecated and will be removed in a future release** — they remain fully functional in this one.
- **CHANGELOG** — `Added` + `Deprecated` entries under Unreleased.

## Design notes

- **Witnesses** (the per-backend plug points) are augmentations on the render buffers, in the buffer's own file/namespace — required for SRTP visibility, and exactly where users already have `open`. They construct DU cases directly and share **no code** with the piped DSL, so the old modules can be removed cleanly later.
- **One `Draw` type for both dimensions** — members that exist on both buffers (cameras, post-process, `drawImmediate`, lights) unify through identically-named witnesses; different-arity overlaps (2D `enableShadows(ctx)` vs 3D `enableShadows()`) are plain overloads.
- **Divergent shapes stay honest** — `TextState` differs structurally across backends (`FontSize+Spacing` vs `Scale`), so text has a param-based member (`size` maps per backend, `spacing` used by raylib and documented as dropped on MonoGame) plus the record form.

## Validation

- `Mibo.Core`, `Mibo.Raylib`, `Mibo.MonoGame` build clean (net8.0 + net10.0); 913 framework tests pass.
- Validated against the Mibo.Samples Platformer: its raylib, MonoGame (DX12), and MonoGame (Vulkan) clients all build with views migrated to the fluent DSL (samples-side changes land separately).

## Breaking changes

None. The piped DSL is untouched and functional; the fluent DSL is additive.
