### PR TITLE
fix(monogame-3d): invalidate material cache after instanced draws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **MonoGame 3D:** models and primitives no longer render with the wrong texture when drawn after instanced draws. Instanced draws always uploaded and bound their material but left the material short-circuit cache stale, so a subsequent non-instanced draw whose material key matched the cached value skipped texture rebinding and sampled whatever the instanced pass had bound.
+
 ## [3.1.0] - 2026-07-19
 
 ### Added

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -625,6 +625,11 @@ module internal PbrShading =
           // Instanced draws always upload the material (one material across all instances).
           PbrUniforms.uploadMaterial(&p, &material)
           PbrUniforms.bindTextures(&p, &material, whiteTex res)
+          // Invalidate the material short-circuit: instanced draws always upload,
+          // but the cache still holds the last non-instanced key. Without this,
+          // a subsequent non-instanced draw whose key matches the stale cache
+          // would skip texture binding and sample the instanced pass's textures.
+          res.HasLastMaterial <- false
 
           if res.LightsDirty then
             PbrUniforms.uploadLights(


### PR DESCRIPTION
## Summary

Fixes #79

`drawInstanced` always uploads and binds its material to the PBR effect's samplers but never updates the `MaterialKey` short-circuit cache (`HasLastMaterial`/`LastKey`). When a subsequent non-instanced draw (`drawModel`, `drawAnimatedModel`, `drawPrimitive`) has a material key matching the stale cache, it skips `uploadMaterial` + `bindTextures` and samples whatever textures the instanced pass left bound — rendering with the wrong texture.

## Root cause

The material cache is **never reset per frame** (only at `Shutdown`), and `drawInstanced` is the only draw path that binds textures without updating or invalidating the cache. So after every instanced draw the cache claims "the PBR effect still has the last non-instanced material bound" when the GPU samplers actually hold the instanced material.

## Fix

Invalidate `HasLastMaterial` in `drawInstanced` right after the upload/bind. This is preferred over setting `LastKey` to the instanced material's key because:

- `drawInstanced` has a B7 fallback path (minimal `Instanced.fx`) that never touches the PBR effect's samplers — `HasLastMaterial <- false` is correct in both paths unconditionally, while `LastKey` would only be safe in the PBR path.
- The cache-hit loss (same-material non-instanced draw immediately after an instanced draw) is an uncommon pattern; the cost of the miss is one `uploadMaterial` + `bindTextures`.

## Testing

- `dotnet fantomas .` — formatted, no changes needed.
- `dotnet build src/Mibo.MonoGame` — 0 errors.
- `dotnet test src/Mibo.MonoGame.Tests` — 14/14 passed.
