### PR TITLE
fix(monogame-3d): clamp beginEffect array uploads to declared slots + document GL array-trimming rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **MonoGame 3D:** custom effects in a `beginEffect` scope that declare fewer light, shadow-caster, or bone array slots than the pipeline maximums (8 point / 4 spot lights, 16 shadow casters, 128 bones) no longer crash with an `IndexOutOfRangeException` during scene upload — array uniforms are clamped to the effect's declared element count. Note that on the OpenGL backend, uniform arrays indexed only with compile-time constants can still crash inside MonoGame's GL constant-buffer upload; index them dynamically (see `docs/shader-uniforms.md` → "Convention notes").
+- **MonoGame 3D:** custom effects in a `beginEffect` scope that declare fewer light, shadow-caster, or bone array slots than the pipeline maximums (8 point / 4 spot lights, 16 shadow casters, 128 bones) no longer crash with an `IndexOutOfRangeException` during scene upload — array uniforms are clamped to the effect's declared element count, and the `pointLightCount`/`spotLightCount` uniforms are clamped to the declared slots too, so a shader's light loop never indexes past its own declaration. Note that on the OpenGL backend, uniform arrays indexed only with compile-time constants can still crash inside MonoGame's GL constant-buffer upload; index them dynamically (see `docs/shader-uniforms.md` → "Convention notes").
 
 ## [3.2.0] - 2026-07-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **MonoGame 3D:** custom effects in a `beginEffect` scope that declare fewer light, shadow-caster, or bone array slots than the pipeline maximums (8 point / 4 spot lights, 16 shadow casters, 128 bones) no longer crash with an `IndexOutOfRangeException` during scene upload — array uniforms are clamped to the effect's declared element count. Note that on the OpenGL backend, uniform arrays indexed only with compile-time constants can still crash inside MonoGame's GL constant-buffer upload; index them dynamically (see `docs/shader-uniforms.md` → "Convention notes").
+
 ## [3.2.0] - 2026-07-25
 
 ### Added

--- a/docs/shader-uniforms.md
+++ b/docs/shader-uniforms.md
@@ -401,7 +401,9 @@ buffer
   (the way `ForwardPbr.fx` indexes with `pointLightShadowIdx[i]` /
   `spotLightShadowIdx[j]`), or declare exactly the slots the shader reads.
   Declaring fewer slots than the pipeline maximums is safe on the upload side —
-  uploads are clamped to the effect's declared element count.
+  uploads are clamped to the effect's declared element count, and the light count
+  uniforms (`pointLightCount`/`spotLightCount`) are clamped to the declared slots
+  as well.
 
 ## See also
 

--- a/docs/shader-uniforms.md
+++ b/docs/shader-uniforms.md
@@ -389,6 +389,19 @@ buffer
   pipeline constructor (raylib) or baked `#define`s (MonoGame). See
   [3D Lighting](graphics3d/lighting.html#light-limits) for the limits and how to
   change them.
+- **MonoGame/OpenGL: index uniform arrays dynamically.** On the DesktopGL
+  backend, a uniform array that is only ever indexed with compile-time constants
+  (e.g. `shadowViewProjs[0]`) can be trimmed by the MojoShader/GLSL toolchain
+  down to the referenced elements — while the effect's parameter table still
+  reports the declared element count. MonoGame's GL constant-buffer upload then
+  writes past the end of the shader's constant buffer and crashes in
+  `EffectPass.Apply` (an `ArgumentException` from `Buffer.BlockCopy`). DirectX
+  and Vulkan keep the declared size, so this surfaces as an OpenGL-only crash.
+  To avoid it, index the array with a uniform value somewhere in the shader
+  (the way `ForwardPbr.fx` indexes with `pointLightShadowIdx[i]` /
+  `spotLightShadowIdx[j]`), or declare exactly the slots the shader reads.
+  Declaring fewer slots than the pipeline maximums is safe on the upload side —
+  uploads are clamped to the effect's declared element count.
 
 ## See also
 

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs
@@ -15,7 +15,9 @@ open Mibo.Elmish.Graphics3D
 // inherits exactly what it declares and nothing more. Array uniforms declared with
 // FEWER slots than the framework maximums (8 point / 4 spot lights, 16 shadow
 // casters, 128 bones) inherit only their declared prefix — uploads are clamped to
-// the parameter's element count rather than erroring.
+// the parameter's element count rather than erroring, and the point/spot light
+// COUNT uniforms are likewise clamped to the declared array slots so the shader's
+// light loop never indexes past its own declaration.
 //
 // This is NOT the PBR hot path. The default pipeline shades via the cached
 // PbrEffectParams (ForwardHelpers) to skip re-resolving names every draw. SceneUpload
@@ -41,7 +43,8 @@ open Mibo.Elmish.Graphics3D
 /// <see cref="T:Mibo.Elmish.Graphics3D.Pipelines.ShadowResult"/>), and bones
 /// (<c>boneMatrices[128]</c>, only when supplied). Array uniforms declared with fewer slots
 /// than the framework maximums receive only their declared prefix — uploads are clamped
-/// to the parameter's element count rather than throwing.
+/// to the parameter's element count rather than throwing, and the point/spot light count
+/// uniforms are clamped to the declared array slots as well.
 /// </para>
 /// <para>
 /// <b>Shadows are opt-in by declaration.</b> A user effect that wants shadow sampling declares the
@@ -140,6 +143,19 @@ module SceneUpload =
   let inline private setVec4Array (p: EffectParameter) (v: Vector4[]) =
     if not(obj.ReferenceEquals(p, null)) then
       p.SetValue(clampToDeclared p v)
+
+  /// <summary>
+  /// Declared element count of an array uniform (null param → <paramref name="fallback"/>).
+  /// Used to clamp the point/spot light COUNT uniforms to the effect's declared array
+  /// slots: an effect declaring <c>pointLightPos[2]</c> must not receive a count of 5,
+  /// or its light loop indexes past its own declaration (reading adjacent constant-buffer
+  /// data on GL).
+  /// </summary>
+  let inline private declaredSlots (p: EffectParameter) (fallback: int) =
+    if obj.ReferenceEquals(p, null) then
+      fallback
+    else
+      p.Elements.Count
 
   /// <summary>Binds the shadow atlas to the effect's named shadow sampler param.</summary>
   let inline private setShadowAtlas (pp: EffectParameter) (tex: Texture2D) =
@@ -276,8 +292,13 @@ module SceneUpload =
 
       setFloat (p "dirLightIntensity") d.Intensity
 
-    // ── Lights: point (upload active count slots) ──
-    let ptCount = min lights.PointLights.Count pointPos.Length
+    // ── Lights: point (upload active count slots, clamped to the effect's declared
+    //    pointLightPos slots so the shader's light loop never indexes past its own
+    //    declaration — pointLightPos is the canonical point-array declaration) ──
+    let ptCount =
+      min
+        (min lights.PointLights.Count pointPos.Length)
+        (declaredSlots (p "pointLightPos") pointPos.Length)
 
     let ptShadowIdx =
       match shadows with
@@ -310,8 +331,12 @@ module SceneUpload =
     setFloatArray (p "pointLightFalloff") pointFalloff
     setIntArray (p "pointLightShadowIdx") pointShadowIdx
 
-    // ── Lights: spot (upload active count slots) ──
-    let spCount = min lights.SpotLights.Count spotPos.Length
+    // ── Lights: spot (upload active count slots, clamped to the effect's declared
+    //    spotLightPos slots — same rationale as point lights above) ──
+    let spCount =
+      min
+        (min lights.SpotLights.Count spotPos.Length)
+        (declaredSlots (p "spotLightPos") spotPos.Length)
 
     let spShadowIdx =
       match shadows with

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs
@@ -12,7 +12,10 @@ open Mibo.Elmish.Graphics3D
 // scene (matrices + material + lights + bones). Absent parameters return null from
 // Parameters["name"] (MonoGame) and are skipped — so an effect that declares only a
 // subset of the contract (e.g. a toon shader with matModel/viewProj/dirLight*/albedoColor)
-// inherits exactly what it declares and nothing more.
+// inherits exactly what it declares and nothing more. Array uniforms declared with
+// FEWER slots than the framework maximums (8 point / 4 spot lights, 16 shadow
+// casters, 128 bones) inherit only their declared prefix — uploads are clamped to
+// the parameter's element count rather than erroring.
 //
 // This is NOT the PBR hot path. The default pipeline shades via the cached
 // PbrEffectParams (ForwardHelpers) to skip re-resolving names every draw. SceneUpload
@@ -36,7 +39,9 @@ open Mibo.Elmish.Graphics3D
 /// M spot, including per-light shadow indices), shadows (the atlas + <c>shadowViewProjs</c>/
 /// <c>shadowUVOffsets</c>/<c>shadowTexelSize</c>/<c>dirLightCastsShadows</c>, when the frame has a
 /// <see cref="T:Mibo.Elmish.Graphics3D.Pipelines.ShadowResult"/>), and bones
-/// (<c>boneMatrices[128]</c>, only when supplied).
+/// (<c>boneMatrices[128]</c>, only when supplied). Array uniforms declared with fewer slots
+/// than the framework maximums receive only their declared prefix — uploads are clamped
+/// to the parameter's element count rather than throwing.
 /// </para>
 /// <para>
 /// <b>Shadows are opt-in by declaration.</b> A user effect that wants shadow sampling declares the
@@ -51,6 +56,44 @@ open Mibo.Elmish.Graphics3D
 /// </para>
 /// </remarks>
 module SceneUpload =
+
+  // ── Array clamping: an effect may declare FEWER array slots than the framework's
+  //    pooled upload arrays (8 point / 4 spot lights, 16 shadow casters, 128 bones).
+  //    MonoGame's SetValue throws IndexOutOfRange when the value is longer than the
+  //    parameter's element list, so uploads are clamped to the declared element count
+  //    ("inherit exactly what you declare" applies to smaller declarations too).
+  //    Clamped copies are cached per parameter — SceneUpload is not the per-frame hot
+  //    path, and the common full-size path stays allocation-free. The cache lives for
+  //    the app's lifetime and holds one small array per clamped parameter. ──
+  let private clampCache =
+    System.Collections.Generic.Dictionary<EffectParameter, obj>()
+
+  let private clampToDeclared (p: EffectParameter) (v: 'T[]) : 'T[] =
+    let declared = p.Elements.Count
+
+    if declared >= v.Length then
+      v
+    else
+      let mutable cachedObj = Unchecked.defaultof<obj>
+
+      let existing =
+        if clampCache.TryGetValue(p, &cachedObj) then
+          match cachedObj with
+          | :? ('T array) as cached when cached.Length = declared ->
+            ValueSome cached
+          | _ -> ValueNone
+        else
+          ValueNone
+
+      match existing with
+      | ValueSome cached ->
+        Array.blit v 0 cached 0 declared
+        cached
+      | ValueNone ->
+        let cached = Array.zeroCreate<'T> declared
+        Array.blit v 0 cached 0 declared
+        clampCache[p] <- box cached
+        cached
 
   // ── null-safe setters (mirror ForwardHelpers' set* but self-contained: this module
   //    can't see the private ForwardHelpers). null params = absent uniform = no-op. ──
@@ -80,23 +123,23 @@ module SceneUpload =
 
   let inline private setVec3Array (p: EffectParameter) (v: Vector3[]) =
     if not(obj.ReferenceEquals(p, null)) then
-      p.SetValue v
+      p.SetValue(clampToDeclared p v)
 
   let inline private setFloatArray (p: EffectParameter) (v: float32[]) =
     if not(obj.ReferenceEquals(p, null)) then
-      p.SetValue v
+      p.SetValue(clampToDeclared p v)
 
   let inline private setIntArray (p: EffectParameter) (v: int[]) =
     if not(obj.ReferenceEquals(p, null)) then
-      p.SetValue v
+      p.SetValue(clampToDeclared p v)
 
   let inline private setMatrixArray (p: EffectParameter) (v: Matrix[]) =
     if not(obj.ReferenceEquals(p, null)) then
-      p.SetValue v
+      p.SetValue(clampToDeclared p v)
 
   let inline private setVec4Array (p: EffectParameter) (v: Vector4[]) =
     if not(obj.ReferenceEquals(p, null)) then
-      p.SetValue v
+      p.SetValue(clampToDeclared p v)
 
   /// <summary>Binds the shadow atlas to the effect's named shadow sampler param.</summary>
   let inline private setShadowAtlas (pp: EffectParameter) (tex: Texture2D) =


### PR DESCRIPTION
## Summary

Fixes a crash class for user effects in `beginEffect`/`endEffect` scopes on the MonoGame backend, and documents an OpenGL shader pitfall discovered while investigating it.

### The clamp

`SceneUpload` pushed the framework's full pooled arrays (8 point / 4 spot lights, 16 shadow casters, 128 bones) into any user effect via `EffectParameter.SetValue`. An effect declaring **fewer** slots than those maximums crashed with an `IndexOutOfRangeException` at upload time — the "inherit exactly what you declare" contract only handled *absent* uniforms, not *smaller* declarations.

Array uploads are now clamped to the parameter's declared element count. Clamped copies are cached per parameter (one small array per clamped parameter, app-lifetime); the common full-size path remains allocation-free. `SceneUpload` is explicitly not the per-frame hot path, so the cache lookup cost is acceptable.

### The docs rule

While reproducing an OpenGL-only crash in the [Mibo.Samples](https://github.com/AngelMunoz/Mibo.Samples) 3D platformer's custom toon/snow effects, we found that on DesktopGL a uniform array indexed **only with compile-time constants** (e.g. `shadowViewProjs[0]`) gets trimmed by the MojoShader/GLSL toolchain down to the referenced elements, while the effect's parameter table still reports the declared count. MonoGame's GL `ConstantBuffer.Update` then walks all declared elements and crashes in `EffectPass.Apply` (`ArgumentException` from `Buffer.BlockCopy`). DirectX (11/12) and Vulkan keep the declared size, so it surfaces as an OpenGL-only crash that reads as "instancing is broken".

`ForwardPbr.fx` is immune because it indexes the shadow arrays dynamically (`pointLightShadowIdx[i]` / `spotLightShadowIdx[j]`). The rule — index arrays dynamically, or declare exactly the slots you read — is now documented in `docs/shader-uniforms.md` → "Convention notes".

Note: the GL constant-buffer overflow itself is inside MonoGame and is **not** fixed here (nor can it be at this layer) — the clamp prevents the *upload-side* crash, the doc rule prevents the *GL metadata* crash.

## Changes

- `src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs` — clamp all array uploads (`Vector3`/`Vector4`/`Matrix`/`float32`/`int`) to `param.Elements.Count`.
- `docs/shader-uniforms.md` — new "Convention notes" entry: MonoGame/OpenGL dynamic-index rule for uniform arrays.
- `CHANGELOG.md` — Unreleased → Fixed entry.

## Validation

- `Mibo.MonoGame.Tests`: 47/47 passing.
- Mibo.Samples Platformer3D runs clean against this branch on all four MonoGame backends: DesktopGL, WindowsDX (DX11), WindowsDX12, DesktopVK.
