### PR TITLE
fix(core): worldToCell resolves the containing cell, not the nearest corner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Core:** `worldToCell` on square (`Grid2DSpatial`), voxel (`Grid3DSpatial`) and the layer axis of 3D hex (`Hex3DSpatial`) grids now returns the cell that *contains* the world position. They previously snapped to the nearest cell corner, so any point in the second half of a cell (and, because of banker's rounding, the exact center of an odd-indexed cell) reported the next cell over. Hex 2D and the hex (XZ) plane of 3D hex are unchanged — those resolve to the nearest hex center as before.
+
 ## [4.0.0] - 2026-08-07
 
 ### Changed

--- a/src/Mibo.Core.Tests/Spatial2DTests.fs
+++ b/src/Mibo.Core.Tests/Spatial2DTests.fs
@@ -211,7 +211,7 @@ let tests =
         // Center of cell 1: X = 48 -> 48/32 = 1.5
         // round(1.5) = 2 (banker's); floor(1.5) = 1.
         for x in [ 1; 2; 3 ] do
-          let centerX = float32 x * 32f
+          let centerX = float32 x * 32f + 16f
           let result = Grid2DSpatial.worldToCell (Vector2(centerX, 0f)) grid
 
           match result with

--- a/src/Mibo.Core.Tests/Spatial2DTests.fs
+++ b/src/Mibo.Core.Tests/Spatial2DTests.fs
@@ -182,6 +182,58 @@ let tests =
           Expect.equal cx 5 "X"
           Expect.equal cy 5 "Y"
         | ValueNone -> failwith "Expected ValueSome"
+
+      // Regression: getWorldPos anchors a cell at its corner
+      // (origin + N*cellSize), so worldToCell must resolve the cell that
+      // *contains* the point (floor), not the nearest corner (round).
+      // Without this, the second half of a cell reports the next cell.
+      testCase "worldToCell returns the containing cell, not the nearest corner"
+      <| fun _ ->
+        let grid = CellGrid2D.create 10 10 (Vector2(32f, 32f)) Vector2.Zero
+
+        // Cell 1 spans X [32, 64). 49 is in the second half of cell 1;
+        // round(49/32) would wrongly snap to cell 2.
+        let result = Grid2DSpatial.worldToCell (Vector2(49f, 10f)) grid
+
+        match result with
+        | ValueSome struct (cx, cy) ->
+          Expect.equal cx 1 "X should be the containing cell"
+          Expect.equal cy 0 "Y should be the containing cell"
+        | ValueNone -> failwith "Expected ValueSome"
+
+      // Regression: F#'s `round` is banker's rounding, so at exact .5
+      // fractional positions (the centers of odd cells) it snaps to the
+      // even neighbor. floor has no such bias.
+      testCase "worldToCell is unbiased at cell-center half points"
+      <| fun _ ->
+        let grid = CellGrid2D.create 10 10 (Vector2(32f, 32f)) Vector2.Zero
+
+        // Center of cell 1: X = 48 -> 48/32 = 1.5
+        // round(1.5) = 2 (banker's); floor(1.5) = 1.
+        for x in [ 1; 2; 3 ] do
+          let centerX = float32 x * 32f
+          let result = Grid2DSpatial.worldToCell (Vector2(centerX, 0f)) grid
+
+          match result with
+          | ValueSome struct (cx, _) ->
+            Expect.equal cx x "Center should map to its own cell"
+          | ValueNone -> failwith "Expected ValueSome"
+
+      testCase "worldToCell handles negative coordinates via floor"
+      <| fun _ ->
+        // Origin negative so cells extend into negative world space.
+        let grid =
+          CellGrid2D.create 10 10 (Vector2(32f, 32f)) (Vector2(-160f, -160f))
+
+        // World X = -159 is just inside cell 0 (origin -160). floor(-159/32
+        // adjusted) must stay 0, not -1 as truncate would give.
+        let result = Grid2DSpatial.worldToCell (Vector2(-159f, -159f)) grid
+
+        match result with
+        | ValueSome struct (cx, cy) ->
+          Expect.equal cx 0 "X should be cell 0"
+          Expect.equal cy 0 "Y should be cell 0"
+        | ValueNone -> failwith "Expected ValueSome"
     ]
 
     // ── Square grid: InRange ──────────────────────────────────────────

--- a/src/Mibo.Core.Tests/Spatial3DTests.fs
+++ b/src/Mibo.Core.Tests/Spatial3DTests.fs
@@ -174,6 +174,26 @@ let tests =
           Grid3DSpatial.worldToCell (Vector3(-100f, -100f, -100f)) grid
 
         Expect.equal result ValueNone "OOB"
+
+      // Regression: getWorldPos anchors a cell at its corner, so worldToCell
+      // must resolve the containing cell (floor), not the nearest corner
+      // (round). Points in the second half of a cell would otherwise report
+      // the next cell.
+      testCase "worldToCell returns the containing cell, not the nearest corner"
+      <| fun _ ->
+        let grid =
+          CellGrid3D.create 10 10 10 (Vector3(32f, 32f, 32f)) Vector3.Zero
+
+        // Cell 1 spans [32, 64) on each axis. (49, 49, 49) is in the second
+        // half of cell 1; round(49/32) would wrongly snap to cell 2.
+        let result = Grid3DSpatial.worldToCell (Vector3(49f, 49f, 49f)) grid
+
+        match result with
+        | ValueSome struct (cx, cy, cz) ->
+          Expect.equal cx 1 "X should be the containing cell"
+          Expect.equal cy 1 "Y should be the containing cell"
+          Expect.equal cz 1 "Z should be the containing cell"
+        | ValueNone -> failwith "Expected ValueSome"
     ]
 
     // ── Voxel grid: InRange ───────────────────────────────────────────
@@ -546,6 +566,27 @@ let tests =
 
         let result = Hex3DSpatial.worldToCell (Vector3(0f, -100f, 0f)) grid
         Expect.equal result ValueNone "OOB layer"
+
+      // Regression: the Y/layer axis is corner-anchored
+      // (HexGrid3D.getWorldPos: origin.Y + layer * LayerHeight), so a world Y
+      // in the second half of a layer must resolve to that layer (floor), not
+      // snap to the next layer boundary (round).
+      testCase "worldToCell layer axis returns the containing layer"
+      <| fun _ ->
+        let grid =
+          HexGrid3D.create 10 5 10 32f 2f Vector3.Zero HexOrientation.PointyTop
+
+        // Layer 1 spans Y [2, 4). Y = 3 is its middle.
+        // Use the exact hex center for col 0 / row 0 so only the layer is in
+        // question. PointyTop center: x = hexW/2, z = hexH/2.
+        let hexW = 32f * sqrt 3f
+        let hexH = 32f * 2f
+        let pos = Vector3(hexW / 2f, 3f, hexH / 2f)
+
+        match Hex3DSpatial.worldToCell pos grid with
+        | ValueSome struct (_, _, layer) ->
+          Expect.equal layer 1 "Should be layer 1"
+        | ValueNone -> failwith "Expected ValueSome"
     ]
 
     // ── Hex3D grid: InRange ───────────────────────────────────────────

--- a/src/Mibo.Core/Layout/Spatial2D.fs
+++ b/src/Mibo.Core/Layout/Spatial2D.fs
@@ -177,7 +177,7 @@ module Grid2DSpatial =
     let dy = float32(y2 - y1)
     sqrt(dx * dx + dy * dy)
 
-  /// Converts a world position to the nearest grid cell coordinates.
+  /// Converts a world position to the grid cell that contains it.
   /// Returns ValueNone if the position is outside the grid.
   let inline worldToCell
     (worldPos: Vector2)
@@ -185,8 +185,8 @@ module Grid2DSpatial =
     : struct (int * int) voption =
     let fx = (worldPos.X - grid.Origin.X) / grid.CellSize.X
     let fy = (worldPos.Y - grid.Origin.Y) / grid.CellSize.Y
-    let cx = int(round fx)
-    let cy = int(round fy)
+    let cx = int(floor fx)
+    let cy = int(floor fy)
 
     if cx >= 0 && cx < grid.Width && cy >= 0 && cy < grid.Height then
       ValueSome(struct (cx, cy))

--- a/src/Mibo.Core/Layout3D/Spatial3D.fs
+++ b/src/Mibo.Core/Layout3D/Spatial3D.fs
@@ -207,7 +207,7 @@ module Grid3DSpatial =
     let dz = float32(z2 - z1)
     sqrt(dx * dx + dy * dy + dz * dz)
 
-  /// Converts a world position to the nearest grid cell. Returns ValueNone
+  /// Converts a world position to the grid cell that contains it. Returns ValueNone
   /// if the position is outside the grid.
   let inline worldToCell
     (worldPos: Vector3)
@@ -216,9 +216,9 @@ module Grid3DSpatial =
     let fx = (worldPos.X - grid.Origin.X) / grid.CellSize.X
     let fy = (worldPos.Y - grid.Origin.Y) / grid.CellSize.Y
     let fz = (worldPos.Z - grid.Origin.Z) / grid.CellSize.Z
-    let cx = int(round fx)
-    let cy = int(round fy)
-    let cz = int(round fz)
+    let cx = int(floor fx)
+    let cy = int(floor fy)
+    let cz = int(floor fz)
 
     if
       cx >= 0
@@ -863,12 +863,14 @@ module Hex3DSpatial =
     (abs(q1 - q2) + abs(r1c - r2c) + abs(s1 - s2)) / 2 + abs(l2 - l1)
 
   /// Converts a 3D world position to the nearest hex3D cell.
+  /// The hex (XZ) plane resolves to the nearest hex center; the Y axis resolves
+  /// to the containing layer.
   let inline worldToCell
     (worldPos: Vector3)
     (grid: HexGrid3D<'T>)
     : struct (int * int * int) voption =
     let layerF = (worldPos.Y - grid.Origin.Y) / grid.LayerHeight
-    let layer = int(round layerF)
+    let layer = int(floor layerF)
 
     if layer < 0 || layer >= grid.Height then
       ValueNone


### PR DESCRIPTION
## Summary

`worldToCell` on the corner-anchored grids reported the wrong cell for any world position that did not land exactly on a cell corner.

## Root cause

`getWorldPos` anchors a cell at its **corner** (`origin + N * cellSize`), but `worldToCell` used `round` — which picks the **nearest corner**, not the containing cell. The correct inverse of a corner anchor is `floor` (the cell that contains the point).

Two consequences:

- Any point in the **second half** of a cell snapped to the **next** cell. E.g. cell size 32: world X = 49 is inside cell 1 (spans 32–64), but `round(49/32) = round(1.53) = 2`.
- F#'s `round` is **banker's rounding** (round-half-to-even), so at exact `.5` fractional positions — the centers of odd-indexed cells — it snapped to the **even** neighbor. E.g. cell 1 center X = 48 → `round(1.5) = 2`.

## What changed

| Surface | Before | After |
|---|---|---|
| `Grid2DSpatial.worldToCell` (square) | `round` | `floor` |
| `Grid3DSpatial.worldToCell` (voxel) | `round` | `floor` |
| `Hex3DSpatial.worldToCell` — layer (Y) axis | `round` | `floor` |
| `Hex2DSpatial.worldToCell` (hex) | `round` / `cubeRound` | **unchanged** (center-anchored) |
| `Hex3DSpatial.worldToCell` — hex (XZ) plane | nearest center | **unchanged** |
| `Spatial3D` layer lerp (`round(... * t)`) | `round` | **unchanged** (legitimate interpolation) |

Hex grids are **center**-anchored (`getWorldPos` adds `size/2`), so nearest-center (`round` / `cubeRound`) is already the correct inverse and is left alone. The Y/layer axis of `Hex3D` is corner-anchored like a voxel stack, so it gets the same `floor` fix.

## Why the existing tests didn't catch it

The roundtrip tests fed `getWorldPos` output back into `worldToCell`. `getWorldPos` returns exact corner points (integer multiples of `cellSize`), where `round`, `floor`, and `truncate` all agree — so the tests passed trivially and never exercised a point *inside* a cell.

## Tests

Added regression tests that place a world point **inside** a cell (not on a corner) and assert it resolves to the containing cell, plus the banker's-rounding half-point case and a negative-coordinate `floor` case for the 2D grid; an inside-cell case for the voxel grid; and a mid-layer case for the `Hex3D` layer axis.

```
Passed!  - Failed: 0, Passed: 512, Skipped: 0, Total: 512
```

## Checklist

- [x] `dotnet fantomas .` run
- [x] `Mibo.Core.Tests` passing (512/512)
- [x] Changelog entry added under `[Unreleased]` → `Fixed`
