### PR TITLE
feat(3d): per-material transparency with sorted alpha blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **MonoGame 3D, Raylib 3D:** per-material transparency. Materials with `0 < Opacity < 1` now render alpha-blended after all opaque geometry, sorted far-to-near by camera distance (MonoGame switches to alpha blending with depth-read for the sorted pass); `Opacity <= 0` renders nothing. Transparent geometry no longer casts shadows — the depth pass is binary — and on MonoGame it is also excluded from the scene-depth pre-pass. Models or effects whose albedo/effect alpha is below 1 (e.g. a raylib albedo `Color.A` below 255) now render transparent instead of opaque casters. Instanced draws and `beginEffect`/`endEffect`-scoped draws keep their previous immediate behavior in this version — give them fully opaque materials.
+
 ## [4.0.0] - 2026-08-07
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **MonoGame 3D, Raylib 3D:** per-material transparency. Materials with `0 < Opacity < 1` now render alpha-blended after all opaque geometry, sorted far-to-near by camera distance (MonoGame switches to alpha blending with depth-read for the sorted pass); `Opacity <= 0` renders nothing. Transparent geometry no longer casts shadows — the depth pass is binary — and on MonoGame it is also excluded from the scene-depth pre-pass. Models or effects whose albedo/effect alpha is below 1 (e.g. a raylib albedo `Color.A` below 255) now render transparent instead of opaque casters. Instanced draws and `beginEffect`/`endEffect`-scoped draws keep their previous immediate behavior in this version — give them fully opaque materials.
+- **MonoGame 3D, Raylib 3D:** per-material transparency. Materials with `0 < Opacity < 1` render alpha-blended after all opaque geometry, sorted far-to-near by camera distance, with depth writes off for the sorted pass (depth test stays on) on both backends; `Opacity <= 0` renders nothing. Transparent geometry does not cast shadows and is excluded from the scene-depth pre-pass — the depth pass is binary — so `PostProcessWithDepth` effects (fog, depth-of-field) sample opaque-only depth on both backends. Models or effects whose albedo/effect alpha is below 1 (e.g. a raylib albedo `Color.A` below 255) now render transparent instead of opaque casters. Instanced and `beginEffect`/`endEffect`-scoped transparent draws are not deferred: they render immediately and unsorted, so they may blend incorrectly against sorted transparents — prefer opaque materials for them.
 
 ## [4.0.0] - 2026-08-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@
 
 ### Added
 
-- **MonoGame 3D, Raylib 3D:** per-material transparency. Materials with `0 < Opacity < 1` render alpha-blended after all opaque geometry, sorted far-to-near by camera distance, with depth writes off for the sorted pass (depth test stays on) on both backends; `Opacity <= 0` renders nothing. Transparent geometry does not cast shadows and is excluded from the scene-depth pre-pass — the depth pass is binary — so `PostProcessWithDepth` effects (fog, depth-of-field) sample opaque-only depth on both backends. Models or effects whose albedo/effect alpha is below 1 (e.g. a raylib albedo `Color.A` below 255) now render transparent instead of opaque casters. Instanced and `beginEffect`/`endEffect`-scoped transparent draws are not deferred: they render immediately and unsorted, so they may blend incorrectly against sorted transparents — prefer opaque materials for them.
+- **MonoGame 3D, Raylib 3D:** per-material transparency. Materials with `0 < Opacity < 1` render alpha-blended after all opaque geometry, sorted far-to-near by camera distance, with depth writes off for the sorted pass (depth test stays on) on both backends; `Opacity <= 0` renders nothing. Transparent geometry does not cast shadows and is excluded from the scene-depth pre-pass — the depth pass is binary — so `PostProcessWithDepth` effects (fog, depth-of-field) sample opaque-only depth on both backends. Instanced and `beginEffect`/`endEffect`-scoped transparent draws are not deferred: they render immediately and unsorted, so they may blend incorrectly against sorted transparents — prefer opaque materials for them.
+
+### Changed
+
+- **Breaking (behavioral): MonoGame 3D, Raylib 3D:** models or effects whose albedo/effect alpha is below 1 (e.g. a raylib albedo `Color.A` below 255, or a MonoGame `BasicEffect.Alpha`/`SkinnedEffect.Alpha` below 1) previously rendered fully opaque and cast shadows. They now render alpha-blended and no longer cast shadows or write scene depth. Games that relied on partially-transparent materials rendering as opaque casters must set `Opacity = 1` (raylib: `Color.A = 255`) to restore the previous behavior.
+
 ### Fixed
 
 - **Core:** `worldToCell` on square (`Grid2DSpatial`), voxel (`Grid3DSpatial`) and the layer axis of 3D hex (`Hex3DSpatial`) grids now returns the cell that *contains* the world position. They previously snapped to the nearest cell corner, so any point in the second half of a cell (and, because of banker's rounding, the exact center of an odd-indexed cell) reported the next cell over. Hex 2D and the hex (XZ) plane of 3D hex are unchanged — those resolve to the nearest hex center as before.

--- a/docs/graphics3d/materials.md
+++ b/docs/graphics3d/materials.md
@@ -60,7 +60,7 @@ buffer
 | `NormalMap` | `Texture2D voption` | `ValueNone` | Normal map for surface detail |
 | `EmissionColor` | `Color` | `Black` | Self-illumination color |
 | `EmissionMap` | `Texture2D voption` | `ValueNone` | Emission texture |
-| `Opacity` | `float32` | `1.0` | Alpha (1 = opaque, 0 = transparent) |
+| `Opacity` | `float32` | `1.0` | Alpha (>= 1 = opaque, 0 = invisible, in between = transparent) |
 | `Tiling` | `Vector2` | `(1, 1)` | UV tiling multiplier |
 
 ## Builder pattern
@@ -144,6 +144,43 @@ let glow = Material3D.unlit Color.Cyan
 ```
 
 Use for UI elements, debug markers, or anything that should appear at full brightness regardless of scene lighting.
+
+## Transparency
+
+`Opacity` controls how the surface mixes with what is behind it:
+
+- `Opacity >= 1.0` — opaque. Renders in the forward pass, writes depth, casts shadows.
+- `0 < Opacity < 1.0` — transparent. Renders after all opaque geometry, sorted far-to-near
+  by camera distance, and alpha-blends with the scene.
+- `Opacity <= 0.0` — not rendered at all (no draw, no shadow).
+
+```fsharp
+let glassMat = {
+    Material3D.defaults with
+        AlbedoColor = Color(200, 220, 255, 120) // alpha 120/255
+        Opacity = 120.0f / 255.0f
+        Roughness = 0.05f
+        Metallic = 0.9f
+}
+buffer.mesh(prims.Cube, transform, glassMat).drop()
+```
+
+Rules:
+
+- **Transparent geometry does not cast shadows.** The shadow pass is binary — it cannot
+  represent partial occlusion — so transparent surfaces are excluded from shadow and
+  scene-depth rendering. `EnableShadows`/`DisableShadows` scopes do not change this.
+- **Ordering is per-camera, far-to-near.** Transparent draws sort by distance to the camera
+  that captured them and render at camera boundaries and end of frame. Intersecting
+  transparent surfaces can still sort incorrectly — there is no per-pixel ordering.
+- **Where opacity comes from.** On raylib, `Opacity` maps from the albedo texture/color
+  alpha channel (`Color.A`); on MonoGame, from the effect's alpha (`BasicEffect.Alpha` /
+  `SkinnedEffect.Alpha`). On MonoGame, transparent draws switch the device to alpha blending
+  with depth-read for the duration of the sorted pass.
+- **Limitations.** Instanced draws and draws inside a `beginEffect`/`endEffect` scope are
+  not deferred in this version: they render immediately and keep their previous shadow
+  behavior. On MonoGame they also keep the frame's opaque blend state — give instanced or
+  effect-scoped geometry fully opaque materials.
 
 ## Primitive meshes
 

--- a/docs/graphics3d/materials.md
+++ b/docs/graphics3d/materials.md
@@ -151,7 +151,9 @@ Use for UI elements, debug markers, or anything that should appear at full brigh
 
 - `Opacity >= 1.0` — opaque. Renders in the forward pass, writes depth, casts shadows.
 - `0 < Opacity < 1.0` — transparent. Renders after all opaque geometry, sorted far-to-near
-  by camera distance, and alpha-blends with the scene.
+  by camera distance, and alpha-blends with the scene. Depth testing stays on but depth
+  writes are off for the sorted pass, so a transparent surface never occludes the geometry
+  behind it in the depth buffer.
 - `Opacity <= 0.0` — not rendered at all (no draw, no shadow).
 
 ```fsharp
@@ -167,20 +169,22 @@ buffer.mesh(prims.Cube, transform, glassMat).drop()
 
 Rules:
 
-- **Transparent geometry does not cast shadows.** The shadow pass is binary — it cannot
-  represent partial occlusion — so transparent surfaces are excluded from shadow and
-  scene-depth rendering. `EnableShadows`/`DisableShadows` scopes do not change this.
+- **Transparent geometry does not cast shadows and does not write depth.** The shadow and
+  scene-depth passes are binary — they cannot represent partial occlusion — so transparent
+  surfaces are excluded from both, and the sorted pass writes with depth off. Consequence:
+  `PostProcessWithDepth` effects (fog, depth-of-field) sample opaque-only depth on both
+  backends. `EnableShadows`/`DisableShadows` scopes do not change this.
 - **Ordering is per-camera, far-to-near.** Transparent draws sort by distance to the camera
   that captured them and render at camera boundaries and end of frame. Intersecting
   transparent surfaces can still sort incorrectly — there is no per-pixel ordering.
 - **Where opacity comes from.** On raylib, `Opacity` maps from the albedo texture/color
   alpha channel (`Color.A`); on MonoGame, from the effect's alpha (`BasicEffect.Alpha` /
-  `SkinnedEffect.Alpha`). On MonoGame, transparent draws switch the device to alpha blending
-  with depth-read for the duration of the sorted pass.
+  `SkinnedEffect.Alpha`). On both backends the sorted transparent pass uses alpha blending
+  with depth writes off (depth test on) for its duration.
 - **Limitations.** Instanced draws and draws inside a `beginEffect`/`endEffect` scope are
-  not deferred in this version: they render immediately and keep their previous shadow
-  behavior. On MonoGame they also keep the frame's opaque blend state — give instanced or
-  effect-scoped geometry fully opaque materials.
+  not deferred in this version: they render immediately and unsorted, so a transparent
+  instanced or effect-scoped surface may blend incorrectly against sorted transparents.
+  Prefer fully opaque materials for them.
 
 ## Primitive meshes
 

--- a/docs/graphics3d/materials.md
+++ b/docs/graphics3d/materials.md
@@ -182,9 +182,11 @@ Rules:
   `SkinnedEffect.Alpha`). On both backends the sorted transparent pass uses alpha blending
   with depth writes off (depth test on) for its duration.
 - **Limitations.** Instanced draws and draws inside a `beginEffect`/`endEffect` scope are
-  not deferred in this version: they render immediately and unsorted, so a transparent
-  instanced or effect-scoped surface may blend incorrectly against sorted transparents.
-  Prefer fully opaque materials for them.
+  not deferred in this version: they render immediately and unsorted. On raylib such a
+  transparent surface still blends (with depth writes on, since it skips the sorted flush);
+  on MonoGame it renders effectively opaque, because the frame's `BlendState.Opaque` is not
+  switched for these immediate draws. Either way a transparent instanced or effect-scoped
+  surface may look wrong against sorted transparents — prefer fully opaque materials for them.
 
 ## Primitive meshes
 

--- a/docs/graphics3d/overview.md
+++ b/docs/graphics3d/overview.md
@@ -204,11 +204,16 @@ identical:
 - **raylib:** the scene renders into a custom framebuffer whose depth attachment is
   a sampleable texture (not a renderbuffer). OpenGL's depth buffer is directly
   sampleable, so no extra geometry pass is needed — the depth you get is the same
-  depth buffer the forward pass wrote.
+  depth buffer the forward pass wrote. Transparent surfaces write with depth off during
+  their sorted pass, so they do not contribute to this depth buffer.
 - **MonoGame:** DirectX/OpenGL depth-stencil buffers are not directly sampleable as
   textures in MonoGame's API, so the pipeline re-renders all opaque geometry into a
   dedicated R32F color render target (cleared to white = far) via a depth-only
   shader. This is an extra geometry pass, but produces the same NDC z values.
+  Transparent geometry is excluded from this pass, matching raylib.
+
+In both cases the depth texture is opaque-only — `PostProcessWithDepth` effects (fog,
+depth-of-field) never see transparent surfaces.
 
 ### Post-process shader requirements
 

--- a/src/Mibo.MonoGame/Graphics3D/Command3D.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Command3D.fs
@@ -66,6 +66,10 @@ module Billboard3D =
 /// <para><c>All</c> applies one <see cref="T:Mibo.Elmish.Graphics3D.Material3D"/> to every mesh part
 /// (allocation-free struct field). <c>PerMesh</c> takes a resolver indexed by a flat counter over
 /// <c>model.Meshes × MeshParts</c> in pipeline iteration order.</para>
+/// <para>The <c>PerMesh</c> resolver is invoked at least once per mesh part per frame on the forward
+/// pass and again during shadow collection (plus additional calls under user-effect scopes), with no
+/// memoization. It must be pure and cheap — prefer returning a precomputed material over allocating
+/// or computing per call.</para>
 /// </summary>
 [<Struct>]
 type MaterialOverride =

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ForwardPipeline.fs
@@ -1,6 +1,7 @@
 namespace Mibo.Elmish.Graphics3D.Pipelines
 
 open System
+open System.Collections.Generic
 open Microsoft.Xna.Framework
 open Microsoft.Xna.Framework.Graphics
 open Mibo.Elmish
@@ -330,6 +331,19 @@ type ForwardPipelineBase
   // bone-transforms scratch are all owned by PbrResources and driven by PbrShading.* (PbrShading.fs).
   let pbrRes = PbrResources()
 
+  // Deferred transparent draws for the forward pass (materials with 0 < Opacity < 1): collected
+  // inline by the default Shade, sorted far-to-near by camera distance at flush points (camera
+  // boundaries, DrawImmediate, end of frame), then drawn after all opaque geometry with alpha
+  // blending + depth-read. Grow-only, reused across frames.
+  let transparentDraws = ResizeArray<TransparentDraw>()
+
+  // Cached far-to-near comparer for the transparent sort — one object for the pipeline
+  // lifetime, no per-frame allocation (List.Sort with a comparer sorts in place).
+  let transparentComparer: IComparer<TransparentDraw> =
+    { new IComparer<TransparentDraw> with
+        member _.Compare(a, b) = b.DistanceSq.CompareTo(a.DistanceSq)
+    }
+
   // Shadow pass: all shadow state (atlas, depth effect + params, origin, raster, pooled
   // caster/skinned/scratch arrays, per-light slot mappings, frustum, bone palette) is owned
   // by ShadowResources and driven by ShadowPass.run. See ShadowPass.fs.
@@ -413,7 +427,8 @@ type ForwardPipelineBase
           pbrRes,
           model,
           transform,
-          ValueNone
+          ValueNone,
+          transparentDraws
         )
       | Command3D.DrawModelWith(model, transform, matOverride) ->
         PbrShading.drawModel(
@@ -423,7 +438,8 @@ type ForwardPipelineBase
           pbrRes,
           model,
           transform,
-          ValueSome matOverride
+          ValueSome matOverride,
+          transparentDraws
         )
       | Command3D.DrawAnimatedModel(model, transform, bones) ->
         PbrShading.drawAnimatedModel(
@@ -434,7 +450,8 @@ type ForwardPipelineBase
           model,
           transform,
           bones,
-          ValueNone
+          ValueNone,
+          transparentDraws
         )
       | Command3D.DrawAnimatedModelWith(model, transform, bones, matOverride) ->
         PbrShading.drawAnimatedModel(
@@ -445,7 +462,8 @@ type ForwardPipelineBase
           model,
           transform,
           bones,
-          ValueSome matOverride
+          ValueSome matOverride,
+          transparentDraws
         )
       | Command3D.DrawPrimitive(mesh, transform, material) ->
         PbrShading.drawPrimitive(
@@ -455,7 +473,8 @@ type ForwardPipelineBase
           pbrRes,
           mesh,
           transform,
-          material
+          material,
+          transparentDraws
         )
       | Command3D.DrawInstanced(mesh,
                                 transforms,
@@ -1231,6 +1250,36 @@ type ForwardPipelineBase
       // skipped. So reset to "no active camera" before the forward loop.
       state.HasCamera <- false
 
+      // Transparent flush: draws the deferred transparents (sorted far-to-near) with alpha
+      // blending + depth-read, then clears the list. Opaque geometry already wrote depth and
+      // the far-to-near sort guarantees each successive transparent is nearer, so it passes
+      // the depth test against everything already drawn. Called at camera boundaries, before
+      // DrawImmediate, and at the end of the frame — must run while the deferring camera's
+      // matrices/viewport are still current. No-op when nothing was deferred. Inline so the
+      // body can take the address of the enclosing mutable state/scene at each call site
+      // (a closure cannot capture byrefs).
+      let inline flushTransparents() =
+        if transparentDraws.Count > 0 then
+          let prevBlend = gd.BlendState
+          let prevDepth = gd.DepthStencilState
+
+          gd.BlendState <- BlendState.AlphaBlend
+          gd.DepthStencilState <- DepthStencilState.DepthRead
+          transparentDraws.Sort(transparentComparer)
+
+          for i = 0 to transparentDraws.Count - 1 do
+            PbrShading.drawTransparent(
+              gd,
+              &state,
+              &scene,
+              pbrRes,
+              transparentDraws[i]
+            )
+
+          gd.BlendState <- prevBlend
+          gd.DepthStencilState <- prevDepth
+          transparentDraws.Clear()
+
       // Running camera-block index into the block plan; advanced at each
       // BeginCamera/BeginCameraConfig below (multi-block frames only).
       let mutable blockIndex = -1
@@ -1252,6 +1301,10 @@ type ForwardPipelineBase
         match buffer[i] with
         // ── Camera ──
         | Command3D.BeginCamera cam ->
+          // Transparents sort by the camera that deferred them — flush before switching to
+          // the new camera's matrices (state still holds the previous camera's view).
+          flushTransparents()
+
           // Re-establish this camera's view (the pre-scan left the LAST camera's view in
           // state; without this, multi-camera scenes render every view from the last one).
           let struct (v, _) = buildMatrices cam
@@ -1286,6 +1339,10 @@ type ForwardPipelineBase
             )
 
         | Command3D.BeginCameraConfig cfg ->
+          // Transparents sort by the camera that deferred them — flush before applying the
+          // new block's viewport/matrices (the previous camera's viewport is still active).
+          flushTransparents()
+
           // Apply viewport + clear color (deferred from pre-scan so clearing happens here).
           match cfg.Viewport with
           | ValueSome rect -> gd.Viewport <- Viewport(rect)
@@ -1344,6 +1401,10 @@ type ForwardPipelineBase
 
         | Command3D.EndCamera ->
           if state.HasCamera then
+            // Transparents sort by the camera that deferred them — flush before the
+            // viewport restore (the deferring camera's viewport is still active).
+            flushTransparents()
+
             // Restore fullscreen viewport + mark camera inactive so subsequent draws are skipped
             // until the next BeginCamera (matches the B5-B9 single-pass semantics; without this,
             // draws after EndCamera would dispatch with stale matrices).
@@ -1415,6 +1476,10 @@ type ForwardPipelineBase
 
         // ── Escape hatch: full device control + the gathered scene data ──
         | Command3D.DrawImmediate action ->
+          // Transparents emitted before the immediate block draw before it (they were
+          // deferred earlier in the buffer).
+          flushTransparents()
+
           let savedHasCamera = state.HasCamera
           let savedViewport = gd.Viewport
 
@@ -1434,6 +1499,10 @@ type ForwardPipelineBase
             // Restore viewport; camera state is logical (matrices), nothing to restore on gd.
             gd.Viewport <- savedViewport
             state.HasCamera <- savedHasCamera
+
+      // ── Transparent flush (end of frame) — state still holds the last camera's
+      // matrices/viewport, which the scene-depth pre-pass below also reads. ──
+      flushTransparents()
 
       // ── Scene depth pre-pass (camera-POV, reusing collected geometry) ──
       // Only runs when PostProcessWithDepth actions exist. Single-camera frames reuse the

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -790,27 +790,11 @@ module internal PbrShading =
                       Opacity = mat.Opacity * tintVec.W
                 }
 
-            if mat.Opacity < 1.0f then
-              // Transparent: defer to the sorted pass. Opacity <= 0 draws nothing at all.
-              // The instanced fallback passes ValueNone for the list — instanced draws
-              // keep the previous immediate behavior.
-              if mat.Opacity > 0.0f then
-                match transparentDraws with
-                | ValueSome draws ->
-                  draws.Add {
-                    Part = ValueSome part
-                    Mesh = ValueNone
-                    World = world
-                    Material = mat
-                    Bones = ValueSome bones
-                    DistanceSq =
-                      Vector3.DistanceSquared(
-                        state.CurrentCamera.Position,
-                        world.Translation
-                      )
-                  }
-                | ValueNone -> ()
-            else
+            // Draws this part immediately with the resolved material. Local inline so the
+            // byref `&mat` is addressed at the call sites (local functions can't take
+            // byref params). Used for opaque parts and for the instanced fallback's
+            // transparent parts, which have no shared transparent list to defer into.
+            let inline drawPartImmediately() =
               let key = materialKey &mat
 
               if not res.HasLastMaterial || key <> res.LastKey then
@@ -826,6 +810,33 @@ module internal PbrShading =
                 drawPart(gd, part)
               finally
                 part.Effect <- saved
+
+            if mat.Opacity <= 0.0f then
+              // Fully invisible: draw nothing.
+              ()
+            elif mat.Opacity < 1.0f then
+              // Transparent: defer to the sorted pass when one is available.
+              // The instanced fallback passes ValueNone (no shared transparent list),
+              // so it draws immediately, unsorted — matching the DX11 real-instancing
+              // path. Sorted deferral of skinned+instanced transparents is a v1
+              // limitation.
+              match transparentDraws with
+              | ValueSome draws ->
+                draws.Add {
+                  Part = ValueSome part
+                  Mesh = ValueNone
+                  World = world
+                  Material = mat
+                  Bones = ValueSome bones
+                  DistanceSq =
+                    Vector3.DistanceSquared(
+                      state.CurrentCamera.Position,
+                      world.Translation
+                    )
+                }
+              | ValueNone -> drawPartImmediately()
+            else
+              drawPartImmediately()
       | _ -> ()
 
   /// <summary>Handles <c>DrawAnimatedModel</c>: Skinned technique for SkinnedEffect parts,

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -1010,10 +1010,15 @@ module internal PbrShading =
         | ValueSome part ->
           // Skinned parts (SkinnedEffect baked effect) get the Skinned technique and the
           // bone palette, copied into the shared scratch, tail-filled with identity.
+          // Gate on bones being present: a DrawModel-deferred transparent part carries
+          // ValueNone (its opaque counterpart draws Standard), so a part that merely has a
+          // baked SkinnedEffect must render Standard here too, or it would use the Skinned
+          // technique with no palette uploaded (stale/zero bones → collapsed vertices).
           let isSkinned =
-            match part.Effect with
-            | :? SkinnedEffect -> true
-            | _ -> false
+            entry.Bones.IsSome
+            && (match part.Effect with
+                | :? SkinnedEffect -> true
+                | _ -> false)
 
           if isSkinned then
             e.CurrentTechnique <- e.Techniques["Skinned"]

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/PbrShading.fs
@@ -69,9 +69,34 @@ type ForwardFrame = {
   /// uploads these uniforms by name so a custom effect can opt into shadow sampling.</summary>
   mutable Shadows: ShadowResult voption
   /// <summary>The total elapsed game time, in seconds (<c>Game.TotalGameTime.TotalSeconds</c>). Uploaded
-  /// as the <c>time</c> uniform so an animated shader (water ripples, flowing textures, pulsing emissive)
+  /// as the <c>time</c> uniform so an animated shader (water ripples, flowing textures, pulsating emissive)
   /// has a clock to read — the only animation input the scene-data contract provides.</summary>
   Time: float32
+}
+
+/// <summary>
+/// A deferred transparent draw for the forward pass: a single model-mesh-part or primitive
+/// draw whose resolved material has <c>0 &lt; Opacity &lt; 1</c>. Collected inline during the
+/// forward pass, sorted far-to-near by camera distance, and flushed after all opaque geometry
+/// with alpha blending + depth-read (opaque geometry already wrote depth; each successive
+/// transparent is nearer and passes the depth test). Transparent geometry is also excluded
+/// from the shadow and scene-depth gathers (see <c>ShadowPass.collectCommand</c>) — something
+/// that renders blended must not write shadow depth.
+/// </summary>
+[<Struct>]
+type TransparentDraw = {
+  /// <summary>The model-mesh-part to draw (ValueNone for primitives).</summary>
+  Part: ModelMeshPart voption
+  /// <summary>The primitive mesh to draw (ValueNone for model parts).</summary>
+  Mesh: PrimitiveMesh voption
+  /// <summary>The world transform of the mesh (per-mesh world for model parts).</summary>
+  World: Matrix
+  /// <summary>The resolved material (override + tint already applied).</summary>
+  Material: Material3D
+  /// <summary>The bone palette for skinned parts (ValueNone otherwise).</summary>
+  Bones: Matrix[] voption
+  /// <summary>Squared distance to the camera that deferred this draw (sort key).</summary>
+  DistanceSq: float32
 }
 
 /// <summary>
@@ -585,7 +610,8 @@ module internal PbrShading =
       res: PbrResources,
       model: Model,
       transform: Matrix,
-      matOverride: MaterialOverride voption
+      matOverride: MaterialOverride voption,
+      transparentDraws: ResizeArray<TransparentDraw>
     ) =
     if ensureEffect(gd, res) then
       match struct (res.Effect, res.Params) with
@@ -634,21 +660,38 @@ module internal PbrShading =
               | ValueSome(MaterialOverride.PerMesh f) -> f partIndex
 
             partIndex <- partIndex + 1
-            let key = materialKey &mat
 
-            if not res.HasLastMaterial || key <> res.LastKey then
-              PbrUniforms.uploadMaterial(&p, &mat)
-              PbrUniforms.bindTextures(&p, &mat, whiteTex res)
-              res.LastKey <- key
-              res.HasLastMaterial <- true
+            if mat.Opacity < 1.0f then
+              // Transparent: defer to the sorted pass. Opacity <= 0 draws nothing at all.
+              if mat.Opacity > 0.0f then
+                transparentDraws.Add {
+                  Part = ValueSome part
+                  Mesh = ValueNone
+                  World = world
+                  Material = mat
+                  Bones = ValueNone
+                  DistanceSq =
+                    Vector3.DistanceSquared(
+                      state.CurrentCamera.Position,
+                      world.Translation
+                    )
+                }
+            else
+              let key = materialKey &mat
 
-            let saved = part.Effect
-            part.Effect <- e
+              if not res.HasLastMaterial || key <> res.LastKey then
+                PbrUniforms.uploadMaterial(&p, &mat)
+                PbrUniforms.bindTextures(&p, &mat, whiteTex res)
+                res.LastKey <- key
+                res.HasLastMaterial <- true
 
-            try
-              drawPart(gd, part)
-            finally
-              part.Effect <- saved
+              let saved = part.Effect
+              part.Effect <- e
+
+              try
+                drawPart(gd, part)
+              finally
+                part.Effect <- saved
       | _ -> ()
 
   /// <summary>Handles <c>DrawAnimatedModel</c>: Skinned technique for SkinnedEffect parts,
@@ -667,7 +710,8 @@ module internal PbrShading =
       transform: Matrix,
       bones: Matrix[],
       matOverride: MaterialOverride voption,
-      tint: Color voption
+      tint: Color voption,
+      transparentDraws: ResizeArray<TransparentDraw> voption
     ) =
     if ensureEffect(gd, res) then
       match struct (res.Effect, res.Params) with
@@ -746,21 +790,42 @@ module internal PbrShading =
                       Opacity = mat.Opacity * tintVec.W
                 }
 
-            let key = materialKey &mat
+            if mat.Opacity < 1.0f then
+              // Transparent: defer to the sorted pass. Opacity <= 0 draws nothing at all.
+              // The instanced fallback passes ValueNone for the list — instanced draws
+              // keep the previous immediate behavior.
+              if mat.Opacity > 0.0f then
+                match transparentDraws with
+                | ValueSome draws ->
+                  draws.Add {
+                    Part = ValueSome part
+                    Mesh = ValueNone
+                    World = world
+                    Material = mat
+                    Bones = ValueSome bones
+                    DistanceSq =
+                      Vector3.DistanceSquared(
+                        state.CurrentCamera.Position,
+                        world.Translation
+                      )
+                  }
+                | ValueNone -> ()
+            else
+              let key = materialKey &mat
 
-            if not res.HasLastMaterial || key <> res.LastKey then
-              PbrUniforms.uploadMaterial(&p, &mat)
-              PbrUniforms.bindTextures(&p, &mat, whiteTex res)
-              res.LastKey <- key
-              res.HasLastMaterial <- true
+              if not res.HasLastMaterial || key <> res.LastKey then
+                PbrUniforms.uploadMaterial(&p, &mat)
+                PbrUniforms.bindTextures(&p, &mat, whiteTex res)
+                res.LastKey <- key
+                res.HasLastMaterial <- true
 
-            let saved = part.Effect
-            part.Effect <- e
+              let saved = part.Effect
+              part.Effect <- e
 
-            try
-              drawPart(gd, part)
-            finally
-              part.Effect <- saved
+              try
+                drawPart(gd, part)
+              finally
+                part.Effect <- saved
       | _ -> ()
 
   /// <summary>Handles <c>DrawAnimatedModel</c>: Skinned technique for SkinnedEffect parts,
@@ -774,7 +839,8 @@ module internal PbrShading =
       model: Model,
       transform: Matrix,
       bones: Matrix[],
-      matOverride: MaterialOverride voption
+      matOverride: MaterialOverride voption,
+      transparentDraws: ResizeArray<TransparentDraw>
     ) =
     drawAnimatedModelCore(
       gd,
@@ -785,7 +851,8 @@ module internal PbrShading =
       transform,
       bones,
       matOverride,
-      ValueNone
+      ValueNone,
+      ValueSome transparentDraws
     )
 
   /// <summary>
@@ -800,9 +867,25 @@ module internal PbrShading =
       res: PbrResources,
       mesh: PrimitiveMesh,
       transform: Matrix,
-      material: Material3D
+      material: Material3D,
+      transparentDraws: ResizeArray<TransparentDraw>
     ) =
-    if ensureEffect(gd, res) then
+    if material.Opacity < 1.0f then
+      // Transparent: defer to the sorted pass. Opacity <= 0 draws nothing at all.
+      if material.Opacity > 0.0f then
+        transparentDraws.Add {
+          Part = ValueNone
+          Mesh = ValueSome mesh
+          World = transform
+          Material = material
+          Bones = ValueNone
+          DistanceSq =
+            Vector3.DistanceSquared(
+              state.CurrentCamera.Position,
+              transform.Translation
+            )
+        }
+    elif ensureEffect(gd, res) then
       match struct (res.Effect, res.Params) with
       | struct (ValueSome e, ValueSome p) ->
         e.CurrentTechnique <- e.Techniques["Standard"]
@@ -864,6 +947,96 @@ module internal PbrShading =
       effect.Projection <- state.Projection
       applyLighting(effect, frame.Lights)
       mesh.Draw(gd, effect)
+
+  /// <summary>
+  /// Draws one deferred transparent entry (<see cref="T:Mibo.Elmish.Graphics3D.Pipelines.TransparentDraw"/>)
+  /// during the forward pass's transparent flush. PBR Standard or Skinned technique by the part's
+  /// baked effect, world/normal/view-proj/camera matrices, material uniforms through the MaterialKey
+  /// short-circuit, and the effect swap around the part draw. The caller has already switched to
+  /// alpha blending + depth-read. Mirrors the per-part body of <c>drawModel</c>/<c>drawAnimatedModelCore</c>
+  /// minus the immediate-draw deferral branch.
+  /// </summary>
+  let drawTransparent
+    (
+      gd: GraphicsDevice,
+      state: byref<ForwardState>,
+      frame: byref<ForwardFrame>,
+      res: PbrResources,
+      entry: TransparentDraw
+    ) =
+    if ensureEffect(gd, res) then
+      match struct (res.Effect, res.Params) with
+      | struct (ValueSome e, ValueSome p) ->
+        let mutable t = entry.World
+        let mutable inv = Matrix.Identity
+        Matrix.Invert(&t, &inv) |> ignore
+        let normalMatrix = Matrix.Transpose inv
+
+        PbrUniforms.setMatrix p.Matrix.MatModel entry.World
+        PbrUniforms.setMatrix p.Matrix.ViewProj (state.View * state.Projection)
+        PbrUniforms.setMatrix p.Matrix.NormalMatrix normalMatrix
+        PbrUniforms.setVec3 p.Matrix.CameraPos state.CurrentCamera.Position
+
+        if res.LightsDirty then
+          PbrUniforms.uploadLights(
+            &p,
+            frame.Lights,
+            frame.PointShadowSlots,
+            frame.SpotShadowSlots
+          )
+
+          res.LightsDirty <- false
+
+        let key = materialKey &entry.Material
+
+        if not res.HasLastMaterial || key <> res.LastKey then
+          PbrUniforms.uploadMaterial(&p, &entry.Material)
+          PbrUniforms.bindTextures(&p, &entry.Material, whiteTex res)
+          res.LastKey <- key
+          res.HasLastMaterial <- true
+
+        match entry.Part with
+        | ValueSome part ->
+          // Skinned parts (SkinnedEffect baked effect) get the Skinned technique and the
+          // bone palette, copied into the shared scratch, tail-filled with identity.
+          let isSkinned =
+            match part.Effect with
+            | :? SkinnedEffect -> true
+            | _ -> false
+
+          if isSkinned then
+            e.CurrentTechnique <- e.Techniques["Skinned"]
+
+            match entry.Bones with
+            | ValueSome bones ->
+              let palette = frame.BonePaletteScratch
+              let palCount = min bones.Length palette.Length
+
+              for i = 0 to palCount - 1 do
+                palette[i] <- bones[i]
+
+              for i = palCount to palette.Length - 1 do
+                palette[i] <- Matrix.Identity
+
+              PbrUniforms.setMatrixArray p.Matrix.Bones palette
+            | ValueNone -> ()
+          else
+            e.CurrentTechnique <- e.Techniques["Standard"]
+
+          let saved = part.Effect
+          part.Effect <- e
+
+          try
+            drawPart(gd, part)
+          finally
+            part.Effect <- saved
+        | ValueNone ->
+          match entry.Mesh with
+          | ValueSome mesh ->
+            e.CurrentTechnique <- e.Techniques["Standard"]
+            mesh.Draw(gd, e)
+          | ValueNone -> ()
+      | _ -> ()
 
   /// <summary>
   /// Stages per-instance world matrices into the reusable <see cref="T:Mibo.Elmish.Graphics3D.VertexInstanceWorld"/>
@@ -1416,7 +1589,8 @@ module internal PbrShading =
             transforms[i],
             slice,
             matOverride,
-            tint
+            tint,
+            ValueNone
           )
       else
         // Bone transforms give each mesh its parent-bone world (the matModel the

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -618,6 +618,7 @@ module internal ShadowPass =
             }
 
             res.CollectedModelPartCount <- res.CollectedModelPartCount + 1
+          | _ -> ()
     | Command3D.DrawModelWith(model, transform, matOverride) ->
       // The override decides opacity in the forward pass, so it matters for depth: parts
       // whose resolved material is transparent are skipped. The flat part index (meshes ×
@@ -665,6 +666,7 @@ module internal ShadowPass =
             }
 
             res.CollectedModelPartCount <- res.CollectedModelPartCount + 1
+          | _ -> ()
     | Command3D.DrawAnimatedModelWith(model, transform, bones, matOverride) ->
       // Mirror DrawAnimatedModel (SkinnedEffect parts only), but the override decides
       // opacity in the forward pass, so it matters for depth: transparent parts are

--- a/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
+++ b/src/Mibo.MonoGame/Graphics3D/Pipelines/ShadowPass.fs
@@ -512,13 +512,26 @@ module internal ShadowPass =
     res.CollectedInstancedCount <- 0
     res.CollectedSkinnedInstancedCount <- 0
 
+  /// True when the part's baked effect renders opaque in the forward pass. The forward pass
+  /// resolves material opacity from the same effect (Material3D.fromEffect reads
+  /// BasicEffect.Alpha/SkinnedEffect.Alpha); other effects map to a default material with
+  /// Opacity = 1. Transparent parts are excluded from depth renders (shadow + scene depth).
+  let private partIsOpaque(part: ModelMeshPart) =
+    match part.Effect with
+    | :? BasicEffect as b -> b.Alpha >= 1.0f
+    | :? SkinnedEffect as s -> s.Alpha >= 1.0f
+    | _ -> true
+
   /// <summary>
   /// Collects one buffer command into the pooled arrays on <paramref name="res"/>, recording a
   /// <c>CastsShadow</c> flag per entry (snapshot of the running cast state — see
   /// <see cref="M:Mibo.Elmish.Graphics3D.Pipelines.ShadowPass.beginCollect"/>). Shared by the
   /// shadow render (filters to <c>CastsShadow = true</c>) and the scene-depth render (all
-  /// entries). <paramref name="gd"/> is used only to lazily build merged part groups for
-  /// skinned + instanced models (<see cref="M:Mibo.Elmish.Graphics3D.Pipelines.MergedModelParts.tryGet"/>).
+  /// entries). Transparent geometry is never collected — the depth pass is binary (no alpha
+  /// test), so a transparent caster would occlude at full strength; being shared, the
+  /// exclusion also applies to the scene-depth render. <paramref name="gd"/> is used only to
+  /// lazily build merged part groups for skinned + instanced models
+  /// (<see cref="M:Mibo.Elmish.Graphics3D.Pipelines.MergedModelParts.tryGet"/>).
   /// </summary>
   let collectCommand
     (gd: GraphicsDevice)
@@ -535,26 +548,30 @@ module internal ShadowPass =
     match cmd with
     | Command3D.EnableShadows -> res.CollectCastEnabled <- true
     | Command3D.DisableShadows -> res.CollectCastEnabled <- false
-    | Command3D.DrawPrimitive(mesh, transform, _) ->
-      if res.CollectedDrawCount >= shadowDraws.Length then
-        Array.Resize(&shadowDraws, shadowDraws.Length * 2)
-        res.Draws <- shadowDraws
+    | Command3D.DrawPrimitive(mesh, transform, material) ->
+      // Transparent primitives (Opacity < 1 in the forward pass) don't cast shadows: the
+      // depth pass is binary (no alpha test), so a transparent caster would occlude at
+      // full strength.
+      if material.Opacity >= 1.0f then
+        if res.CollectedDrawCount >= shadowDraws.Length then
+          Array.Resize(&shadowDraws, shadowDraws.Length * 2)
+          res.Draws <- shadowDraws
 
-      let worldBounds = mesh.Bounds.Transform transform
+        let worldBounds = mesh.Bounds.Transform transform
 
-      shadowDraws[res.CollectedDrawCount] <- {
-        Mesh = mesh
-        Transform = transform
-        WorldBounds = worldBounds
-        CastsShadow = castEnabled
-      }
+        shadowDraws[res.CollectedDrawCount] <- {
+          Mesh = mesh
+          Transform = transform
+          WorldBounds = worldBounds
+          CastsShadow = castEnabled
+        }
 
-      res.CollectedDrawCount <- res.CollectedDrawCount + 1
+        res.CollectedDrawCount <- res.CollectedDrawCount + 1
     | Command3D.DrawAnimatedModel(model, transform, bones) ->
       for mesh in model.Meshes do
         for part in mesh.MeshParts do
           match part.Effect with
-          | :? SkinnedEffect ->
+          | :? SkinnedEffect when partIsOpaque part ->
             if res.CollectedSkinnedCount >= shadowSkinnedDraws.Length then
               Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
               res.SkinnedDraws <- shadowSkinnedDraws
@@ -572,7 +589,7 @@ module internal ShadowPass =
       for mesh in model.Meshes do
         for part in mesh.MeshParts do
           match part.Effect with
-          | :? SkinnedEffect ->
+          | :? SkinnedEffect when partIsOpaque part ->
             if res.CollectedSkinnedCount >= shadowSkinnedDraws.Length then
               Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
               res.SkinnedDraws <- shadowSkinnedDraws
@@ -585,7 +602,7 @@ module internal ShadowPass =
             }
 
             res.CollectedSkinnedCount <- res.CollectedSkinnedCount + 1
-          | _ ->
+          | _ when partIsOpaque part ->
             if res.CollectedModelPartCount >= shadowModelPartDraws.Length then
               Array.Resize(
                 &shadowModelPartDraws,
@@ -601,12 +618,25 @@ module internal ShadowPass =
             }
 
             res.CollectedModelPartCount <- res.CollectedModelPartCount + 1
-    | Command3D.DrawModelWith(model, transform, _) ->
-      // Override material is irrelevant to depth; gather identically to DrawModel.
+    | Command3D.DrawModelWith(model, transform, matOverride) ->
+      // The override decides opacity in the forward pass, so it matters for depth: parts
+      // whose resolved material is transparent are skipped. The flat part index (meshes ×
+      // parts) mirrors the forward pass's drawModel counter. Transparent parts don't cast
+      // shadows: the depth pass is binary (no alpha test), so a transparent caster would
+      // occlude at full strength.
+      let mutable partIndex = 0
+
       for mesh in model.Meshes do
         for part in mesh.MeshParts do
+          let opaque =
+            match matOverride with
+            | MaterialOverride.All m -> m.Opacity >= 1.0f
+            | MaterialOverride.PerMesh f -> (f partIndex).Opacity >= 1.0f
+
+          partIndex <- partIndex + 1
+
           match part.Effect with
-          | :? SkinnedEffect ->
+          | :? SkinnedEffect when opaque ->
             if res.CollectedSkinnedCount >= shadowSkinnedDraws.Length then
               Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
               res.SkinnedDraws <- shadowSkinnedDraws
@@ -619,7 +649,7 @@ module internal ShadowPass =
             }
 
             res.CollectedSkinnedCount <- res.CollectedSkinnedCount + 1
-          | _ ->
+          | _ when opaque ->
             if res.CollectedModelPartCount >= shadowModelPartDraws.Length then
               Array.Resize(
                 &shadowModelPartDraws,
@@ -635,12 +665,24 @@ module internal ShadowPass =
             }
 
             res.CollectedModelPartCount <- res.CollectedModelPartCount + 1
-    | Command3D.DrawAnimatedModelWith(model, transform, bones, _) ->
-      // Mirror DrawAnimatedModel: SkinnedEffect parts only.
+    | Command3D.DrawAnimatedModelWith(model, transform, bones, matOverride) ->
+      // Mirror DrawAnimatedModel (SkinnedEffect parts only), but the override decides
+      // opacity in the forward pass, so it matters for depth: transparent parts are
+      // skipped. The flat part index (meshes × parts) mirrors the forward pass's
+      // drawAnimatedModel counter.
+      let mutable partIndex = 0
+
       for mesh in model.Meshes do
         for part in mesh.MeshParts do
+          let opaque =
+            match matOverride with
+            | MaterialOverride.All m -> m.Opacity >= 1.0f
+            | MaterialOverride.PerMesh f -> (f partIndex).Opacity >= 1.0f
+
+          partIndex <- partIndex + 1
+
           match part.Effect with
-          | :? SkinnedEffect ->
+          | :? SkinnedEffect when opaque ->
             if res.CollectedSkinnedCount >= shadowSkinnedDraws.Length then
               Array.Resize(&shadowSkinnedDraws, shadowSkinnedDraws.Length * 2)
               res.SkinnedDraws <- shadowSkinnedDraws

--- a/src/Mibo.Raylib/Graphics3D/Command3D.fs
+++ b/src/Mibo.Raylib/Graphics3D/Command3D.fs
@@ -12,6 +12,9 @@ open Mibo.Elmish
 /// <para><c>All</c> applies one <see cref="T:Mibo.Elmish.Graphics3D.Material3D"/> to every sub-mesh
 /// (allocation-free struct field). <c>PerMesh</c> takes a resolver indexed by the pipeline's sub-mesh
 /// iteration order — mesh index <c>0..model.MeshCount-1</c> on the raylib backend.</para>
+/// <para>The <c>PerMesh</c> resolver is invoked several times per mesh per frame (forward pass,
+/// shadow collection, and the per-frame shader-variant warm-up), with no memoization. It must be
+/// pure and cheap — prefer returning a precomputed material over allocating or computing per call.</para>
 /// </summary>
 [<Struct>]
 type MaterialOverride =

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -569,6 +569,20 @@ module internal ShadowPassHelpers =
     BoneCount: int
   }
 
+  /// A deferred transparent draw for the forward pass: a single mesh draw whose material
+  /// has <c>0 &lt; Opacity &lt; 1</c>. Transparents are not drawn inline — they are collected,
+  /// sorted far-to-near by camera distance, and flushed after all opaque geometry. The PBR
+  /// fragment already outputs alpha and the default ALPHA blend is always active, so the
+  /// flush is a draw-order change only (no blend/depth-state switch needed).
+  [<Struct>]
+  type TransparentMeshDraw = {
+    Mesh: Mesh
+    Transform: Matrix4x4
+    Bones: Matrix4x4[] voption
+    Material: Material3D
+    DistanceSq: float32
+  }
+
   /// <summary>
   /// Grow-only pooled collection of mesh draws for the shadow pass, gathered per command
   /// (<c>Begin</c> → <c>Add</c>* → <c>Finish</c>) instead of a count scan + rent-exact +
@@ -602,55 +616,78 @@ module internal ShadowPassHelpers =
       instancedCount <- 0
 
     /// <summary>Collects one buffer command. Draws emitted while shadows are disabled are
-    /// skipped (they don't cast); everything else appends to the pooled spans.</summary>
+    /// skipped (they don't cast); materials with <c>Opacity &lt; 1.0</c> are also skipped —
+    /// transparent geometry doesn't cast shadows (the depth pass is binary, no alpha test,
+    /// so a blended object must not write shadow depth). Instanced draws are collected
+    /// whole regardless (their commands carry no material on this backend).</summary>
     member _.Add(cmd: Command3D) =
       match cmd with
       | Command3D.DisableShadows -> shadowsEnabled <- false
       | Command3D.EnableShadows -> shadowsEnabled <- true
-      | Command3D.DrawMesh(mesh, transform, _) when shadowsEnabled ->
-        ensureMesh(meshCount + 1)
+      | Command3D.DrawMesh(mesh, transform, material) when shadowsEnabled ->
+        if material.Opacity >= 1.0f then
+          ensureMesh(meshCount + 1)
 
-        meshDraws[meshCount] <- {
-          Mesh = mesh
-          Transform = transform
-          Bones = ValueNone
-        }
+          meshDraws[meshCount] <- {
+            Mesh = mesh
+            Transform = transform
+            Bones = ValueNone
+          }
 
-        meshCount <- meshCount + 1
-      | Command3D.DrawSkinnedMesh(mesh, transform, _, bones) when shadowsEnabled ->
-        ensureMesh(meshCount + 1)
+          meshCount <- meshCount + 1
+      | Command3D.DrawSkinnedMesh(mesh, transform, material, bones) when
+        shadowsEnabled
+        ->
+        if material.Opacity >= 1.0f then
+          ensureMesh(meshCount + 1)
 
-        meshDraws[meshCount] <- {
-          Mesh = mesh
-          Transform = transform
-          Bones = ValueSome bones
-        }
+          meshDraws[meshCount] <- {
+            Mesh = mesh
+            Transform = transform
+            Bones = ValueSome bones
+          }
 
-        meshCount <- meshCount + 1
+          meshCount <- meshCount + 1
       | Command3D.DrawModel(model, transform) when shadowsEnabled ->
         for mi = 0 to model.MeshCount - 1 do
           let mesh = NativePtr.get model.Meshes mi
-          ensureMesh(meshCount + 1)
+          let matIdx = NativePtr.get model.MeshMaterial mi
+          let raylibMat = NativePtr.get model.Materials matIdx
 
-          meshDraws[meshCount] <- {
-            Mesh = mesh
-            Transform = transform
-            Bones = ValueNone
-          }
+          // Per-submesh opacity from the model's native materials (Color.A / 255).
+          if
+            (NativePtr.get raylibMat.Maps (int MaterialMapIndex.Albedo)).Color.A = 255uy
+          then
+            ensureMesh(meshCount + 1)
 
-          meshCount <- meshCount + 1
-      | Command3D.DrawModelWith(model, transform, _) when shadowsEnabled ->
+            meshDraws[meshCount] <- {
+              Mesh = mesh
+              Transform = transform
+              Bones = ValueNone
+            }
+
+            meshCount <- meshCount + 1
+      | Command3D.DrawModelWith(model, transform, matOverride) when
+        shadowsEnabled
+        ->
         for mi = 0 to model.MeshCount - 1 do
           let mesh = NativePtr.get model.Meshes mi
-          ensureMesh(meshCount + 1)
 
-          meshDraws[meshCount] <- {
-            Mesh = mesh
-            Transform = transform
-            Bones = ValueNone
-          }
+          let opaque =
+            match matOverride with
+            | MaterialOverride.All m -> m.Opacity >= 1.0f
+            | MaterialOverride.PerMesh f -> (f mi).Opacity >= 1.0f
 
-          meshCount <- meshCount + 1
+          if opaque then
+            ensureMesh(meshCount + 1)
+
+            meshDraws[meshCount] <- {
+              Mesh = mesh
+              Transform = transform
+              Bones = ValueNone
+            }
+
+            meshCount <- meshCount + 1
       | Command3D.DrawMeshInstanced(mesh, transforms, _, instanceCount) when
         shadowsEnabled
         ->
@@ -2585,6 +2622,20 @@ type ForwardPipelineBase
   // former count-scan + rent-exact + fill-scan (two buffer walks + pool churn per pass).
   let drawCollection = MeshDrawCollection()
 
+  // Deferred transparent draws for the forward pass (materials with 0 < Opacity < 1):
+  // collected inline, sorted far-to-near by camera distance at flush points (camera
+  // boundaries, DrawImmediate, end of frame), then drawn after all opaque geometry.
+  // The PBR fragment already outputs alpha and the default ALPHA blend is always
+  // active, so the flush is a draw-order change only. Grow-only, reused across frames.
+  let transparentDraws = ResizeArray<TransparentMeshDraw>()
+
+  // Cached far-to-near comparer for the transparent sort — one object for the pipeline
+  // lifetime, no per-frame allocation (List.Sort with a comparer sorts in place).
+  let transparentComparer: IComparer<TransparentMeshDraw> =
+    { new IComparer<TransparentMeshDraw> with
+        member _.Compare(a, b) = b.DistanceSq.CompareTo(a.DistanceSq)
+    }
+
   let applyPostProcess
     (ctx: GameContext)
     (sceneTarget: RenderTexture2D)
@@ -3506,11 +3557,140 @@ type ForwardPipelineBase
     let mutable activeEffect: Shader voption = ValueNone
 
     let dispatchForwardPass(sceneRT: RenderTexture2D voption) =
+      // True when every submesh of the model draws opaque under the given override —
+      // gate for the single-pass fast path (the common case, keeps the per-model
+      // BeginShaderMode). ValueNone = the model's own native materials
+      // (Color.A = 255 ⟺ Opacity = 1.0 — see Material3D.fromRaylibMaterial).
+      let modelAllOpaque(model: Model, matOverride: MaterialOverride voption) =
+        match matOverride with
+        | ValueSome(MaterialOverride.All m) -> m.Opacity >= 1.0f
+        | ValueSome(MaterialOverride.PerMesh f) ->
+          let mutable ok = true
+          let mutable mi = 0
+
+          while ok && mi < model.MeshCount do
+            if (f mi).Opacity < 1.0f then
+              ok <- false
+
+            mi <- mi + 1
+
+          ok
+        | ValueNone ->
+          let mutable ok = true
+          let mutable mi = 0
+
+          while ok && mi < model.MeshCount do
+            let matIdx = NativePtr.get model.MeshMaterial mi
+            let raylibMat = NativePtr.get model.Materials matIdx
+
+            if
+              (NativePtr.get raylibMat.Maps (int MaterialMapIndex.Albedo))
+                .Color.A
+              <> 255uy
+            then
+              ok <- false
+
+            mi <- mi + 1
+
+          ok
+
+      // Mixed-opacity model: draw each submesh inline when opaque, defer when transparent.
+      let drawModelSplit
+        (
+          model: Model,
+          transform: Matrix4x4,
+          matOverride: MaterialOverride voption,
+          distSq: float32
+        ) =
+        for mi = 0 to model.MeshCount - 1 do
+          let mesh = NativePtr.get model.Meshes mi
+
+          let mat3d =
+            match matOverride with
+            | ValueNone ->
+              Material3D.fromRaylibMaterial(
+                NativePtr.get
+                  model.Materials
+                  (NativePtr.get model.MeshMaterial mi)
+              )
+            | ValueSome(MaterialOverride.All m) -> m
+            | ValueSome(MaterialOverride.PerMesh f) -> f mi
+
+          if mat3d.Opacity >= 1.0f then
+            handleDrawMesh(
+              forwardShader,
+              &variants.Forward,
+              lights,
+              maxPt,
+              maxSp,
+              pointShadowSlots,
+              spotShadowSlots,
+              currentCamera,
+              mesh,
+              transform,
+              mat3d
+            )
+          elif mat3d.Opacity > 0.0f then
+            transparentDraws.Add {
+              Mesh = mesh
+              Transform = transform
+              Bones = ValueNone
+              Material = mat3d
+              DistanceSq = distSq
+            }
+
+      // Draws the deferred transparents (sorted far-to-near) and clears the list. Must run
+      // while a camera is active (DrawMesh requires BeginMode3D) and before any EndMode3D /
+      // DrawImmediate boundary; no-op when nothing was deferred. Re-enters the per-draw
+      // handlers, so lights/material caches and shader begin/end stay consistent.
+      let flushTransparents() =
+        if transparentDraws.Count > 0 then
+          transparentDraws.Sort(transparentComparer)
+
+          for i = 0 to transparentDraws.Count - 1 do
+            let d = transparentDraws[i]
+
+            match d.Bones with
+            | ValueNone ->
+              handleDrawMesh(
+                forwardShader,
+                &variants.Forward,
+                lights,
+                maxPt,
+                maxSp,
+                pointShadowSlots,
+                spotShadowSlots,
+                currentCamera,
+                d.Mesh,
+                d.Transform,
+                d.Material
+              )
+            | ValueSome bones ->
+              handleDrawSkinnedMesh(
+                skinnedShader,
+                &variants.Skinned,
+                lights,
+                maxPt,
+                maxSp,
+                pointShadowSlots,
+                spotShadowSlots,
+                currentCamera,
+                d.Mesh,
+                d.Transform,
+                d.Material,
+                bones
+              )
+
+          transparentDraws.Clear()
+
       for i = 0 to buffer.Count - 1 do
         match buffer[i] with
         // ── Camera management (inline — simple state toggles) ──
         | Command3D.BeginCamera cam ->
           if cameraActive then
+            // Transparents sort by the camera that deferred them — flush before leaving.
+            flushTransparents()
+
             if shaderActive then
               Raylib.EndShaderMode()
               shaderActive <- false
@@ -3539,6 +3719,9 @@ type ForwardPipelineBase
 
         | Command3D.BeginCameraConfig cfg ->
           if cameraActive then
+            // Transparents sort by the camera that deferred them — flush before leaving.
+            flushTransparents()
+
             if shaderActive then
               Raylib.EndShaderMode()
               shaderActive <- false
@@ -3568,6 +3751,8 @@ type ForwardPipelineBase
 
         | Command3D.EndCamera ->
           if cameraActive then
+            flushTransparents()
+
             if shaderActive then
               Raylib.EndShaderMode()
               shaderActive <- false
@@ -3599,62 +3784,110 @@ type ForwardPipelineBase
               // Default path: inline PBR fast path (hot path — no virtual call).
               match buffer[i] with
               | Command3D.DrawMesh(mesh, transform, material) ->
-                handleDrawMesh(
-                  forwardShader,
-                  &variants.Forward,
-                  lights,
-                  maxPt,
-                  maxSp,
-                  pointShadowSlots,
-                  spotShadowSlots,
-                  currentCamera,
-                  mesh,
-                  transform,
-                  material
-                )
+                if material.Opacity >= 1.0f then
+                  handleDrawMesh(
+                    forwardShader,
+                    &variants.Forward,
+                    lights,
+                    maxPt,
+                    maxSp,
+                    pointShadowSlots,
+                    spotShadowSlots,
+                    currentCamera,
+                    mesh,
+                    transform,
+                    material
+                  )
+                elif material.Opacity > 0.0f then
+                  transparentDraws.Add {
+                    Mesh = mesh
+                    Transform = transform
+                    Bones = ValueNone
+                    Material = material
+                    DistanceSq =
+                      Vector3.DistanceSquared(
+                        currentCamera.Position,
+                        transform.Translation
+                      )
+                  }
               | Command3D.DrawModel(model, transform) ->
-                handleDrawModel(
-                  forwardShader,
-                  &variants.Forward,
-                  lights,
-                  maxPt,
-                  maxSp,
-                  pointShadowSlots,
-                  spotShadowSlots,
-                  currentCamera,
-                  model,
-                  transform,
-                  ValueNone
-                )
+                if modelAllOpaque(model, ValueNone) then
+                  handleDrawModel(
+                    forwardShader,
+                    &variants.Forward,
+                    lights,
+                    maxPt,
+                    maxSp,
+                    pointShadowSlots,
+                    spotShadowSlots,
+                    currentCamera,
+                    model,
+                    transform,
+                    ValueNone
+                  )
+                else
+                  drawModelSplit(
+                    model,
+                    transform,
+                    ValueNone,
+                    Vector3.DistanceSquared(
+                      currentCamera.Position,
+                      transform.Translation
+                    )
+                  )
               | Command3D.DrawModelWith(model, transform, matOverride) ->
-                handleDrawModel(
-                  forwardShader,
-                  &variants.Forward,
-                  lights,
-                  maxPt,
-                  maxSp,
-                  pointShadowSlots,
-                  spotShadowSlots,
-                  currentCamera,
-                  model,
-                  transform,
-                  ValueSome matOverride
-                )
+                if modelAllOpaque(model, ValueSome matOverride) then
+                  handleDrawModel(
+                    forwardShader,
+                    &variants.Forward,
+                    lights,
+                    maxPt,
+                    maxSp,
+                    pointShadowSlots,
+                    spotShadowSlots,
+                    currentCamera,
+                    model,
+                    transform,
+                    ValueSome matOverride
+                  )
+                else
+                  drawModelSplit(
+                    model,
+                    transform,
+                    ValueSome matOverride,
+                    Vector3.DistanceSquared(
+                      currentCamera.Position,
+                      transform.Translation
+                    )
+                  )
               | Command3D.DrawSkinnedMesh(mesh, transform, material, bones) ->
-                handleDrawSkinnedMesh(
-                  skinnedShader,
-                  &variants.Skinned,
-                  lights,
-                  maxPt,
-                  maxSp,
-                  pointShadowSlots,
-                  spotShadowSlots,
-                  currentCamera,
-                  mesh,
-                  transform,
-                  material,
-                  bones
-                )
+                if material.Opacity >= 1.0f then
+                  handleDrawSkinnedMesh(
+                    skinnedShader,
+                    &variants.Skinned,
+                    lights,
+                    maxPt,
+                    maxSp,
+                    pointShadowSlots,
+                    spotShadowSlots,
+                    currentCamera,
+                    mesh,
+                    transform,
+                    material,
+                    bones
+                  )
+                elif material.Opacity > 0.0f then
+                  transparentDraws.Add {
+                    Mesh = mesh
+                    Transform = transform
+                    Bones = ValueSome bones
+                    Material = material
+                    DistanceSq =
+                      Vector3.DistanceSquared(
+                        currentCamera.Position,
+                        transform.Translation
+                      )
+                  }
               | Command3D.DrawMeshInstanced(mesh,
                                             transforms,
                                             material,
@@ -3734,6 +3967,10 @@ type ForwardPipelineBase
           let view = Rlgl.GetMatrixModelview()
           let projection = Rlgl.GetMatrixProjection()
 
+          // Transparents emitted before the immediate block draw before it (they were
+          // deferred earlier in the buffer).
+          flushTransparents()
+
           if shaderActive then
             Raylib.EndShaderMode()
             shaderActive <- false
@@ -3771,7 +4008,10 @@ type ForwardPipelineBase
         | Command3D.PostProcess _
         | Command3D.PostProcessWithDepth _ -> ()
 
-      // End remaining shader/camera state after dispatch
+      // End remaining shader/camera state after dispatch — transparents flush first
+      // (they need the camera scope open).
+      flushTransparents()
+
       if shaderActive then
         Raylib.EndShaderMode()
 

--- a/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
+++ b/src/Mibo.Raylib/Graphics3D/Pipelines/ForwardPbrPipeline.fs
@@ -573,7 +573,9 @@ module internal ShadowPassHelpers =
   /// has <c>0 &lt; Opacity &lt; 1</c>. Transparents are not drawn inline — they are collected,
   /// sorted far-to-near by camera distance, and flushed after all opaque geometry. The PBR
   /// fragment already outputs alpha and the default ALPHA blend is always active, so the
-  /// flush is a draw-order change only (no blend/depth-state switch needed).
+  /// flush needs no blend-state switch; it only toggles depth writes off for the duration
+  /// of the pass (see <c>flushTransparents</c>) so transparents don't occlude the geometry
+  /// behind them in the depth buffer.
   [<Struct>]
   type TransparentMeshDraw = {
     Mesh: Mesh
@@ -619,7 +621,8 @@ module internal ShadowPassHelpers =
     /// skipped (they don't cast); materials with <c>Opacity &lt; 1.0</c> are also skipped —
     /// transparent geometry doesn't cast shadows (the depth pass is binary, no alpha test,
     /// so a blended object must not write shadow depth). Instanced draws are collected
-    /// whole regardless (their commands carry no material on this backend).</summary>
+    /// whole regardless: their commands carry a material, but it is not consulted here
+    /// (per-part material resolution for instanced draws is a v1 limitation).</summary>
     member _.Add(cmd: Command3D) =
       match cmd with
       | Command3D.DisableShadows -> shadowsEnabled <- false
@@ -2624,9 +2627,9 @@ type ForwardPipelineBase
 
   // Deferred transparent draws for the forward pass (materials with 0 < Opacity < 1):
   // collected inline, sorted far-to-near by camera distance at flush points (camera
-  // boundaries, DrawImmediate, end of frame), then drawn after all opaque geometry.
-  // The PBR fragment already outputs alpha and the default ALPHA blend is always
-  // active, so the flush is a draw-order change only. Grow-only, reused across frames.
+  // boundaries, DrawImmediate, end of frame), then drawn after all opaque geometry with
+  // depth writes off. The PBR fragment already outputs alpha and the default ALPHA blend
+  // is always active, so the flush toggles only the depth mask. Grow-only, reused across frames.
   let transparentDraws = ResizeArray<TransparentMeshDraw>()
 
   // Cached far-to-near comparer for the transparent sort — one object for the pipeline
@@ -3647,6 +3650,13 @@ type ForwardPipelineBase
         if transparentDraws.Count > 0 then
           transparentDraws.Sort(transparentComparer)
 
+          // Standard transparency: depth test stays on (a closer opaque surface can still
+          // hide a transparent one), but depth writes go off so a transparent surface
+          // doesn't occlude the geometry behind it in the depth buffer. This keeps the
+          // depth texture exposed to PostProcessWithDepth effects opaque-only on both
+          // backends (MonoGame uses DepthStencilState.DepthRead for the same reason).
+          Rlgl.DisableDepthMask()
+
           for i = 0 to transparentDraws.Count - 1 do
             let d = transparentDraws[i]
 
@@ -3681,6 +3691,7 @@ type ForwardPipelineBase
                 bones
               )
 
+          Rlgl.EnableDepthMask()
           transparentDraws.Clear()
 
       for i = 0 to buffer.Count - 1 do


### PR DESCRIPTION
## Summary

Per-material transparency for the 3D pipelines on both backends. A material with `0 < Opacity < 1` now renders alpha-blended after all opaque geometry, sorted far-to-near by camera distance; `Opacity <= 0` renders nothing.

## Behavior

- `Opacity >= 1.0` — opaque: immediate draw, writes depth, casts shadows (existing fast paths unchanged).
- `0 < Opacity < 1.0` — transparent: deferred to a far-to-near sorted pass drawn after all opaque geometry, alpha-blended.
  - **Raylib:** draw-order only — the default ALPHA blend state is already active and the PBR fragment already outputs `texColor.a * opacity`.
  - **MonoGame:** the flush switches to `BlendState.AlphaBlend` + `DepthStencilState.DepthRead`, then restores the previous device state.
- `Opacity <= 0.0` — not drawn, no shadow.

**Behavioral change:** transparent geometry no longer casts shadows on either backend — the depth pass is binary (no alpha test), so a transparent caster would occlude at full strength. MonoGame also excludes transparents from the scene-depth pre-pass (it shares the shadow collection). Models/effects whose albedo/effect alpha is below 1 (e.g. a raylib albedo `Color.A` < 255) now render transparent instead of opaque casters.

## Scope / limitations (v1)

- Deferral covers `mesh`, `model`, `modelWith`/`modelWithPerMesh`, `animatedModel`, `animatedModelWith`/`animatedModelWithPerMesh`, and `primitive` draws.
- Instanced draws and `beginEffect`/`endEffect`-scoped draws are unchanged in this version: immediate, previous shadow behavior, and on MonoGame the frame's opaque blend state — use fully opaque materials with them.
- `EnableShadows`/`DisableShadows` scopes do not override the transparency no-cast rule.

## Implementation notes

- Allocation-free hot paths: grow-only `ResizeArray` for deferred draws, one cached `IComparer` for the in-place sort, struct draw entries, squared camera distances.
- Model fast paths preserved: fully opaque models keep the existing single-shader draw; only mixed-opacity models split per sub-mesh.
- Shadow collection mirrors the forward pass's flat part counters for `MaterialOverride.All`/`PerMesh`.
- The MonoGame flush is a local `inline` function taking the address of the enclosing mutable `state`/`scene` at each call site — no byref parameters, no closure.

## Docs & changelog

- `docs/graphics3d/materials.md`: corrected `Opacity` row; new "Transparency" section with rules and limitations.
- `CHANGELOG.md`: entry under `[Unreleased]`.

## Validation

- `dotnet fantomas .` clean.
- Full solution build: 0 errors.
- Test suites: Core 507/507, MonoGame 126/126, Raylib 484/484.
