### PR TITLE
fix(3d): copy instanced transforms at record time on both backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- **MonoGame 3D, Raylib 3D:** instanced draws (`instanced`, `animatedModelInstanced`) now copy the caller's `transforms` array when the draw is recorded. Commands execute after the whole view is recorded, so refilling one shared array for the next camera block previously overwrote transforms the earlier block had not drawn yet (on DX11/Vulkan the refilled array could also replay the earlier block's staged rows). Keeping one persistent array per group and refilling it between blocks or frames is now safe, giving zero steady-state allocation; the copy costs one pooled-array rent plus one `Array.Copy` per instanced command.
+- **MonoGame 3D, Raylib 3D:** instanced draws (`instanced`, `animatedModelInstanced`) now copy the caller's `transforms` array when the draw is recorded. A frame's draws execute only after the whole view is recorded, so reusing one array across camera blocks previously rendered the earlier block with the later block's transforms. Keeping one persistent array per group and refilling it between blocks or frames is now safe, with zero steady-state allocation beyond one pooled copy per instanced command.
 
 ## [4.0.0-rc-001] - 2026-08-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **MonoGame 3D, Raylib 3D:** instanced draws (`instanced`, `animatedModelInstanced`) now copy the caller's `transforms` array when the draw is recorded. Commands execute after the whole view is recorded, so refilling one shared array for the next camera block previously overwrote transforms the earlier block had not drawn yet (on DX11/Vulkan the refilled array could also replay the earlier block's staged rows). Keeping one persistent array per group and refilling it between blocks or frames is now safe, giving zero steady-state allocation; the copy costs one pooled-array rent plus one `Array.Copy` per instanced command.
+
 ## [4.0.0-rc-001] - 2026-08-02
 
 ### Added

--- a/src/Mibo.MonoGame.Tests/Animation3DTests.fs
+++ b/src/Mibo.MonoGame.Tests/Animation3DTests.fs
@@ -454,9 +454,16 @@ let tests =
                                                _) ->
           Expect.equal count 2 "two instances"
 
-          Expect.isTrue
+          Expect.isFalse
             (System.Object.ReferenceEquals(t, transforms))
-            "transforms array forwarded untouched"
+            "transforms are copied at record time (the caller may reuse its array)"
+
+          Expect.equal t[0] Matrix.Identity "transform 0 copied"
+
+          Expect.equal
+            t[1].Translation
+            (Vector3(10.0f, 0.0f, 0.0f))
+            "transform 1 copied"
 
           // ArrayPool may return a larger array than requested — verify the
           // logical content (first count * boneCount elements) is correct.
@@ -479,6 +486,41 @@ let tests =
           | _ -> failtest "material override not forwarded"
 
           Expect.equal c (ValueSome colors) "colors forwarded"
+        | other ->
+          failtest $"expected DrawAnimatedModelInstanced, got %A{other}"
+      }
+
+      test
+        "mutating the caller's transforms after Add does not affect the command" {
+        use buffer = new RenderBuffer3D()
+
+        let pose: BonePose = {
+          WorldPoses = [||]
+          Palette = Array.create 3 Matrix.Identity
+        }
+
+        let transforms = [| Matrix.Identity |]
+
+        buffer.AddAnimatedModelInstanced(
+          testModel,
+          transforms,
+          [| pose |],
+          ValueNone,
+          ValueNone
+        )
+
+        // Simulate the caller refilling its persistent array (e.g. for the
+        // next camera block) before the buffer executes.
+        transforms[0] <- Matrix.CreateTranslation(99.0f, 99.0f, 99.0f)
+
+        match buffer[0] with
+        | Command3D.DrawAnimatedModelInstanced(_, t, _, _, _, count, _) ->
+          Expect.equal count 1 "one instance"
+
+          Expect.equal
+            t[0]
+            Matrix.Identity
+            "the recorded command must keep the values from record time"
         | other ->
           failtest $"expected DrawAnimatedModelInstanced, got %A{other}"
       }

--- a/src/Mibo.MonoGame.Tests/Mibo.MonoGame.Tests.fsproj
+++ b/src/Mibo.MonoGame.Tests/Mibo.MonoGame.Tests.fsproj
@@ -19,6 +19,7 @@
     <Compile Include="PaletteGroupTests.fs" />
     <Compile Include="InstanceWorldCacheTests.fs" />
     <Compile Include="SkinnedInstancedCacheTests.fs" />
+    <Compile Include="RenderBuffer3DTests.fs" />
     <Compile Include="Main.fs" />
   </ItemGroup>
 

--- a/src/Mibo.MonoGame.Tests/RenderBuffer3DTests.fs
+++ b/src/Mibo.MonoGame.Tests/RenderBuffer3DTests.fs
@@ -1,0 +1,59 @@
+module Mibo.MonoGame.Tests.RenderBuffer3DTests
+
+open Expecto
+open Microsoft.Xna.Framework
+open Mibo.Elmish.Graphics3D
+
+// AddDrawInstanced witness: the buffer copies the caller's transforms into a
+// pooled array at record time, so refilling the array after the call (e.g.
+// for the next camera block) cannot corrupt the recorded command — the same
+// guarantee AddAnimatedModelInstanced gives.
+
+let private stubMesh: PrimitiveMesh = {
+  Vertices = null
+  Indices = null
+  PrimitiveCount = 0
+  Bounds = BoundingSphere()
+}
+
+[<Tests>]
+let tests =
+  testList "AddDrawInstanced witness" [
+    test "copies transforms at record time and clamps the count" {
+      use buffer = new RenderBuffer3D()
+
+      let transforms = [|
+        Matrix.Identity
+        Matrix.CreateTranslation(1.0f, 2.0f, 3.0f)
+      |]
+
+      buffer.AddDrawInstanced(
+        stubMesh,
+        transforms,
+        Material3D.defaults,
+        5,
+        ValueNone
+      )
+
+      // Simulate the caller refilling its persistent array before execution.
+      transforms[0] <- Matrix.CreateTranslation(9.0f, 9.0f, 9.0f)
+
+      Expect.equal buffer.Count 1 "expected exactly one command"
+
+      match buffer[0] with
+      | Command3D.DrawInstanced(_, t, _, _, count) ->
+        Expect.equal count 2 "count clamps to transforms.Length (was 5)"
+
+        Expect.isFalse
+          (System.Object.ReferenceEquals(t, transforms))
+          "transforms are copied at record time"
+
+        Expect.equal
+          t[0]
+          Matrix.Identity
+          "mutating the caller's array must not affect the recorded command"
+
+        Expect.equal t[1] transforms[1] "transform 1 copied"
+      | other -> failtest $"expected DrawInstanced, got %A{other}"
+    }
+  ]

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneData.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/SceneData.fs
@@ -331,7 +331,8 @@ type PaletteChunkCache() =
 /// </summary>
 /// <remarks>
 /// Memo validity is per frame, same as <see cref="T:Mibo.Elmish.Graphics3D.Pipelines.PaletteChunkCache"/>:
-/// transforms arrays are game-owned and stable for the duration of the render flush, and
+/// the buffer copies caller transforms into per-frame rented arrays at record time, so each
+/// command's array is stable for the duration of the render flush, and
 /// <c>ReleaseAll</c> — called once per frame alongside the palette cache's — drops every
 /// memo. Keyed by array reference + count. The DX12 grouped path does NOT use this cache:
 /// its forward/depth group budgets differ (PaletteGroup.MaxMatrices vs MaxMatricesDepth),

--- a/src/Mibo.MonoGame/Graphics3D/RenderBuffer3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/RenderBuffer3D.fs
@@ -108,9 +108,9 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
 
   /// <summary>
   /// Rents a <c>Matrix[]</c> from the shared <see cref="T:System.Buffers.ArrayPool`1"/>
-  /// and tracks it for automatic return at the end of the frame. Used by instanced
-  /// animated-model witnesses that need a scratch palette array consumed synchronously
-  /// within the same frame.
+  /// and tracks it for automatic return at the end of the frame. Used by the instanced
+  /// draw witnesses for the scratch palette and per-command transforms copies consumed
+  /// synchronously within the same frame.
   /// </summary>
   member _.RentMatrixArray(needed: int) =
     let arr = ArrayPool<Microsoft.Xna.Framework.Matrix>.Shared.Rent(needed)
@@ -208,8 +208,22 @@ type RenderBuffer3D with
       instanceCount: int,
       colors: Microsoft.Xna.Framework.Color[] voption
     ) =
+    // Copy the transforms into a rented array: the command executes after
+    // the whole view has been recorded, so a caller reusing its backing
+    // array (across camera blocks or frames) must not be able to overwrite
+    // this command's transforms before they execute. Same by-reference
+    // fix as AddAnimatedModelInstanced.
+    // max 0: ArrayPool.Rent throws on a negative length — a negative
+    // instanceCount was (and stays) a recorded no-op.
+    let count = max 0 (min instanceCount transforms.Length)
+    let transformsCopy = b.RentMatrixArray(count)
+    Array.Copy(transforms, 0, transformsCopy, 0, count)
+
+    // Pass count (not instanceCount): the rented array may be longer than
+    // count, and the pipeline clamps draws to transforms.Length — with the
+    // pooled length that clamp could read past the copied rows.
     b.Add(
-      Command3D.DrawInstanced(mesh, transforms, colors, material, instanceCount)
+      Command3D.DrawInstanced(mesh, transformsCopy, colors, material, count)
     )
 
   member inline b.AddDrawModel(model: Model, transform: Matrix) =
@@ -311,6 +325,9 @@ type RenderBuffer3D with
   /// <c>Palette</c> must hold at least one matrix per bone: a longer palette
   /// truncates to its first <c>boneCount</c> entries, a shorter one throws
   /// <see cref="T:System.ArgumentException"/>.
+  /// Both <paramref name="transforms"/> and the palettes are copied into
+  /// pooled arrays at record time, so the caller may freely reuse or refill
+  /// its arrays once this call returns.
   /// </summary>
   member inline b.AddAnimatedModelInstanced
     (
@@ -337,10 +354,18 @@ type RenderBuffer3D with
 
         Array.Copy(src, 0, palettes, i * boneCount, boneCount)
 
+      // Copy the instance transforms into a rented array too: the command
+      // executes after the whole view has been recorded (and after later
+      // camera blocks are recorded), so storing the caller's array by
+      // reference would let a refill — e.g. reusing one array across camera
+      // blocks — overwrite this command's transforms before they execute.
+      let transformsCopy = b.RentMatrixArray(count)
+      Array.Copy(transforms, 0, transformsCopy, 0, count)
+
       b.Add(
         Command3D.DrawAnimatedModelInstanced(
           am.Model,
-          transforms,
+          transformsCopy,
           palettes,
           material,
           colors,

--- a/src/Mibo.Raylib.Tests/Animation3DTests.fs
+++ b/src/Mibo.Raylib.Tests/Animation3DTests.fs
@@ -1228,9 +1228,12 @@ let animatedInstancedWitnessTests =
         | Command3D.DrawSkinnedMeshInstanced(_, t, palettes, _, count, _) ->
           Expect.equal count 2 "Two instances"
 
-          Expect.isTrue
+          Expect.isFalse
             (Object.ReferenceEquals(t, transforms))
-            "Transforms array should be forwarded untouched"
+            "Transforms are copied at record time (the caller may reuse its array)"
+
+          Expect.equal t[0] transforms[0] "Transform 0 copied"
+          Expect.equal t[1] transforms[1] "Transform 1 copied"
 
           // ArrayPool may return a larger array than requested.
           Expect.isTrue
@@ -1240,6 +1243,35 @@ let animatedInstancedWitnessTests =
           Expect.equal palettes[0] poseA.Palette[0] "Instance 0 palette first"
           Expect.equal palettes[1] poseB.Palette[0] "Instance 1 palette second"
         | _ -> Tests.failtest "Expected DrawSkinnedMeshInstanced"
+    }
+
+    test
+      "mutating the caller's transforms after Add does not affect the command" {
+      let am = makeAnimatedModel 1
+      use buffer = new RenderBuffer3D()
+      let localTransforms = [| Matrix4x4.Identity |]
+
+      buffer.AddAnimatedModelInstanced(
+        am,
+        localTransforms,
+        [| poseA |],
+        ValueNone,
+        ValueNone
+      )
+
+      // Simulate the caller refilling its persistent array (e.g. for the
+      // next camera block) before the buffer executes.
+      localTransforms[0] <- Raymath.MatrixTranslate(9.0f, 9.0f, 9.0f)
+
+      match buffer[0] with
+      | Command3D.DrawSkinnedMeshInstanced(_, t, _, _, count, _) ->
+        Expect.equal count 1 "One instance"
+
+        Expect.equal
+          t[0]
+          Matrix4x4.Identity
+          "The recorded command must keep the values from record time"
+      | _ -> Tests.failtest "Expected DrawSkinnedMeshInstanced"
     }
 
     test "instance count clamps to the shorter array" {

--- a/src/Mibo.Raylib.Tests/Graphics3DTests.fs
+++ b/src/Mibo.Raylib.Tests/Graphics3DTests.fs
@@ -691,6 +691,35 @@ let renderBuffer3DTests =
       | _ -> Tests.failtest "Expected DrawLine3D"
     }
 
+    test
+      "AddDrawInstanced copies transforms at record time and clamps the count" {
+      use buf = new RenderBuffer3D()
+      let transforms = [| identity; Matrix4x4.CreateTranslation(v3a) |]
+
+      buf.AddDrawInstanced(mesh, transforms, Material3D.defaults, 5, ValueNone)
+
+      // Simulate the caller refilling its persistent array before execution.
+      transforms[0] <- Matrix4x4.CreateTranslation(v3b)
+
+      Expect.equal buf.Count 1 "Expected exactly one command"
+
+      match buf.Item 0 with
+      | Command3D.DrawMeshInstanced(_, t, _, count) ->
+        Expect.equal count 2 "Count clamps to transforms.Length (was 5)"
+
+        Expect.isFalse
+          (Object.ReferenceEquals(t, transforms))
+          "Transforms are copied at record time"
+
+        Expect.equal
+          t[0]
+          identity
+          "Mutating the caller's array must not affect the recorded command"
+
+        Expect.equal t[1] transforms[1] "Transform 1 copied"
+      | _ -> Tests.failtest "Expected DrawMeshInstanced"
+    }
+
     test "Clear resets count to 0" {
       use buf = new RenderBuffer3D()
       buf.Add(Command3D.drawLine3D v3a v3b Color.White)

--- a/src/Mibo.Raylib/Graphics3D/RenderBuffer3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/RenderBuffer3D.fs
@@ -123,11 +123,12 @@ type RenderBuffer3D([<Struct>] ?capacity: int) =
       Array.Clear(items, 0, items.Length)
 
   /// <summary>
-  /// Tracks a rented palette array so it can be returned to the
-  /// <see cref="T:System.Buffers.ArrayPool`1"/> after the pipeline consumes the
-  /// commands. Called from <c>AddAnimatedModelInstanced</c> (an inline
-  /// extension member) — it cannot see primary-constructor <c>let</c>
-  /// bindings, so it reaches the field through this public method.
+  /// Tracks a rented matrix array (palette or transforms copy) so it can be
+  /// returned to the <see cref="T:System.Buffers.ArrayPool`1"/> after the
+  /// pipeline consumes the commands. Called from the instanced draw witnesses
+  /// (<c>AddDrawInstanced</c>/<c>AddAnimatedModelInstanced</c>, both inline
+  /// extension members) — they cannot see primary-constructor <c>let</c>
+  /// bindings, so they reach the field through this public method.
   /// </summary>
   member _.RegisterRentedArray(arr: System.Numerics.Matrix4x4[]) =
     rentedArrays.Add(arr)
@@ -208,9 +209,22 @@ type RenderBuffer3D with
         )
       )
     | ValueNone ->
-      b.Add(
-        Command3D.DrawMeshInstanced(mesh, transforms, material, instanceCount)
-      )
+      // Copy the transforms into a rented array: the command executes after
+      // the whole view has been recorded, so a caller reusing its backing
+      // array (across camera blocks or frames) must not be able to overwrite
+      // this command's transforms before they execute. Same by-reference
+      // fix as AddAnimatedModelInstanced.
+      // max 0: ArrayPool.Rent throws on a negative length — a negative
+      // instanceCount was (and stays) a recorded no-op.
+      let count = max 0 (min instanceCount transforms.Length)
+      let transformsCopy = ArrayPool<Matrix4x4>.Shared.Rent(count)
+      b.RegisterRentedArray(transformsCopy)
+      Array.Copy(transforms, 0, transformsCopy, 0, count)
+
+      // Pass count (not instanceCount): the rented array may be longer than
+      // count, and the pipeline clamps draws to transforms.Length — with the
+      // pooled length that clamp could read past the copied rows.
+      b.Add(Command3D.DrawMeshInstanced(mesh, transformsCopy, material, count))
 
   member inline b.AddDrawModel(model: Model, transform: Matrix4x4) =
     b.Add(Command3D.DrawModel(model, transform))
@@ -377,6 +391,9 @@ type RenderBuffer3D with
   /// (<c>MaterialOverride.All</c> / <c>MaterialOverride.PerMesh</c>).
   /// <paramref name="colors"/> is MonoGame-only — <c>ValueSome</c> raises
   /// <see cref="T:System.NotSupportedException"/>.
+  /// Both <paramref name="transforms"/> and the palettes are copied into
+  /// pooled arrays at record time, so the caller may freely reuse or refill
+  /// its arrays once this call returns.
   /// </summary>
   member inline b.AddAnimatedModelInstanced
     (
@@ -414,6 +431,16 @@ type RenderBuffer3D with
         let model = am.State.Model
         let meshes = model.MeshesAsSpan()
 
+        // Copy the instance transforms into a rented array too: the command
+        // executes after the whole view has been recorded (and after later
+        // camera blocks are recorded), so storing the caller's array by
+        // reference would let a refill — e.g. reusing one array across
+        // camera blocks — overwrite this command's transforms before they
+        // execute.
+        let transformsCopy = ArrayPool<Matrix4x4>.Shared.Rent(count)
+        b.RegisterRentedArray(transformsCopy)
+        Array.Copy(transforms, 0, transformsCopy, 0, count)
+
         for i = 0 to meshes.Length - 1 do
           let mat =
             match material with
@@ -432,7 +459,7 @@ type RenderBuffer3D with
           b.Add(
             Command3D.DrawSkinnedMeshInstanced(
               meshes[i],
-              transforms,
+              transformsCopy,
               palettes,
               mat,
               count,


### PR DESCRIPTION
## Summary

Fixes a crash class for user effects in `beginEffect`/`endEffect` scopes on the MonoGame backend, and documents an OpenGL shader pitfall discovered while investigating it.

### The clamp

`SceneUpload` pushed the framework's full pooled arrays (8 point / 4 spot lights, 16 shadow casters, 128 bones) into any user effect via `EffectParameter.SetValue`. An effect declaring **fewer** slots than those maximums crashed with an `IndexOutOfRangeException` at upload time — the "inherit exactly what you declare" contract only handled *absent* uniforms, not *smaller* declarations.

Array uploads are now clamped to the parameter's declared element count. Clamped copies are cached per parameter (one small array per clamped parameter, app-lifetime); the common full-size path remains allocation-free. `SceneUpload` is explicitly not the per-frame hot path, so the cache lookup cost is acceptable.

### The docs rule

While reproducing an OpenGL-only crash in the [Mibo.Samples](https://github.com/AngelMunoz/Mibo.Samples) 3D platformer's custom toon/snow effects, we found that on DesktopGL a uniform array indexed **only with compile-time constants** (e.g. `shadowViewProjs[0]`) gets trimmed by the MojoShader/GLSL toolchain down to the referenced elements, while the effect's parameter table still reports the declared count. MonoGame's GL `ConstantBuffer.Update` then walks all declared elements and crashes in `EffectPass.Apply` (`ArgumentException` from `Buffer.BlockCopy`). DirectX (11/12) and Vulkan keep the declared size, so it surfaces as an OpenGL-only crash that reads as "instancing is broken".

`ForwardPbr.fx` is immune because it indexes the shadow arrays dynamically (`pointLightShadowIdx[i]` / `spotLightShadowIdx[j]`). The rule — index arrays dynamically, or declare exactly the slots you read — is now documented in `docs/shader-uniforms.md` → "Convention notes".

Note: the GL constant-buffer overflow itself is inside MonoGame and is **not** fixed here (nor can it be at this layer) — the clamp prevents the *upload-side* crash, the doc rule prevents the *GL metadata* crash.

## Changes

- `src/Mibo.MonoGame/Graphics3D/Pipelines/SceneUpload.fs` — clamp all array uploads (`Vector3`/`Vector4`/`Matrix`/`float32`/`int`) to `param.Elements.Count`.
- `docs/shader-uniforms.md` — new "Convention notes" entry: MonoGame/OpenGL dynamic-index rule for uniform arrays.
- `CHANGELOG.md` — Unreleased → Fixed entry.

## Validation

- `Mibo.MonoGame.Tests`: 47/47 passing.
- Mibo.Samples Platformer3D runs clean against this branch on all four MonoGame backends: DesktopGL, WindowsDX (DX11), WindowsDX12, DesktopVK.
