### PR TITLE
feat: deferred work (IntentQueue) + subscriptions for adaptive programs

### DIFF
--- a/.github/workflows/opencode-review.yml
+++ b/.github/workflows/opencode-review.yml
@@ -35,3 +35,6 @@ jobs:
             - Look out for rendering affecting changes not noted in the PR
             - Look out for asymetry between backends. E.g. something added to raylib and not monogame and viceversa
             - When bug fixes are submtted for rendering concerns, make sure both backends are fixed or do not share the same bug
+
+            DO NOT MAKE ANY CHANGES LOCALLY, DO NOT CHANGE THE PR DESCRIPTION OR REACTIONS.
+            FOCUS ON THE REVIEW ONLY AND REPORT IN ASD-STE100 SIMPLIFIED TECHNICAL ENGLISH.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Removed
 
-- **Breaking (experimental): Adaptive:** the restart machinery (`AdaptiveContext.RestartRequested`, `AdaptiveHeadless.Restart()`) — a fresh world is dispose the runner and create a new one.
+- **Breaking (experimental): Adaptive:** the restart machinery (`AdaptiveContext.RestartRequested`, `AdaptiveHeadless.Restart()`) — dispose of the runner and create a new one.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@
 
 ### Added
 
+- **Adaptive (experimental):** deferred work — the adaptive counterpart of `Cmd`. `AdaptiveContext.Intents` takes `unit -> unit` work from `Update` (or any thread) and runs it at the moment the name says: `post` (after this step's `Update`, drained until empty so reaction chains settle before the frame is forced), `postNextFrame` (top of the next step), `postTask`/`postAsync` (background work; the completion returns on the owner thread where root writes are legal). `AdaptiveHeadless.Post` injects work without holding the `Update` context.
+- **Adaptive (experimental):** subscriptions — the adaptive counterpart of `Sub`. `AdaptiveProgram.withSubscriptions` takes a keyed `amap` of `AdaptiveSub` specs; the runner diffs it per step (no work when nothing moved) to attach, keep, or detach, and detaches all on `Dispose`. Callbacks receive the queue's `post` function, so events from any thread land in the drain instead of running handlers directly.
 - **Templates:** `Mibo.Templates` (the `mibo-2d`/`mibo-3d`/`mibo-mg-2d`/`mibo-mg-3d` starters) is now packed and published with each release, versioned from the repo changelog like the libraries.
+
+### Changed
+
+- **Breaking (experimental): Adaptive:** `AdaptiveProgram.Init` and the subscription projection now receive the new `AdaptiveFrameContext` (framework roots + `GameContext`, no work queue); only `Update` receives `AdaptiveContext` with `Intents` — the frame builder cannot defer work by construction.
+- **Breaking (experimental): Adaptive:** `AdaptiveHeadless.RunAsync` yields `StepOutcome<'Frame>` (`GameTime` + `Frame`) instead of `struct (GameTime * 'Frame)`.
+
+### Removed
+
+- **Breaking (experimental): Adaptive:** the restart machinery (`AdaptiveContext.RestartRequested`, `AdaptiveHeadless.Restart()`) — a fresh world is dispose the runner and create a new one.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - **Adaptive (experimental):** deferred work — the adaptive counterpart of `Cmd`. `AdaptiveContext.Intents` takes `unit -> unit` work from `Update` (or any thread) and runs it at the moment the name says: `post` (after this step's `Update`, drained until empty so reaction chains settle before the frame is forced), `postNextFrame` (top of the next step), `postTask`/`postAsync` (background work; the completion returns on the owner thread where root writes are legal). `AdaptiveHeadless.Post` injects work without holding the `Update` context.
-- **Adaptive (experimental):** subscriptions — the adaptive counterpart of `Sub`. `AdaptiveProgram.withSubscriptions` takes a keyed `amap` of `AdaptiveSub` specs; the runner diffs it per step (no work when nothing moved) to attach, keep, or detach, and detaches all on `Dispose`. Callbacks receive the queue's `post` function, so events from any thread land in the drain instead of running handlers directly.
+- **Adaptive (experimental):** subscriptions — the adaptive counterpart of `Sub`. `AdaptiveInit.withSubscriptions` takes a keyed `amap` of `AdaptiveSub` specs (dynamic, state-driven subscription sets can use `AMap.custom`); the runner diffs it per step — gated on the map's version, so clean steps do no diff work — to attach, keep, or detach, and detaches everything on `Dispose`. Callbacks receive the queue's pre-step `post`: events drain at the frame boundary before `Update`, so input published right before a `Step` reaches the sim in that same step.
 - **Templates:** `Mibo.Templates` (the `mibo-2d`/`mibo-3d`/`mibo-mg-2d`/`mibo-mg-3d` starters) is now packed and published with each release, versioned from the repo changelog like the libraries.
 
 ### Changed

--- a/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
+++ b/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
@@ -74,31 +74,6 @@ let mkTimeProgram() =
       AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue totalSeconds))
     (fun _ctx _gameTime -> ())
 
-/// Steps the runner (16ms per step) until <c>predicate</c> holds or
-/// <c>maxSteps</c> steps have run; returns the number of steps taken.
-/// Bounded poll for async completions that land at later step boundaries.
-/// Yields briefly between steps: the completion being polled for arrives via
-/// the thread pool, and a tight loop on the polling thread would starve it.
-let pollSteps
-  (runner: AdaptiveHeadless<'Frame>)
-  (predicate: unit -> bool)
-  (maxSteps: int)
-  =
-  let mutable steps = 0
-
-  // Wall-clock bound in addition to the step budget: the completion under
-  // test requires a thread-pool hop (Async.Start), and on constrained runners
-  // the pool can take hundreds of ms to run a trivial work item. The step
-  // budget alone (~1-2 ms/step) is then marginal and the tests flake.
-  let sw = System.Diagnostics.Stopwatch.StartNew()
-
-  while (steps < maxSteps && not(predicate()) && sw.Elapsed.TotalSeconds < 10.0) do
-    runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
-    steps <- steps + 1
-    Thread.Sleep 1
-
-  steps
-
 /// A RunAsync program that starts a background task on the first step; the
 /// completion writes a world-owned root. The root handle is published once
 /// Init has run.
@@ -555,11 +530,12 @@ let adaptiveHeadlessTests =
         let results = ResizeArray<struct (float32 * float)>()
         let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
         let enumerator = enum.GetAsyncEnumerator(cts.Token)
+        let sw = System.Diagnostics.Stopwatch.StartNew()
 
         try
           let mutable running = true
 
-          while running do
+          while running && sw.Elapsed < TimeSpan.FromSeconds 10 do
             try
               let! hasNext = enumerator.MoveNextAsync().AsTask()
 
@@ -575,20 +551,21 @@ let adaptiveHeadlessTests =
                 // the next step boundary on the game thread.
                 if results.Count = 1 then
                   getRoot().Post(2.0f)
+
+                // Stop once the posted value shows up in a frame.
+                if outcome.Frame = 2.0f then
+                  running <- false
               else
                 running <- false
             with :? OperationCanceledException ->
               running <- false
-
-            if results.Count >= 4 then
-              cts.Cancel()
         finally
           enumerator.DisposeAsync().AsTask().Wait()
 
         Expect.isGreaterThanOrEqual
           results.Count
-          4
-          "Should yield at least 4 frames"
+          2
+          "Should yield at least 2 frames"
 
         let struct (first, _) = results[0]
         Expect.equal first 0.0f "First frame should carry the initial value"
@@ -1048,18 +1025,20 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
         1
         "The force should see the settled map (one entry left)"
 
-    testCase "postTask completion re-enters as posted work at a later step"
+    testCase "postTask completion reaches a later frame through RunAsync"
     <| fun _ ->
-      let result = CVal.create 0
-      let mutable onDoneRan = false
-      let mutable onDoneThreadId = 0
+      let mutable root = Unchecked.defaultof<cval<int>>
       let mutable started = false
+      let mutable onDoneThreadId = 0
       let testThreadId = Environment.CurrentManagedThreadId
 
       let program =
         AdaptiveProgram.mkProgram
           (fun _ctx ->
-            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue result))
+            let value = CVal.create 0
+            root <- value
+
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
           (fun ctx _gameTime ->
             if not started then
               started <- true
@@ -1067,40 +1046,50 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
               ctx.Intents.postTask(
                 (fun () -> Task.FromResult(42)),
                 (fun v ->
-                  onDoneRan <- true
                   onDoneThreadId <- Environment.CurrentManagedThreadId
-                  result.Set v),
+                  root.Set v),
                 (fun _ -> ())
               ))
 
       use runner = new AdaptiveHeadless<int>(program)
+      use cts = new CancellationTokenSource()
 
-      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      task {
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let mutable seen = 0
+        let mutable running = true
 
-      Expect.isFalse
-        onDoneRan
-        "The completion must not run in the starting step"
+        try
+          while running && sw.Elapsed < TimeSpan.FromSeconds 10 do
+            let! hasNext = enumerator.MoveNextAsync().AsTask()
 
-      let steps = pollSteps runner (fun () -> onDoneRan) 1000
+            if hasNext then
+              let frame = enumerator.Current.Frame
 
-      Expect.isLessThan
-        steps
-        1000
-        "The completion should arrive within the poll budget"
+              if frame = 42 then
+                seen <- frame
+                running <- false
+            else
+              running <- false
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
 
-      Expect.isTrue onDoneRan "The completion should have run"
+        Expect.equal
+          seen
+          42
+          "The completion's root write should reach a later frame"
 
-      Expect.equal
-        onDoneThreadId
-        testThreadId
-        "The completion must run on the owner thread"
+        Expect.notEqual
+          onDoneThreadId
+          testThreadId
+          "The completion should run on the game thread, not the test thread"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
 
-      Expect.equal
-        runner.Frame
-        42
-        "The completion's root write should reach a later frame"
-
-    testCase "postTask error path delivers the exception as posted work"
+    testCase "postTask error path delivers the exception through RunAsync"
     <| fun _ ->
       let mutable onErrorRan = false
       let mutable onDoneRan = false
@@ -1123,25 +1112,40 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
               ))
 
       use runner = new AdaptiveHeadless<float32>(program)
-      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      use cts = new CancellationTokenSource()
 
-      let steps = pollSteps runner (fun () -> onErrorRan) 1000
+      task {
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+        let sw = System.Diagnostics.Stopwatch.StartNew()
+        let mutable running = true
 
-      Expect.isLessThan
-        steps
-        1000
-        "The error should arrive within the poll budget"
+        try
+          while running && sw.Elapsed < TimeSpan.FromSeconds 10 do
+            let! hasNext = enumerator.MoveNextAsync().AsTask()
 
-      Expect.isTrue onErrorRan "The error handler should have run"
+            if hasNext then
+              // Keep consuming outcomes until the error handler runs or the
+              // wall-clock deadline passes.
+              running <- not onErrorRan
+            else
+              running <- false
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
 
-      // AwaitTask surfaces a faulted task's AggregateException, so assert the
-      // inner message rather than the exact wrapper text.
-      Expect.stringContains
-        receivedMessage
-        "boom"
-        "The error handler should receive the exception"
+        Expect.isTrue onErrorRan "The error handler should have run"
 
-      Expect.isFalse onDoneRan "The done handler must not run on failure"
+        // AwaitTask surfaces a faulted task's AggregateException, so assert the
+        // inner message rather than the exact wrapper text.
+        Expect.stringContains
+          receivedMessage
+          "boom"
+          "The error handler should receive the exception"
+
+        Expect.isFalse onDoneRan "The done handler must not run on failure"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
 
     testCase
       "RunAsync yields outcomes; postTask completions re-enter via the intent queue"
@@ -1263,9 +1267,10 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       let program =
         AdaptiveProgram.mkProgram
-          (fun _ctx -> AdaptiveInit.ofFrameBuilder(fun () -> 0.0f))
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> 0.0f)
+            |> AdaptiveInit.withSubscriptions(fun _ctx -> subMap))
           (fun _ctx _gameTime -> ())
-        |> AdaptiveProgram.withSubscriptions(fun _ctx -> subMap)
 
       use runner = new AdaptiveHeadless<float32>(program)
       runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
@@ -1300,9 +1305,11 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       Expect.equal attaches 2 "A returning key should attach again"
 
-    testCase "Subscription events post work handled at the next post drain"
+    testCase
+      "Subscription events post work handled at the next boundary, before Update"
     <| fun _ ->
       let value = CVal.create 0
+      let trace = ResizeArray<string>()
       let mutable capturedPost = Unchecked.defaultof<(unit -> unit) -> unit>
       let mutable postThreadId = 0
       let testThreadId = Environment.CurrentManagedThreadId
@@ -1327,26 +1334,33 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
       let program =
         AdaptiveProgram.mkProgram
           (fun _ctx ->
-            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
-          (fun _ctx _gameTime -> ())
-        |> AdaptiveProgram.withSubscriptions(fun _ctx -> subMap)
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value)
+            |> AdaptiveInit.withSubscriptions(fun _ctx -> subMap))
+          (fun _ctx _gameTime -> trace.Add "update")
 
       use runner = new AdaptiveHeadless<int>(program)
       runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      trace.Clear()
 
-      // A subscription event: the captured callback posts work for the post
-      // drain of the next step.
+      // A subscription event: the captured callback posts work for the
+      // pre-step drain of the next step.
       capturedPost(fun () ->
         postThreadId <- Environment.CurrentManagedThreadId
+        trace.Add "event"
         value.Set 5)
 
       Expect.equal runner.Frame 0 "The event must not run synchronously"
       runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
 
       Expect.equal
+        (List.ofSeq trace)
+        [ "event"; "update" ]
+        "The event should be handled before Update"
+
+      Expect.equal
         runner.Frame
         5
-        "The posted event should apply at the next post drain"
+        "The posted event should apply before the step's force"
 
       Expect.equal
         postThreadId
@@ -1377,9 +1391,10 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       let program =
         AdaptiveProgram.mkProgram
-          (fun _ctx -> AdaptiveInit.ofFrameBuilder(fun () -> 0.0f))
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> 0.0f)
+            |> AdaptiveInit.withSubscriptions(fun _ctx -> subMap))
           (fun _ctx _gameTime -> ())
-        |> AdaptiveProgram.withSubscriptions(fun _ctx -> subMap)
 
       do
         use runner = new AdaptiveHeadless<float32>(program)

--- a/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
+++ b/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
@@ -2,6 +2,7 @@ module Mibo.Adaptive.Tests.AdaptiveHeadless
 
 open System
 open System.Threading
+open System.Threading.Tasks
 open Expecto
 open Mibo.Adaptive
 open Mibo.Elmish
@@ -72,6 +73,51 @@ let mkTimeProgram() =
 
       AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue totalSeconds))
     (fun _ctx _gameTime -> ())
+
+/// Steps the runner (16ms per step) until <c>predicate</c> holds or
+/// <c>maxSteps</c> steps have run; returns the number of steps taken.
+/// Bounded poll for async completions that land at later step boundaries.
+/// Yields briefly between steps: the completion being polled for arrives via
+/// the thread pool, and a tight loop on the polling thread would starve it.
+let pollSteps
+  (runner: AdaptiveHeadless<'Frame>)
+  (predicate: unit -> bool)
+  (maxSteps: int)
+  =
+  let mutable steps = 0
+
+  while steps < maxSteps && not(predicate()) do
+    runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+    steps <- steps + 1
+    Thread.Sleep 1
+
+  steps
+
+/// A RunAsync program that starts a background task on the first step; the
+/// completion writes a world-owned root. The root handle is published once
+/// Init has run.
+let mkRunAsyncWorkProgram() =
+  let mutable root = Unchecked.defaultof<cval<int>>
+  let mutable started = false
+
+  let program =
+    AdaptiveProgram.mkProgram
+      (fun _ctx ->
+        let value = CVal.create 0
+        root <- value
+
+        AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
+      (fun ctx _gameTime ->
+        if not started then
+          started <- true
+
+          ctx.Intents.postTask(
+            (fun () -> Task.FromResult(99)),
+            (fun v -> root.Set v),
+            (fun _ -> ())
+          ))
+
+  struct (program, (fun () -> root))
 
 [<Tests>]
 let adaptiveHeadlessTests =
@@ -381,30 +427,6 @@ let adaptiveHeadlessTests =
 
       Expect.isTrue disposed "Init disposables should be disposed"
 
-    testCase "Init disposables are disposed and re-created on restart"
-    <| fun _ ->
-      let mutable disposedCount = 0
-
-      let program =
-        AdaptiveProgram.mkProgram
-          (fun ctx ->
-            AdaptiveInit.ofFrameBuilder(fun () -> 0.0f)
-            |> AdaptiveInit.withDisposable
-              { new IDisposable with
-                  member _.Dispose() = disposedCount <- disposedCount + 1
-              })
-          (fun _ctx _gameTime -> ())
-
-      use runner = new AdaptiveHeadless<float32>(program)
-      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
-      runner.Restart()
-      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
-
-      Expect.equal
-        disposedCount
-        1
-        "Restart should dispose the first init's disposable"
-
     testCase "StepN advances N frames and returns the last frame"
     <| fun _ ->
       let counter = CVal.create 0
@@ -536,8 +558,11 @@ let adaptiveHeadlessTests =
               let! hasNext = enumerator.MoveNextAsync().AsTask()
 
               if hasNext then
-                let struct (gt, frame) = enumerator.Current
-                results.Add(struct (frame, gt.TotalTime.TotalSeconds))
+                let outcome = enumerator.Current
+
+                results.Add(
+                  struct (outcome.Frame, outcome.GameTime.TotalTime.TotalSeconds)
+                )
 
                 // Init has run by the first frame, so the root handle is
                 // published; cross-thread writes go through Post and land at
@@ -768,4 +793,597 @@ let adaptiveHeadlessTests =
           }
           |> ignore)
         "StepSeconds <= 0 should throw"
+  ]
+
+[<Tests>]
+let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
+  testList "AdaptiveHeadless deferred work and subscriptions" [
+    testCase
+      "Posted intent runs in the same step, after Update and before the force"
+    <| fun _ ->
+      let value = CVal.create 0
+      let mutable seenInUpdate = -1
+      let trace = ResizeArray<string>()
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
+          (fun _ctx _gameTime ->
+            trace.Add "update"
+            seenInUpdate <- AVal.getValue value)
+
+      use runner = new AdaptiveHeadless<int>(program)
+
+      // Warm up so the owner thread (and the intent queue) exist before posting.
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      trace.Clear()
+
+      runner.Post(fun () ->
+        trace.Add "post"
+        value.Set 42)
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        (List.ofSeq trace)
+        [ "update"; "post" ]
+        "Posted intent should drain after Update, in the same step"
+
+      Expect.equal
+        seenInUpdate
+        0
+        "Update should not yet see the intent of its own step"
+
+      Expect.equal runner.Frame 42 "The force should see the intent.s write"
+
+    testCase
+      "Intent posted during Update runs in the same step, before the force"
+    <| fun _ ->
+      let value = CVal.create 0
+      let trace = ResizeArray<string>()
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
+          (fun ctx _gameTime ->
+            trace.Add "update"
+
+            if trace.Count = 1 then
+              ctx.Intents.post(fun () ->
+                trace.Add "post"
+                value.Set 7))
+
+      use runner = new AdaptiveHeadless<int>(program)
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        (List.ofSeq trace)
+        [ "update"; "post" ]
+        "An Update-posted intent should drain in the same step, after Update"
+
+      Expect.equal
+        runner.Frame
+        7
+        "The posted intent.s write should reach the force"
+
+    testCase
+      "Intent posted from a foreign thread lands at the next post drain, in post order"
+    <| fun _ ->
+      let trace = ResizeArray<int>()
+      // -1 marks the Update phase, so the post drain is observable.
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx -> AdaptiveInit.ofFrameBuilder(fun () -> 0.0f))
+          (fun _ctx _gameTime -> trace.Add -1)
+
+      use runner = new AdaptiveHeadless<float32>(program)
+      // Warm up so the owner thread (and the intent queue) exist before the
+      // foreign thread posts. The warm-up step's Update already wrote to the
+      // trace; reset it so the emptiness assertion below only sees the posts.
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      trace.Clear()
+
+      use doneSignal = new ManualResetEventSlim(false)
+
+      let thread =
+        Thread(fun () ->
+          runner.Post(fun () -> trace.Add 1)
+          runner.Post(fun () -> trace.Add 2)
+          runner.Post(fun () -> trace.Add 3)
+          doneSignal.Set())
+
+      thread.IsBackground <- true
+      thread.Start()
+      doneSignal.Wait()
+      thread.Join()
+
+      Expect.isEmpty
+        trace
+        "Foreign-thread intents must not run on the posting thread"
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        (List.ofSeq trace)
+        [ -1; 1; 2; 3 ]
+        "Foreign-thread intents should drain in post order, at the post drain"
+
+    testCase "A posted chain drains until empty within one step, in post order"
+    <| fun _ ->
+      let value = CVal.create 0
+      let trace = ResizeArray<string>()
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
+          (fun ctx _gameTime ->
+            trace.Add "update"
+
+            if trace.Count = 1 then
+              // A posts B, B posts C: the post drain runs until empty, so
+              // the whole chain settles within this step, before the force.
+              ctx.Intents.post(fun () ->
+                trace.Add "a"
+                value.Set 1
+
+                ctx.Intents.post(fun () ->
+                  trace.Add "b"
+                  value.Set 2
+
+                  ctx.Intents.post(fun () ->
+                    trace.Add "c"
+                    value.Set 3))))
+
+      use runner = new AdaptiveHeadless<int>(program)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        (List.ofSeq trace)
+        [ "update"; "a"; "b"; "c" ]
+        "The chain should drain in one step, in post order"
+
+      Expect.equal runner.Frame 3 "The force should see the chain's final write"
+
+    testCase "NextStep runs at the next step's boundary, not this step"
+    <| fun _ ->
+      let value = CVal.create 0
+      let trace = ResizeArray<string>()
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
+          (fun ctx _gameTime ->
+            trace.Add "update"
+
+            if trace.Count = 1 then
+              ctx.Intents.postNextFrame(fun () ->
+                trace.Add "next-step"
+                value.Set 9))
+
+      use runner = new AdaptiveHeadless<int>(program)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        (List.ofSeq trace)
+        [ "update" ]
+        "A next-step deferral must not run in the posting step"
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        (List.ofSeq trace)
+        [ "update"; "next-step"; "update" ]
+        "A next-step deferral runs at the next boundary, before Update"
+
+      Expect.equal runner.Frame 9 "The deferral's write should reach the force"
+
+    testCase
+      "A posted intent.s write is visible in the same step.s forced frame"
+    <| fun _ ->
+      // The dead-enemy case: Update posts the removal; the post drain
+      // applies it before the Force, so the frame never renders the
+      // half-settled state (a dead enemy drawn standing for one frame).
+      let alive = CVal.create true
+      let mutable posted = false
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue alive))
+          (fun ctx _gameTime ->
+            if not posted && AVal.getValue alive then
+              posted <- true
+              ctx.Intents.post(fun () -> alive.Set false))
+
+      use runner = new AdaptiveHeadless<bool>(program)
+      let frame = runner.Step(TimeSpan.FromMilliseconds(16))
+
+      Expect.isTrue posted "The intent should have been posted"
+      Expect.isFalse frame "The force must see the posted intent.s write"
+
+    testCase
+      "Posted chain removing from a cmap under a live projection does not throw"
+    <| fun _ ->
+      let entities = CMap.ofSeq [ 1, "a"; 2, "b"; 3, "c" ]
+
+      // A live projection over the map, forced by the frame builder every step.
+      let names = entities |> AMap.map(fun _k v -> v)
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> (AMap.getValue names).Count))
+          (fun ctx _gameTime ->
+            ctx.Intents.post(fun () ->
+              // Handler 1: enumerates the collection to completion.
+              let mutable seen = ""
+
+              for KeyValue(_, v) in AMap.getValue entities do
+                seen <- seen + v
+
+              // Handler 2 (chained from handler 1): mutates the collection.
+              // The post drain runs thunks strictly sequentially, so the
+              // enumeration above finished before this removal — no
+              // mid-enumeration mutation.
+              ctx.Intents.post(fun () ->
+                CMap.remove 1 entities
+                CMap.remove 2 entities)))
+
+      use runner = new AdaptiveHeadless<int>(program)
+      let frame = runner.Step(TimeSpan.FromMilliseconds(16))
+
+      Expect.equal
+        frame
+        1
+        "The force should see the settled map (one entry left)"
+
+    testCase "postTask completion re-enters as posted work at a later step"
+    <| fun _ ->
+      let result = CVal.create 0
+      let mutable onDoneRan = false
+      let mutable onDoneThreadId = 0
+      let mutable started = false
+      let testThreadId = Environment.CurrentManagedThreadId
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue result))
+          (fun ctx _gameTime ->
+            if not started then
+              started <- true
+
+              ctx.Intents.postTask(
+                (fun () -> Task.FromResult(42)),
+                (fun v ->
+                  onDoneRan <- true
+                  onDoneThreadId <- Environment.CurrentManagedThreadId
+                  result.Set v),
+                (fun _ -> ())
+              ))
+
+      use runner = new AdaptiveHeadless<int>(program)
+
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.isFalse
+        onDoneRan
+        "The completion must not run in the starting step"
+
+      let steps = pollSteps runner (fun () -> onDoneRan) 1000
+
+      Expect.isLessThan
+        steps
+        1000
+        "The completion should arrive within the poll budget"
+
+      Expect.isTrue onDoneRan "The completion should have run"
+
+      Expect.equal
+        onDoneThreadId
+        testThreadId
+        "The completion must run on the owner thread"
+
+      Expect.equal
+        runner.Frame
+        42
+        "The completion's root write should reach a later frame"
+
+    testCase "postTask error path delivers the exception as posted work"
+    <| fun _ ->
+      let mutable onErrorRan = false
+      let mutable onDoneRan = false
+      let mutable receivedMessage = ""
+      let mutable started = false
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx -> AdaptiveInit.ofFrameBuilder(fun () -> 0.0f))
+          (fun ctx _gameTime ->
+            if not started then
+              started <- true
+
+              ctx.Intents.postTask(
+                (fun () -> Task.FromException<int>(exn "boom")),
+                (fun _ -> onDoneRan <- true),
+                (fun ex ->
+                  onErrorRan <- true
+                  receivedMessage <- ex.Message)
+              ))
+
+      use runner = new AdaptiveHeadless<float32>(program)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      let steps = pollSteps runner (fun () -> onErrorRan) 1000
+
+      Expect.isLessThan
+        steps
+        1000
+        "The error should arrive within the poll budget"
+
+      Expect.isTrue onErrorRan "The error handler should have run"
+
+      // AwaitTask surfaces a faulted task's AggregateException, so assert the
+      // inner message rather than the exact wrapper text.
+      Expect.stringContains
+        receivedMessage
+        "boom"
+        "The error handler should receive the exception"
+
+      Expect.isFalse onDoneRan "The done handler must not run on failure"
+
+    testCase
+      "RunAsync yields outcomes; postTask completions re-enter via the intent queue"
+    <| fun _ ->
+      let struct (program, _) = mkRunAsyncWorkProgram()
+      use runner = new AdaptiveHeadless<int>(program)
+      use cts = new CancellationTokenSource()
+
+      task {
+        let outcomes = ResizeArray<StepOutcome<int>>()
+        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
+        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+
+        try
+          let mutable running = true
+
+          while running do
+            try
+              let! hasNext = enumerator.MoveNextAsync().AsTask()
+
+              if hasNext then
+                outcomes.Add enumerator.Current
+
+                if outcomes.Count >= 12 then
+                  cts.Cancel()
+              else
+                running <- false
+            with :? OperationCanceledException ->
+              running <- false
+        finally
+          enumerator.DisposeAsync().AsTask().Wait()
+
+        Expect.isGreaterThanOrEqual
+          outcomes.Count
+          12
+          "Should yield at least 12 outcomes"
+
+        Expect.equal
+          outcomes[0].Frame
+          0
+          "The first outcome predates the async completion"
+
+        Expect.isTrue
+          (outcomes |> Seq.exists(fun outcome -> outcome.Frame = 99))
+          "The async completion's root write should appear in a later outcome"
+      }
+      |> Async.AwaitTask
+      |> Async.RunSynchronously
+
+    testCase "FixedStep settles after each sub-step's Update"
+    <| fun _ ->
+      let counter = CVal.create 0
+      let trace = ResizeArray<string>()
+      let mutable posted = false
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue counter))
+          (fun ctx _gameTime ->
+            trace.Add "update"
+            counter.Set(AVal.getValue counter + 1)
+
+            if not posted then
+              posted <- true
+
+              // Posted from sub-step 1: the post drain runs after each
+              // sub-step's Update, so this applies BEFORE sub-step 2's Update
+              // reads the counter.
+              ctx.Intents.post(fun () ->
+                trace.Add "post"
+                counter.Set(AVal.getValue counter * 10)))
+        |> AdaptiveProgram.withFixedStep {
+          StepSeconds = 0.01f
+          MaxStepsPerFrame = 5
+          MaxFrameSeconds = ValueNone
+        }
+
+      use runner = new AdaptiveHeadless<int>(program)
+      // One 50ms frame at a 10ms step → 5 sub-steps; the frame is forced once.
+      runner.Step(TimeSpan.FromMilliseconds 50) |> ignore
+
+      // Sub-step 1: update (0 → 1), post (1 → 10). Sub-steps 2-5: update
+      // only (10 → 14).
+      Expect.equal
+        (List.ofSeq trace)
+        [ "update"; "post"; "update"; "update"; "update"; "update" ]
+        "The post drain runs after sub-step 1's Update, before sub-step 2's"
+
+      Expect.equal runner.Frame 14 "Sub-step 2 must read the settled counter"
+
+    testCase
+      "Subscriptions attach once, survive recomputes by key, and detach when the key leaves"
+    <| fun _ ->
+      let driver = CVal.create 0
+      let mutable attaches = 0
+      let mutable disposes = 0
+
+      let sub = {
+        Id = SubId.ofString "test/sub"
+        Attach =
+          fun _post ->
+            attaches <- attaches + 1
+
+            { new IDisposable with
+                member _.Dispose() = disposes <- disposes + 1
+            }
+      }
+
+      let subMap =
+        driver
+        |> CVal.value
+        |> AVal.map(fun n ->
+          if n >= 0 then
+            Map.ofList [ SubId.ofString "test/sub", sub ] |> Map.toSeq
+          else
+            Seq.empty<SubId * AdaptiveSub>)
+        |> AMap.ofAVal
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx -> AdaptiveInit.ofFrameBuilder(fun () -> 0.0f))
+          (fun _ctx _gameTime -> ())
+        |> AdaptiveProgram.withSubscriptions(fun _ctx -> subMap)
+
+      use runner = new AdaptiveHeadless<float32>(program)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal attaches 1 "The first step should attach the subscription"
+      Expect.equal disposes 0 "Nothing should be detached yet"
+
+      // The map recomputes twice with fresh closure values; the key survives,
+      // so the runtime must keep the attachment (identity is the key).
+      runner.Post(fun () -> driver.Set 1)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      runner.Post(fun () -> driver.Set 2)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal attaches 1 "A surviving key must not re-attach on recompute"
+      Expect.equal disposes 0 "A surviving key must not be detached"
+
+      // The key leaves the map: dispose. The post lands in the post drain
+      // after this step's Update; the diff at the NEXT step's boundary sees
+      // the vanished key, so the detach needs one extra step.
+      runner.Post(fun () -> driver.Set -1)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal disposes 1 "A vanished key should be detached"
+
+      // The key returns: attach fresh (same post drain → boundary-diff lag).
+      runner.Post(fun () -> driver.Set 3)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal attaches 2 "A returning key should attach again"
+
+    testCase "Subscription events post work handled at the next post drain"
+    <| fun _ ->
+      let value = CVal.create 0
+      let mutable capturedPost = Unchecked.defaultof<(unit -> unit) -> unit>
+      let mutable postThreadId = 0
+      let testThreadId = Environment.CurrentManagedThreadId
+
+      let sub = {
+        Id = SubId.ofString "test/event"
+        Attach =
+          fun post ->
+            capturedPost <- post
+
+            { new IDisposable with
+                member _.Dispose() = ()
+            }
+      }
+
+      let subMap =
+        AVal.constant(
+          Map.ofList [ SubId.ofString "test/event", sub ] |> Map.toSeq
+        )
+        |> AMap.ofAVal
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx ->
+            AdaptiveInit.ofFrameBuilder(fun () -> AVal.getValue value))
+          (fun _ctx _gameTime -> ())
+        |> AdaptiveProgram.withSubscriptions(fun _ctx -> subMap)
+
+      use runner = new AdaptiveHeadless<int>(program)
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      // A subscription event: the captured callback posts work for the post
+      // drain of the next step.
+      capturedPost(fun () ->
+        postThreadId <- Environment.CurrentManagedThreadId
+        value.Set 5)
+
+      Expect.equal runner.Frame 0 "The event must not run synchronously"
+      runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+
+      Expect.equal
+        runner.Frame
+        5
+        "The posted event should apply at the next post drain"
+
+      Expect.equal
+        postThreadId
+        testThreadId
+        "The posted work should run on the owner thread"
+
+    testCase "Dispose detaches all subscriptions"
+    <| fun _ ->
+      let mutable attaches = 0
+      let mutable disposes = 0
+
+      let sub = {
+        Id = SubId.ofString "test/sub"
+        Attach =
+          fun _post ->
+            attaches <- attaches + 1
+
+            { new IDisposable with
+                member _.Dispose() = disposes <- disposes + 1
+            }
+      }
+
+      let subMap =
+        AVal.constant(
+          Map.ofList [ SubId.ofString "test/sub", sub ] |> Map.toSeq
+        )
+        |> AMap.ofAVal
+
+      let program =
+        AdaptiveProgram.mkProgram
+          (fun _ctx -> AdaptiveInit.ofFrameBuilder(fun () -> 0.0f))
+          (fun _ctx _gameTime -> ())
+        |> AdaptiveProgram.withSubscriptions(fun _ctx -> subMap)
+
+      do
+        use runner = new AdaptiveHeadless<float32>(program)
+        runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
+        Expect.equal attaches 1 "The first step should attach the subscription"
+
+        Expect.equal
+          disposes
+          0
+          "An attached subscription must not be disposed early"
+
+      Expect.equal disposes 1 "Dispose should detach all subscriptions"
   ]

--- a/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
+++ b/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
@@ -86,7 +86,13 @@ let pollSteps
   =
   let mutable steps = 0
 
-  while steps < maxSteps && not(predicate()) do
+  // Wall-clock bound in addition to the step budget: the completion under
+  // test requires a thread-pool hop (Async.Start), and on constrained runners
+  // the pool can take hundreds of ms to run a trivial work item. The step
+  // budget alone (~1-2 ms/step) is then marginal and the tests flake.
+  let sw = System.Diagnostics.Stopwatch.StartNew()
+
+  while (steps < maxSteps && not(predicate()) && sw.Elapsed.TotalSeconds < 10.0) do
     runner.Step(TimeSpan.FromMilliseconds(16)) |> ignore
     steps <- steps + 1
     Thread.Sleep 1
@@ -835,7 +841,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
         0
         "Update should not yet see the intent of its own step"
 
-      Expect.equal runner.Frame 42 "The force should see the intent.s write"
+      Expect.equal runner.Frame 42 "The force should see the intent's write"
 
     testCase
       "Intent posted during Update runs in the same step, before the force"
@@ -867,7 +873,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
       Expect.equal
         runner.Frame
         7
-        "The posted intent.s write should reach the force"
+        "The posted intent's write should reach the force"
 
     testCase
       "Intent posted from a foreign thread lands at the next post drain, in post order"
@@ -983,7 +989,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
       Expect.equal runner.Frame 9 "The deferral's write should reach the force"
 
     testCase
-      "A posted intent.s write is visible in the same step.s forced frame"
+      "A posted intent's write is visible in the same step's forced frame"
     <| fun _ ->
       // The dead-enemy case: Update posts the removal; the post drain
       // applies it before the Force, so the frame never renders the
@@ -1004,7 +1010,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
       let frame = runner.Step(TimeSpan.FromMilliseconds(16))
 
       Expect.isTrue posted "The intent should have been posted"
-      Expect.isFalse frame "The force must see the posted intent.s write"
+      Expect.isFalse frame "The force must see the posted intent's write"
 
     testCase
       "Posted chain removing from a cmap under a live projection does not throw"

--- a/src/Mibo.Core/Adaptive.Headless.fs
+++ b/src/Mibo.Core/Adaptive.Headless.fs
@@ -30,9 +30,10 @@ type StepOutcome<'Frame> = {
 /// <para>
 /// The runner owns the frame boundary. Each
 /// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>:
-/// (1) applies cross-thread posts and drains the next-frame lane at the
-/// frame boundary, then compares the program's subscription projection
-/// against the attached table,
+/// (1) applies cross-thread posts, drains the next-frame lane and the
+/// pre-step lane (subscription events, e.g. input) at the frame boundary,
+/// then compares the program's subscription projection against the attached
+/// table,
 /// (2) writes the current game time into the time root (once, or once per
 /// fixed step when <see cref="F:Mibo.Adaptive.AdaptiveProgram`1.FixedStep"/> is set),
 /// (3) runs the program's <c>Update</c> phase,
@@ -93,6 +94,14 @@ type AdaptiveHeadless<'Frame>
   // ResizeArray per step would cost ~96 B even on clean steps).
   let staleSubIds = ResizeArray<SubId>()
 
+  // The version of the last map the projection returned. The runner checks
+  // it every step and skips the subscription diff when it did not change —
+  // clean steps stay allocation-free even with subscriptions attached. The
+  // version increases on every applied delta. If a projection returns maps
+  // whose content changes without a version change, that projection is
+  // responsible for the staleness.
+  let mutable lastSubMapVersion = -1L
+
   let mutable fixedAccSeconds = 0.0f
 
   let mutable gameTime = {
@@ -102,6 +111,9 @@ type AdaptiveHeadless<'Frame>
 
   let mutable frame = Unchecked.defaultof<'Frame>
   let mutable frameBuilder: unit -> 'Frame = Unchecked.defaultof<unit -> 'Frame>
+
+  let mutable subscriptions: AdaptiveFrameContext -> amap<SubId, AdaptiveSub> =
+    Unchecked.defaultof<AdaptiveFrameContext -> amap<SubId, AdaptiveSub>>
   // Guards RunAsync: at most one enumerator may drive the runner at a time.
   let mutable runAsyncActive = 0
 
@@ -127,6 +139,7 @@ type AdaptiveHeadless<'Frame>
 
       let init = program.Init frameCtx
       frameBuilder <- init.FrameBuilder
+      subscriptions <- init.Subscriptions
       disposables.AddRange init.Disposables
 
       // Force the first frame so Frame is never default after initialization.
@@ -140,36 +153,33 @@ type AdaptiveHeadless<'Frame>
       initialized <- true
 
 
-  /// Diff the program's subscription projection against the attached table.
+  /// Diff the subscription projection against the attached table.
   /// Runs on the owner thread at the frame boundary, after the next-frame lane
   /// drain and before the time root write. The projection is an amap
   /// keyed by SubId: reading it is incremental — no work when no dependency
   /// moved — and the comparison decides what to attach, keep, and detach.
   let diffSubscriptions() =
-    match program.Subscriptions with
-    | ValueNone ->
-      // No projection: detach anything left over (the projection is fixed at
-      // program build, so this is a safety net rather than a live path).
-      for KeyValueV(_, d) in attachedSubs do
-        d.Dispose()
+    let map = subscriptions frameCtx
 
-      attachedSubs.Clear()
-    | ValueSome subscribe ->
-      // Reads the current map content without forcing it (AMap.getValue, not
-      // AMap.force): zero allocation on clean steps — the recompute only runs
-      // when a dependency moved. The result is used and discarded within this
-      // step, so it is always fresh.
-      let current = subscribe frameCtx |> AMap.getValue
+    if map.Version <> lastSubMapVersion then
+      lastSubMapVersion <- map.Version
 
-      // New key → attach, handing the subscription the post function:
-      // events never run handlers directly, they post work for the next
-      // post drain, on the owner thread, in order.
+      // Reads the current map content without forcing it (AMap.getValue,
+      // not AMap.force): zero allocation on clean steps — the recompute
+      // only runs when a dependency moved. The result is used and
+      // discarded within this step, so it is always fresh.
+      let current = map |> AMap.getValue
+
+      // New key → attach, handing the subscription the pre-step post
+      // function: events never run handlers directly, they post work that
+      // the runner handles on the owner thread at the next step's boundary,
+      // before Update, in order.
       for KeyValueV(id, sub) in current do
         if not(attachedSubs.ContainsKey id) then
-          attachedSubs[id] <- sub.Attach intents.post
+          attachedSubs[id] <- sub.Attach intents.postPreStep
 
-      // Missing key → detach. Surviving keys are kept as-is: the key is the
-      // identity, never re-attach on a fresh closure value.
+      // Missing key → detach. Surviving keys are kept as-is: the key is
+      // the identity, never re-attach on a fresh closure value.
       if attachedSubs.Count > 0 then
         staleSubIds.Clear()
 
@@ -244,9 +254,12 @@ type AdaptiveHeadless<'Frame>
 
       // Frame boundary: apply cross-thread
       // posts (e.g. input-thread writes), then drain the next-frame lane —
-      // explicit postNextFrame deferrals, once per Step, before the time write.
+      // explicit postNextFrame deferrals, once per Step, before the time
+      // write — and the pre-step lane, which holds subscription events
+      // (input): they are handled before Update reads state.
       Posting.pump()
       intents.DrainNextFrame()
+      intents.DrainPreStep()
 
       // Subscription lifecycle: diff the program's subscription projection
       // against the attached table.

--- a/src/Mibo.Core/Adaptive.Headless.fs
+++ b/src/Mibo.Core/Adaptive.Headless.fs
@@ -10,18 +10,38 @@ open System.Threading.Tasks
 open Mibo.Elmish
 
 /// <summary>
+/// One step's worth of simulation produced by
+/// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.RunAsync"/>: the game time
+/// and the forced frame of the step.
+/// </summary>
+[<Struct>]
+type StepOutcome<'Frame> = {
+  /// <summary>The total and per-step elapsed time of the step.</summary>
+  GameTime: GameTime
+
+  /// <summary>The forced frame of the step.</summary>
+  Frame: 'Frame
+}
+
+/// <summary>
 /// Runs an adaptive program with explicit frame stepping.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The runner owns the frame boundary. Each <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>:
-/// (1) applies cross-thread posts at the frame boundary,
+/// The runner owns the frame boundary. Each
+/// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>:
+/// (1) applies cross-thread posts and drains the next-frame buffer at the
+/// frame boundary, then diffs the program's subscription projection against
+/// the attached table,
 /// (2) writes the current game time into the time root (once, or once per
 /// fixed step when <see cref="F:Mibo.Adaptive.AdaptiveProgram`1.FixedStep"/> is set),
 /// (3) runs the program's <c>Update</c> phase,
-/// (4) forces the frame builder — the frame's projections recompute exactly
+/// (4) drains the intent queue until empty — posted work runs in post
+/// order, and thunks posted during the drain run in the same pass (after
+/// each sub-step's <c>Update</c> under fixed-step),
+/// (5) forces the frame builder — the frame's projections recompute exactly
 /// once if any of their dependencies moved, and not at all otherwise — and
-/// (5) notifies the observers with the forced frame. Draw code reads the
+/// (6) notifies the observers with the forced frame. Draw code reads the
 /// returned frame: reads are O(1) until the next write.
 /// </para>
 /// <para>
@@ -30,8 +50,10 @@ open Mibo.Elmish
 /// creates the graph lazily on the first user — the thread that first calls
 /// <c>Step</c>/<c>StepN</c>/<c>StepUntil</c>/<c>Run</c>, or the dedicated game
 /// thread of <c>RunAsync</c>. All graph work then happens on that thread.
-/// Cross-thread writes go through <c>cval.Post</c> and are drained by
-/// <c>Posting.pump</c> at the start of every step.
+/// Cross-thread writes go through <c>cval.Post</c> — drained by
+/// <c>Posting.pump</c> at the start of every step — and external work goes
+/// through <see cref="P:Mibo.Adaptive.AdaptiveContext.Intents"/> (the post
+/// lane is thread-safe, drained at the next post drain after <c>Update</c>).
 /// </para>
 /// </remarks>
 type AdaptiveHeadless<'Frame>
@@ -52,9 +74,19 @@ type AdaptiveHeadless<'Frame>
 
   let mutable gameContext = Unchecked.defaultof<GameContext>
   let mutable exitCell = Unchecked.defaultof<cval<bool>>
-  let mutable restartCell = Unchecked.defaultof<cval<bool>>
+  let mutable frameCtx = Unchecked.defaultof<AdaptiveFrameContext>
   let mutable ctx = Unchecked.defaultof<AdaptiveContext>
   let mutable initialized = false
+
+  // The framework-owned intent queue, created eagerly: external
+  // injection (Post) must be safe before the graph exists, and the queue has
+  // no thread affinity — only its drains do (owner thread, inside Step).
+  let intents = IntentQueue()
+
+  // Attached subscription disposables, keyed by SubId. The runtime diffs the
+  // program's subscription projection against this table every step: new key
+  // → attach, missing key → detach, surviving key → keep (identity is the key).
+  let attachedSubs = Dictionary<SubId, IDisposable>()
 
   let mutable fixedAccSeconds = 0.0f
 
@@ -75,20 +107,23 @@ type AdaptiveHeadless<'Frame>
       gameContext <- defaultArg context (GameContext.create(w, h))
 
       let timeCell =
-        CVal.create(
-          {
-            TotalTime = TimeSpan.Zero
-            ElapsedGameTime = TimeSpan.Zero
-          }
-        )
+        CVal.create {
+          TotalTime = TimeSpan.Zero
+          ElapsedGameTime = TimeSpan.Zero
+        }
 
       exitCell <- CVal.create false
-      restartCell <- CVal.create false
-      ctx <- AdaptiveContext(gameContext, timeCell, exitCell, restartCell)
 
-      let init = program.Init ctx
+      // Phase reachability by type: Init and the subscription projection get
+      // the queue-less frame context; only Update gets the full context with
+      // the intent queue.
+      frameCtx <- AdaptiveFrameContext(gameContext, timeCell, exitCell)
+
+      ctx <- AdaptiveContext(frameCtx, intents)
+
+      let init = program.Init frameCtx
       frameBuilder <- init.FrameBuilder
-      disposables.AddRange(init.Disposables)
+      disposables.AddRange init.Disposables
 
       // Force the first frame so Frame is never default after initialization.
       frame <- frameBuilder()
@@ -100,46 +135,54 @@ type AdaptiveHeadless<'Frame>
 
       initialized <- true
 
+
+  /// Diff the program's subscription projection against the attached table.
+  /// Runs on the owner thread at the frame boundary, after the next-frame lane
+  /// drain and before the time root write. The projection is an amap
+  /// keyed by SubId: reading it is incremental — no work when no dependency
+  /// moved — and the diff table does the real attach/detach work.
+  let diffSubscriptions() =
+    match program.Subscriptions with
+    | ValueNone ->
+      // No projection: detach anything left over (the projection is fixed at
+      // program build, so this is a safety net rather than a live path).
+      for KeyValueV(_, d) in attachedSubs do
+        d.Dispose()
+
+      attachedSubs.Clear()
+    | ValueSome subscribe ->
+      // Transient view of the current map content (AMap.getValue, not
+      // AMap.force): zero allocation on clean steps — only the incremental
+      // recompute runs when a dependency moved. Used synchronously inside
+      // this step, so the transient view's validity window is respected.
+      let current = subscribe frameCtx |> AMap.getValue
+
+      // New key → attach, handing the subscription the post function:
+      // events never run handlers directly, they post work for the next
+      // post drain, on the owner thread, in order.
+      for KeyValueV(id, sub) in current do
+        if not(attachedSubs.ContainsKey id) then
+          attachedSubs[id] <- sub.Attach intents.post
+
+      // Missing key → detach. Surviving keys are kept as-is: the key is the
+      // identity, never re-attach on a fresh closure value.
+      if attachedSubs.Count > 0 then
+        let stale = ResizeArray<SubId>()
+
+        for KeyValueV(id, _) in attachedSubs do
+          if not(current.ContainsKey id) then
+            stale.Add id
+
+        for id in stale do
+
+          attachedSubs
+          |> Dictionary.tryGetValue id
+          |> ValueOption.iter(fun d ->
+            d.Dispose()
+            attachedSubs.Remove id |> ignore)
+
   /// <summary>Whether the runner has received an exit request.</summary>
   member _.ShouldQuit = if initialized then AVal.getValue exitCell else false
-
-  /// <summary>
-  /// Whether the program has requested a rebuild (it wrote
-  /// <see cref="P:Mibo.Adaptive.AdaptiveContext.RestartRequested"/>). The
-  /// windowed hosts check this after <c>Step</c> and call
-  /// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Restart"/>.
-  /// </summary>
-  member _.RestartRequested =
-    if initialized then AVal.getValue restartCell else false
-
-  /// <summary>
-  /// Rebuild the program: disposes the program's disposables (e.g. input
-  /// subscriptions), re-runs <c>Init</c> with the same context — a fresh graph
-  /// over the same roots, which is what makes restart safe — resets the
-  /// internal clock and fixed-step accumulator, and forces the first frame. The
-  /// program requests it by writing <c>RestartRequested</c>; the windowed hosts
-  /// consume it after <c>Step</c>, headless users call this directly.
-  /// </summary>
-  member _.Restart() =
-    if initialized then
-      for i = 0 to disposables.Count - 1 do
-        disposables[i].Dispose()
-
-      disposables.Clear()
-
-      let init = program.Init ctx
-      frameBuilder <- init.FrameBuilder
-      disposables.AddRange(init.Disposables)
-
-      gameTime <- {
-        TotalTime = TimeSpan.Zero
-        ElapsedGameTime = TimeSpan.Zero
-      }
-
-      fixedAccSeconds <- 0.0f
-
-      restartCell.Set(false)
-      frame <- frameBuilder()
 
   /// <summary>Total elapsed virtual time.</summary>
   member _.GameTime = gameTime
@@ -155,10 +198,12 @@ type AdaptiveHeadless<'Frame>
   /// <para>
   /// When <see cref="F:Mibo.Adaptive.AdaptiveProgram`1.FixedStep"/> is set, the
   /// frame delta is converted into zero or more fixed-size steps: the time root
-  /// is written and <c>Update</c> runs once per step. The frame is forced once
-  /// at the end regardless, so intermediate steps are integrated but not
-  /// observed by the frame. This mirrors the MVU <c>TickFrame</c> fixed-step
-  /// loop, calling <c>Update</c> instead of dispatching a mapped message.
+  /// is written, <c>Update</c> runs, and the intent queue drains until empty
+  /// once per step. The frame is forced once at the end regardless, so
+  /// intermediate steps are integrated but not observed by the frame. This
+  /// mirrors the MVU <c>TickFrame</c> fixed-step loop, calling <c>Update</c>
+  /// instead of dispatching a mapped message. The next-frame lane drains once
+  /// per Step at the boundary — never per sub-step.
   /// </para>
   /// <para>
   /// This mutates the runner's internal state (time root, program roots, frame).
@@ -166,7 +211,25 @@ type AdaptiveHeadless<'Frame>
   /// — they all advance the simulation and using them together will produce simulation corruption.
   /// </para>
   /// </remarks>
-  member _.Step(elapsed: TimeSpan) : 'Frame =
+  member this.Step(elapsed: TimeSpan) : 'Frame =
+    let f = this.StepCore elapsed
+
+    // Observers (drain point 6): notify with the forced frame, after the step
+    // completes. Post-quit steps are no-ops (StepCore returned the cached
+    // frame early), so they do not notify.
+    if not this.ShouldQuit then
+      for i = 0 to observers.Count - 1 do
+        observers[i].OnNext(gameContext, frame, gameTime)
+
+    f
+
+  /// The shared step engine: applies posts, drains the next-frame lane, diffs
+  /// the subscription projection, writes the time root and runs <c>Update</c>
+  /// (once, or once per fixed step, each followed by the post drain), and
+  /// forces the frame. Returns the forced frame; the caller decides its
+  /// disposition — Step notifies the observers, RunAsync packages it for the
+  /// consumer.
+  member private _.StepCore(elapsed: TimeSpan) : 'Frame =
     ensureInitialized()
 
     if AVal.getValue exitCell then
@@ -177,10 +240,15 @@ type AdaptiveHeadless<'Frame>
       // comparison boxes both operands (48 bytes/call on the frame path).
       let elapsed = if elapsed.Ticks < 0L then TimeSpan.Zero else elapsed
 
-      // Apply cross-thread posts (e.g. input-thread writes) at the frame
-      // boundary, once per Step — mirrors MVU draining deferred effects at the
-      // top of TickFrame.
+      // Frame boundary (drain points 1-2 of the step table): apply cross-thread
+      // posts (e.g. input-thread writes), then drain the next-frame lane —
+      // explicit postNextFrame deferrals, once per Step, before the time write.
       Posting.pump()
+      intents.DrainNextFrame()
+
+      // Subscription lifecycle: diff the program's subscription projection
+      // against the attached table.
+      diffSubscriptions()
 
       match program.FixedStep with
       | ValueNone ->
@@ -190,10 +258,17 @@ type AdaptiveHeadless<'Frame>
         }
 
         // The time root is the framework's write into the graph.
-        ctx.Time.Set(gameTime)
+        ctx.Time.Set gameTime
 
-        // The imperative phase: reads projections, writes roots.
+        // The imperative phase: reads projections, writes roots, posts
+        // intents.
         program.Update ctx gameTime
+
+        // Post drain (drain point 4): posted work runs until empty, in post
+        // order — thunks posted during the drain (from any thread) run in the
+        // same pass. Work posted during Update reacts within THIS step, before
+        // the force; foreign-thread posts land at the next post drain.
+        intents.Drain()
 
       | ValueSome cfg ->
         let maxFrame = cfg.MaxFrameSeconds |> ValueOption.defaultValue 0.25f
@@ -217,16 +292,17 @@ type AdaptiveHeadless<'Frame>
             ElapsedGameTime = stepElapsed
           }
 
-          ctx.Time.Set(gameTime)
+          ctx.Time.Set gameTime
           program.Update ctx gameTime
 
-      // The force phase: recompute the frame's projections exactly once
-      // (not at all if none of their dependencies moved) and pack the struct.
+          // Post drain after each sub-step's Update: every sub-step reads
+          // settled state. Drained until empty.
+          intents.Drain()
+
+      // The force phase (drain point 5): recompute the frame's projections
+      // exactly once (not at all if none of their dependencies moved) and pack
+      // the struct.
       frame <- frameBuilder()
-
-      for i = 0 to observers.Count - 1 do
-        observers[i].OnNext(gameContext, frame, gameTime)
-
       frame
 
   /// <summary>Advance the simulation by N frames and return the last forced frame.</summary>
@@ -309,17 +385,38 @@ type AdaptiveHeadless<'Frame>
           Thread.Sleep 1
     }
 
+  /// <summary>
+  /// Thread-safe external injection: posts a thunk to the post lane, where it
+  /// runs on the owner thread at the next post drain — after the next step's
+  /// <c>Update</c> (after each sub-step's <c>Update</c> under fixed-step), in
+  /// post order, drained until empty, before the frame is forced. A
+  /// convenience for foreign code (tests, network callbacks, AI drivers) that
+  /// holds the runner but not the Update context: the same as
+  /// <see cref="M:Mibo.Adaptive.IntentQueue.post"/>.
+  /// </summary>
+  member _.Post(thunk: unit -> unit) = intents.post thunk
+
   /// <summary>Run the simulation asynchronously, yielding each frame as an async enumerable.</summary>
   /// <param name="interval">Tick interval.</param>
   /// <param name="ct">Optional cancellation token to stop the loop.</param>
-  /// <returns>An async sequence of <c>(GameTime * 'Frame)</c> snapshots.</returns>
+  /// <returns>An async sequence of <see cref="T:Mibo.Adaptive.StepOutcome`1"/> snapshots: the game time and the forced frame of each step.</returns>
   /// <remarks>
   /// <para>
   /// The world loop runs on a dedicated background game thread — the graph is
   /// confined to its creating thread, and async continuation threads are not it.
-  /// The async enumerable is a consumer of that thread: it receives the frames
-  /// the loop produces, in order. The <c>for .. in</c> syntax in F# 8+ can iterate
-  /// over <c>IAsyncEnumerable</c> directly.
+  /// The async enumerable is a consumer of that thread: it receives the
+  /// outcomes the loop produces, in order. The <c>for .. in</c> syntax in F# 8+
+  /// can iterate over <c>IAsyncEnumerable</c> directly:
+  /// <code>
+  /// for outcome in world.RunAsync hz30 do
+  ///   render outcome.Frame
+  /// </code>
+  /// The consumer renders the packed frame — it never touches the world's
+  /// graph. Background work started with
+  /// <see cref="M:Mibo.Adaptive.IntentQueue.postTask`1"/> / <c>postAsync</c>
+  /// runs off the world thread, and its completion posts back into the world's
+  /// intent queue (thread-safe) and runs at the next post drain on the game
+  /// thread.
   /// </para>
   /// <para>
   /// At most one enumerator may consume a runner at a time: a second
@@ -340,7 +437,7 @@ type AdaptiveHeadless<'Frame>
 
     let ct = defaultValueArg ct CancellationToken.None
 
-    { new IAsyncEnumerable<struct (GameTime * 'Frame)> with
+    { new IAsyncEnumerable<StepOutcome<'Frame>> with
         member _.GetAsyncEnumerator(cancellationToken) =
           // One consumer at a time: two enumerators would step the same runner
           // concurrently, racing on gameTime/frame and the fixed-step
@@ -356,10 +453,10 @@ type AdaptiveHeadless<'Frame>
             )
 
           // The game thread owns the graph (created on first use) and posts the
-          // frames to this queue; the async enumerator waits on the signal.
-          let frames = ConcurrentQueue<struct (GameTime * 'Frame)>()
+          // outcomes to this queue; the async enumerator waits on the signal.
+          let frames = ConcurrentQueue<StepOutcome<'Frame>>()
           let signal = new SemaphoreSlim(0)
-          let mutable current = Unchecked.defaultof<struct (GameTime * 'Frame)>
+          let mutable current = Unchecked.defaultof<StepOutcome<'Frame>>
           // Set when the game thread dies with an exception. Rethrown from
           // MoveNextAsync so the consumer sees a normal error instead of the
           // process being killed by an unhandled thread exception.
@@ -386,8 +483,16 @@ type AdaptiveHeadless<'Frame>
 
                       if elapsed >= nextTick then
                         nextTick <- nextTick + intervalMs
-                        this.Step interval |> ignore
-                        frames.Enqueue(struct (this.GameTime, this.Frame))
+                        let f = this.StepCore interval
+
+                        frames.Enqueue { GameTime = this.GameTime; Frame = f }
+
+                        // Observers (drain point 6): the forced frame of the
+                        // step, notified on the game thread. The consumer
+                        // receives the same frame through the outcome.
+                        for i = 0 to observers.Count - 1 do
+                          observers[i].OnNext(gameContext, frame, gameTime)
+
                         signal.Release() |> ignore
                       else
                         Thread.Sleep 1
@@ -403,7 +508,7 @@ type AdaptiveHeadless<'Frame>
           gameThread.IsBackground <- true
           gameThread.Start()
 
-          { new IAsyncEnumerator<struct (GameTime * 'Frame)> with
+          { new IAsyncEnumerator<StepOutcome<'Frame>> with
               member _.Current = current
 
               member _.MoveNextAsync() =
@@ -415,7 +520,7 @@ type AdaptiveHeadless<'Frame>
                       match gameThreadError with
                       | null ->
                         let mutable item =
-                          Unchecked.defaultof<struct (GameTime * 'Frame)>
+                          Unchecked.defaultof<StepOutcome<'Frame>>
 
                         if frames.TryDequeue(&item) then
                           current <- item
@@ -440,8 +545,13 @@ type AdaptiveHeadless<'Frame>
           }
     }
 
-  /// <summary>Dispose program disposables and observers, and clean up resources.</summary>
+  /// <summary>Detach all subscriptions, dispose program disposables and observers, and clean up resources.</summary>
   member _.Dispose() =
+    for KeyValueV(_, d) in attachedSubs do
+      d.Dispose()
+
+    attachedSubs.Clear()
+
     for i = 0 to disposables.Count - 1 do
       disposables[i].Dispose()
 

--- a/src/Mibo.Core/Adaptive.Headless.fs
+++ b/src/Mibo.Core/Adaptive.Headless.fs
@@ -30,14 +30,14 @@ type StepOutcome<'Frame> = {
 /// <para>
 /// The runner owns the frame boundary. Each
 /// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>:
-/// (1) applies cross-thread posts and drains the next-frame buffer at the
-/// frame boundary, then diffs the program's subscription projection against
-/// the attached table,
+/// (1) applies cross-thread posts and drains the next-frame lane at the
+/// frame boundary, then compares the program's subscription projection
+/// against the attached table,
 /// (2) writes the current game time into the time root (once, or once per
 /// fixed step when <see cref="F:Mibo.Adaptive.AdaptiveProgram`1.FixedStep"/> is set),
 /// (3) runs the program's <c>Update</c> phase,
 /// (4) drains the intent queue until empty — posted work runs in post
-/// order, and thunks posted during the drain run in the same pass (after
+/// order, and work posted during the drain runs in the same drain (after
 /// each sub-step's <c>Update</c> under fixed-step),
 /// (5) forces the frame builder — the frame's projections recompute exactly
 /// once if any of their dependencies moved, and not at all otherwise — and
@@ -45,15 +45,15 @@ type StepOutcome<'Frame> = {
 /// returned frame: reads are O(1) until the next write.
 /// </para>
 /// <para>
-/// The adaptive graph is confined to the thread that creates it (AdaptiveSlop's
-/// owner-thread model: no locks, allocation-free steady state). The runner
+/// The adaptive graph is confined to the thread that creates it: no locks,
+/// allocation-free steady state. The runner
 /// creates the graph lazily on the first user — the thread that first calls
 /// <c>Step</c>/<c>StepN</c>/<c>StepUntil</c>/<c>Run</c>, or the dedicated game
 /// thread of <c>RunAsync</c>. All graph work then happens on that thread.
 /// Cross-thread writes go through <c>cval.Post</c> — drained by
 /// <c>Posting.pump</c> at the start of every step — and external work goes
 /// through <see cref="P:Mibo.Adaptive.AdaptiveContext.Intents"/> (the post
-/// lane is thread-safe, drained at the next post drain after <c>Update</c>).
+/// lane is thread-safe; the runner drains it after <c>Update</c>).
 /// </para>
 /// </remarks>
 type AdaptiveHeadless<'Frame>
@@ -88,6 +88,11 @@ type AdaptiveHeadless<'Frame>
   // → attach, missing key → detach, surviving key → keep (identity is the key).
   let attachedSubs = Dictionary<SubId, IDisposable>()
 
+  // Reused per-step buffer for SubIds whose subscription disappeared: hoisted
+  // so steps with attached subscriptions stay allocation-free (a fresh
+  // ResizeArray per step would cost ~96 B even on clean steps).
+  let staleSubIds = ResizeArray<SubId>()
+
   let mutable fixedAccSeconds = 0.0f
 
   let mutable gameTime = {
@@ -114,9 +119,8 @@ type AdaptiveHeadless<'Frame>
 
       exitCell <- CVal.create false
 
-      // Phase reachability by type: Init and the subscription projection get
-      // the queue-less frame context; only Update gets the full context with
-      // the intent queue.
+      // Init and the subscription projection get the queue-less frame
+      // context; only Update gets the full context with the intent queue.
       frameCtx <- AdaptiveFrameContext(gameContext, timeCell, exitCell)
 
       ctx <- AdaptiveContext(frameCtx, intents)
@@ -140,7 +144,7 @@ type AdaptiveHeadless<'Frame>
   /// Runs on the owner thread at the frame boundary, after the next-frame lane
   /// drain and before the time root write. The projection is an amap
   /// keyed by SubId: reading it is incremental — no work when no dependency
-  /// moved — and the diff table does the real attach/detach work.
+  /// moved — and the comparison decides what to attach, keep, and detach.
   let diffSubscriptions() =
     match program.Subscriptions with
     | ValueNone ->
@@ -151,10 +155,10 @@ type AdaptiveHeadless<'Frame>
 
       attachedSubs.Clear()
     | ValueSome subscribe ->
-      // Transient view of the current map content (AMap.getValue, not
-      // AMap.force): zero allocation on clean steps — only the incremental
-      // recompute runs when a dependency moved. Used synchronously inside
-      // this step, so the transient view's validity window is respected.
+      // Reads the current map content without forcing it (AMap.getValue, not
+      // AMap.force): zero allocation on clean steps — the recompute only runs
+      // when a dependency moved. The result is used and discarded within this
+      // step, so it is always fresh.
       let current = subscribe frameCtx |> AMap.getValue
 
       // New key → attach, handing the subscription the post function:
@@ -167,14 +171,13 @@ type AdaptiveHeadless<'Frame>
       // Missing key → detach. Surviving keys are kept as-is: the key is the
       // identity, never re-attach on a fresh closure value.
       if attachedSubs.Count > 0 then
-        let stale = ResizeArray<SubId>()
+        staleSubIds.Clear()
 
         for KeyValueV(id, _) in attachedSubs do
           if not(current.ContainsKey id) then
-            stale.Add id
+            staleSubIds.Add id
 
-        for id in stale do
-
+        for id in staleSubIds do
           attachedSubs
           |> Dictionary.tryGetValue id
           |> ValueOption.iter(fun d ->
@@ -214,7 +217,7 @@ type AdaptiveHeadless<'Frame>
   member this.Step(elapsed: TimeSpan) : 'Frame =
     let f = this.StepCore elapsed
 
-    // Observers (drain point 6): notify with the forced frame, after the step
+    // Observers: notify with the forced frame, after the step
     // completes. Post-quit steps are no-ops (StepCore returned the cached
     // frame early), so they do not notify.
     if not this.ShouldQuit then
@@ -226,9 +229,8 @@ type AdaptiveHeadless<'Frame>
   /// The shared step engine: applies posts, drains the next-frame lane, diffs
   /// the subscription projection, writes the time root and runs <c>Update</c>
   /// (once, or once per fixed step, each followed by the post drain), and
-  /// forces the frame. Returns the forced frame; the caller decides its
-  /// disposition — Step notifies the observers, RunAsync packages it for the
-  /// consumer.
+  /// forces the frame. Returns the forced frame: Step then notifies the
+  /// observers; RunAsync packages it into the outcome for the consumer.
   member private _.StepCore(elapsed: TimeSpan) : 'Frame =
     ensureInitialized()
 
@@ -240,7 +242,7 @@ type AdaptiveHeadless<'Frame>
       // comparison boxes both operands (48 bytes/call on the frame path).
       let elapsed = if elapsed.Ticks < 0L then TimeSpan.Zero else elapsed
 
-      // Frame boundary (drain points 1-2 of the step table): apply cross-thread
+      // Frame boundary: apply cross-thread
       // posts (e.g. input-thread writes), then drain the next-frame lane —
       // explicit postNextFrame deferrals, once per Step, before the time write.
       Posting.pump()
@@ -264,10 +266,11 @@ type AdaptiveHeadless<'Frame>
         // intents.
         program.Update ctx gameTime
 
-        // Post drain (drain point 4): posted work runs until empty, in post
-        // order — thunks posted during the drain (from any thread) run in the
-        // same pass. Work posted during Update reacts within THIS step, before
-        // the force; foreign-thread posts land at the next post drain.
+        // Post drain: posted work runs until empty, in post
+        // order — work posted during the drain (from any thread) is picked up
+        // by the same drain. Work posted during Update reacts within THIS
+        // step, before the force; foreign-thread posts land at the next post
+        // drain.
         intents.Drain()
 
       | ValueSome cfg ->
@@ -299,7 +302,7 @@ type AdaptiveHeadless<'Frame>
           // settled state. Drained until empty.
           intents.Drain()
 
-      // The force phase (drain point 5): recompute the frame's projections
+      // Force phase: recompute the frame's projections
       // exactly once (not at all if none of their dependencies moved) and pack
       // the struct.
       frame <- frameBuilder()
@@ -386,7 +389,7 @@ type AdaptiveHeadless<'Frame>
     }
 
   /// <summary>
-  /// Thread-safe external injection: posts a thunk to the post lane, where it
+  /// Thread-safe external injection: posts work to the post lane, where it
   /// runs on the owner thread at the next post drain — after the next step's
   /// <c>Update</c> (after each sub-step's <c>Update</c> under fixed-step), in
   /// post order, drained until empty, before the frame is forced. A
@@ -394,7 +397,7 @@ type AdaptiveHeadless<'Frame>
   /// holds the runner but not the Update context: the same as
   /// <see cref="M:Mibo.Adaptive.IntentQueue.post"/>.
   /// </summary>
-  member _.Post(thunk: unit -> unit) = intents.post thunk
+  member _.Post(work: unit -> unit) = intents.post work
 
   /// <summary>Run the simulation asynchronously, yielding each frame as an async enumerable.</summary>
   /// <param name="interval">Tick interval.</param>
@@ -487,7 +490,7 @@ type AdaptiveHeadless<'Frame>
 
                         frames.Enqueue { GameTime = this.GameTime; Frame = f }
 
-                        // Observers (drain point 6): the forced frame of the
+                        // Observers: the forced frame of the
                         // step, notified on the game thread. The consumer
                         // receives the same frame through the outcome.
                         for i = 0 to observers.Count - 1 do

--- a/src/Mibo.Core/AdaptiveProgram.fs
+++ b/src/Mibo.Core/AdaptiveProgram.fs
@@ -1,42 +1,157 @@
 namespace Mibo.Adaptive
 
 open System
+open System.Collections.Concurrent
+open System.Threading.Tasks
 open Mibo.Elmish
 
 /// <summary>
-/// The graph-building context handed to an
-/// <see cref="T:Mibo.Adaptive.AdaptiveProgram`1"/> <c>Init</c> function.
+/// The intent queue of an adaptive program: the single place to post
+/// <c>unit -> unit</c> work during <c>Update</c>. Intents are thunks deferred
+/// to a moment the runtime owns, exposed as moment-named entry points:
+/// <see cref="M:Mibo.Adaptive.IntentQueue.post"/> (later in this step),
+/// <see cref="M:Mibo.Adaptive.IntentQueue.postNextFrame"/> (top of the next
+/// step), and <see cref="M:Mibo.Adaptive.IntentQueue.postTask"/> /
+/// <see cref="M:Mibo.Adaptive.IntentQueue.postAsync"/> (background work whose
+/// completion returns via <c>post</c>). The adaptive counterpart of <c>Cmd</c>
+/// — closures capture the handler, so no message type is needed.
 /// </summary>
 /// <remarks>
-/// The context exposes the framework-owned roots: the time cell, written by the
-/// runner at the start of every <c>Step</c>, the exit-request cell, read by the
-/// runner to decide whether to stop, and the restart-request cell, read by the
-/// host to decide whether to rebuild the program. The program reads these cells
-/// and derives its projections from them like any other root; only
-/// <c>ExitRequested</c>/<c>RestartRequested</c> are written by the program.
+/// Both lanes are MPSC: a
+/// <see cref="T:System.Collections.Concurrent.ConcurrentQueue`1"/> for
+/// producers, drained wholesale by the single consumer (the runner) on the
+/// owner thread. The post drain runs until empty — thunks posted during the
+/// drain run in the same pass, in post order, mirroring MVU's
+/// <c>DispatchMode.Immediate</c> semantics; work-posting-work cycles are the
+/// user's responsibility, exactly as message cycles are in MVU. The
+/// next-frame lane drains once per <c>Step</c> at the boundary, never per
+/// sub-step.
+/// Allocation: one queue node per posted thunk — acceptable on the cold
+/// path, zero on steps with no posted work.
 /// </remarks>
-type AdaptiveContext
-  internal
-  (
-    ctx: GameContext,
-    time: cval<GameTime>,
-    exitRequested: cval<bool>,
-    restartRequested: cval<bool>
-  ) =
-  /// <summary>The framework-owned time root. The runner writes it at the start of every <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>; projections may depend on it (animation, physics, timers).</summary>
+type IntentQueue() =
+  let posted = ConcurrentQueue<unit -> unit>()
+  let nextFrame = ConcurrentQueue<unit -> unit>()
+
+  /// <summary>
+  /// Defers <c>work</c> to the next post drain: it runs on the owner thread
+  /// after the next <c>Update</c> (after each sub-step's <c>Update</c> under
+  /// fixed-step), in post order, drained until empty, before the frame is
+  /// forced. Cross-system reactions, foreign-thread posts, and async
+  /// completions go here. Safe to call from any thread; the thunk itself must
+  /// only run owner-thread legal writes (plain <c>Set</c> calls). The
+  /// adaptive counterpart of <c>Cmd.ofMsg</c>.
+  /// </summary>
+  /// <param name="work">The work to run at the post drain.</param>
+  member _.post(work: unit -> unit) = posted.Enqueue work
+
+  /// <summary>
+  /// Defers <c>work</c> to the top of the NEXT
+  /// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>: it runs on the
+  /// owner thread at the frame boundary, after cross-thread posts are applied
+  /// (<c>Posting.pump</c>) and before the time root is written. The adaptive
+  /// counterpart of <c>Cmd.deferNextFrame</c> — the lane exists for explicit
+  /// deferrals that must not react within the posting step. Safe to call
+  /// from any thread.
+  /// </summary>
+  /// <param name="work">The work to run at the next step's boundary.</param>
+  member _.postNextFrame(work: unit -> unit) = nextFrame.Enqueue work
+
+  /// <summary>
+  /// Defers a background task to this queue: the starter runs on the owner
+  /// thread at the next post drain, <c>work</c> runs off the owner thread,
+  /// and the completion (<c>ofSuccess</c> or <c>ofError</c>) is posted to the
+  /// same lane and runs on the owner thread at a later post drain, where root
+  /// writes are legal. The runtime owns the crossing — the caller never
+  /// touches post/pump. The adaptive counterpart of <c>Cmd.ofTask</c>.
+  /// </summary>
+  /// <param name="work">The background work to start; must not touch the graph.</param>
+  /// <param name="ofSuccess">Receives the result on the owner thread at a later post drain.</param>
+  /// <param name="ofError">Receives the exception on the owner thread at a later post drain.</param>
+  member this.postTask
+    (work: unit -> Task<'T>, ofSuccess: 'T -> unit, ofError: exn -> unit)
+    =
+    this.post(fun () ->
+      async {
+        try
+          let! r = work() |> Async.AwaitTask
+          posted.Enqueue(fun () -> ofSuccess r)
+        with ex ->
+          posted.Enqueue(fun () -> ofError ex)
+      }
+      |> Async.Start)
+
+  /// <summary>
+  /// Defers an F# async workflow to this queue: the starter runs on the owner
+  /// thread at the next post drain, the workflow runs off the owner thread,
+  /// and the completion (<c>ofSuccess</c> or <c>ofError</c>) is posted to the
+  /// same lane and runs on the owner thread at a later post drain, where root
+  /// writes are legal. The adaptive counterpart of <c>Cmd.ofAsync</c>.
+  /// </summary>
+  /// <param name="work">The async workflow to start; must not touch the graph.</param>
+  /// <param name="ofSuccess">Receives the result on the owner thread at a later post drain.</param>
+  /// <param name="ofError">Receives the exception on the owner thread at a later post drain.</param>
+  member this.postAsync
+    (work: Async<'T>, ofSuccess: 'T -> unit, ofError: exn -> unit)
+    =
+    this.post(fun () ->
+      async {
+        try
+          let! r = work
+          posted.Enqueue(fun () -> ofSuccess r)
+        with ex ->
+          posted.Enqueue(fun () -> ofError ex)
+      }
+      |> Async.Start)
+
+  /// <summary>
+  /// Runs every pending posted thunk in post order on the calling (owner)
+  /// thread until the lane is empty: thunks posted during the drain (from
+  /// any thread) run in the same pass, in post order. No termination bound.
+  /// </summary>
+  member internal _.Drain() =
+    let mutable next = Unchecked.defaultof<unit -> unit>
+
+    while posted.TryDequeue(&next) do
+      next()
+
+  /// <summary>
+  /// Runs the next-frame lane on the calling (owner) thread: everything queued
+  /// at the top of the step, in post order. Thunks posted during this drain
+  /// also run in the same pass (same semantics as the post drain).
+  /// </summary>
+  member internal _.DrainNextFrame() =
+    let mutable next = Unchecked.defaultof<unit -> unit>
+
+    while nextFrame.TryDequeue(&next) do
+      next()
+
+/// <summary>
+/// The graph-building context handed to an
+/// <see cref="T:Mibo.Adaptive.AdaptiveProgram`1"/> <c>Init</c> function and to
+/// the subscription projection
+/// (<see cref="M:Mibo.Adaptive.AdaptiveProgram.withSubscriptions"/>).
+/// </summary>
+/// <remarks>
+/// The context exposes the framework-owned roots: the time cell, written by
+/// the runner at the start of every <c>Step</c> (once per fixed sub-step),
+/// the exit-request cell, read by the runner to decide whether to stop, plus
+/// the <see cref="T:Mibo.Elmish.GameContext"/> holding the window dimensions
+/// and the registered services. The program reads these cells and derives
+/// its projections from them like any other root; only <c>ExitRequested</c>
+/// is written by the program. The context deliberately does NOT expose the
+/// intent queue — phase
+/// reachability by type: the frame builder and init/projection construction
+/// must not be able to defer work. The queue is reachable only from the
+/// <c>Update</c> phase, via <see cref="T:Mibo.Adaptive.AdaptiveContext"/>.
+/// </remarks>
+type AdaptiveFrameContext
+  internal (ctx: GameContext, time: cval<GameTime>, exitRequested: cval<bool>) =
+  /// <summary>The framework-owned time root. The runner writes it at the start of every <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/> (once per fixed sub-step); projections may depend on it (animation, physics, timers).</summary>
   member _.Time = time
 
   /// <summary>The exit-request root. Set it to <c>true</c> to make the runner stop — the adaptive counterpart of <c>Cmd.signalExit</c>.</summary>
   member _.ExitRequested = exitRequested
-
-  /// <summary>
-  /// The restart-request root. Set it to <c>true</c> to rebuild the program: the
-  /// runner disposes the program's disposables, re-runs <c>Init</c> — a fresh
-  /// graph over the same roots — and forces the first frame. The windowed
-  /// hosts consume it after <c>Step</c>; headless users call
-  /// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Restart"/> themselves.
-  /// </summary>
-  member _.RestartRequested = restartRequested
 
   /// <summary>
   /// The <see cref="T:Mibo.Elmish.GameContext"/> the runner owns: the window
@@ -53,6 +168,56 @@ type AdaptiveContext
   /// <summary>Current window height in pixels. Default: 600.</summary>
   member _.WindowHeight = ctx.WindowHeight
 
+/// <summary>
+/// The <c>Update</c>-phase context: everything on
+/// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/> plus the framework-owned
+/// intent queue, <see cref="P:Mibo.Adaptive.AdaptiveContext.Intents"/> —
+/// intents are thunks of <c>unit -> unit</c> work deferred to a
+/// framework-owned moment (after <c>Update</c>, at the top of the next step,
+/// or as background work whose completion returns via <c>post</c>).
+/// </summary>
+/// <remarks>
+/// The queue is reachable only here, where posting is legal: <c>Update</c>
+/// reacts to what it read and defers work; the frame builder and projection
+/// construction see only
+/// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>, so the force phase
+/// cannot enqueue — correctness by construction, no runtime guards.
+/// </remarks>
+type AdaptiveContext
+  internal (frameCtx: AdaptiveFrameContext, intents: IntentQueue) =
+  /// <summary>The framework-owned time root. The runner writes it at the start of every <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/> (once per fixed sub-step); projections may depend on it (animation, physics, timers).</summary>
+  member _.Time = frameCtx.Time
+
+  /// <summary>The exit-request root. Set it to <c>true</c> to make the runner stop — the adaptive counterpart of <c>Cmd.signalExit</c>.</summary>
+  member _.ExitRequested = frameCtx.ExitRequested
+
+  /// <summary>
+  /// The <see cref="T:Mibo.Elmish.GameContext"/> the runner owns: the window
+  /// dimensions and the registered services (IAssets, IInput, custom). Programs
+  /// read services directly from here in <c>Init</c> and <c>Update</c> — the
+  /// host registers what it owns and the program pulls the rest; there is no
+  /// registration ceremony.
+  /// </summary>
+  member _.Context = frameCtx.Context
+
+  /// <summary>Current window width in pixels. Default: 800.</summary>
+  member _.WindowWidth = frameCtx.WindowWidth
+
+  /// <summary>Current window height in pixels. Default: 600.</summary>
+  member _.WindowHeight = frameCtx.WindowHeight
+
+  /// <summary>
+  /// The intent queue: the single place to post <c>unit -> unit</c> work
+  /// during <c>Update</c>. Choose the moment by name —
+  /// <see cref="M:Mibo.Adaptive.IntentQueue.post"/> (after this step's
+  /// <c>Update</c>, until empty), <see cref="M:Mibo.Adaptive.IntentQueue.postNextFrame"/>
+  /// (at the top of the next step), or
+  /// <see cref="M:Mibo.Adaptive.IntentQueue.postTask"/>/<c>postAsync</c>
+  /// (background work whose completion returns via <c>post</c>). The adaptive
+  /// counterpart of <c>Cmd</c>.
+  /// </summary>
+  member _.Intents = intents
+
 /// <summary>The result of building an adaptive program's graph.</summary>
 [<Struct>]
 type AdaptiveInit<'Frame> = {
@@ -63,7 +228,7 @@ type AdaptiveInit<'Frame> = {
   /// </summary>
   FrameBuilder: unit -> 'Frame
 
-  /// <summary>Disposables released when the runner is disposed or restarted.</summary>
+  /// <summary>Disposables released when the runner is disposed.</summary>
   Disposables: IDisposable list
 }
 
@@ -80,16 +245,19 @@ module AdaptiveInit =
   /// Creates an init from a frame builder with no disposables.
   /// </summary>
   /// <param name="frameBuilder">Forces the frame's output projections and packs them into <c>'Frame</c>.</param>
-  let ofFrameBuilder(frameBuilder: unit -> 'Frame) : AdaptiveInit<'Frame> = {
-    FrameBuilder = frameBuilder
-    Disposables = []
-  }
+  let inline ofFrameBuilder
+    ([<InlineIfLambda>] frameBuilder: unit -> 'Frame)
+    : AdaptiveInit<'Frame> =
+    {
+      FrameBuilder = frameBuilder
+      Disposables = []
+    }
 
   /// <summary>
   /// Appends a list of disposables to the init. The disposables are released
-  /// when the runner is disposed or when the program is restarted.
+  /// when the runner is disposed.
   /// </summary>
-  let withDisposables
+  let inline withDisposables
     (disposables: IDisposable list)
     (init: AdaptiveInit<'Frame>)
     : AdaptiveInit<'Frame> =
@@ -100,9 +268,9 @@ module AdaptiveInit =
 
   /// <summary>
   /// Adds a single disposable to the init. The disposable is released when the
-  /// runner is disposed or when the program is restarted.
+  /// runner is disposed.
   /// </summary>
-  let withDisposable
+  let inline withDisposable
     (disposable: IDisposable)
     (init: AdaptiveInit<'Frame>)
     : AdaptiveInit<'Frame> =
@@ -119,10 +287,12 @@ module AdaptiveInit =
 /// <remarks>
 /// <para>
 /// When enabled, the runner converts the variable frame time into zero or more
-/// fixed-size steps per <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>: for
-/// each step it applies cross-thread posts, writes the time root, and runs the
-/// program's <c>Update</c> phase. The frame is forced once at the end, so the
-/// intermediate steps are integrated but not observed by the frame.
+/// fixed-size steps per <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>: it
+/// applies cross-thread posts once at the boundary, then per fixed-size step
+/// writes the time root, runs the program's <c>Update</c> phase, and drains the
+/// intent queue until empty — each sub-step reads settled state. The frame is
+/// forced once at the end, so the intermediate steps are integrated but not
+/// observed by the frame.
 /// </para>
 /// <para>
 /// This mirrors the MVU <c>TickFrame</c> fixed-step loop, calling
@@ -151,23 +321,74 @@ type AdaptiveFixedStepConfig = {
 }
 
 /// <summary>
+/// A subscription spec: a stable identifier plus an attach function. The
+/// adaptive counterpart of <see cref="T:Mibo.Elmish.Sub`1"/>: the attach
+/// function receives the post function instead of
+/// <c>Dispatch&lt;'Msg&gt;</c>, so subscription events never run handlers
+/// directly — they post work, handled on the owner thread at the next post
+/// drain, in order.
+/// </summary>
+[<Struct>]
+type AdaptiveSub = {
+  /// <summary>Stable key the runtime uses to diff subscriptions across steps.</summary>
+  Id: SubId
+
+  /// <summary>
+  /// Attaches the subscription and returns a disposable that detaches it. The
+  /// <c>post</c> argument is the same-step lane's entry point
+  /// (<see cref="M:Mibo.Adaptive.IntentQueue.post"/>): event callbacks
+  /// (possibly on foreign threads) may only enqueue work for the next post
+  /// drain — confinement is preserved by construction.
+  /// </summary>
+  Attach: ((unit -> unit) -> unit) -> IDisposable
+}
+
+/// <summary>Functions for composing <see cref="T:Mibo.Adaptive.AdaptiveSub"/> values.</summary>
+module AdaptiveSub =
+
+  /// <summary>
+  /// Prefixes the subscription's <see cref="T:Mibo.Elmish.SubId"/> with a
+  /// namespace, for parent-child composition — the adaptive counterpart of
+  /// <c>Sub.map</c> without the message mapping. Delegates to
+  /// <see cref="M:Mibo.Elmish.SubId.prefix"/>.
+  /// </summary>
+  let inline prefix (prefix: string) (sub: AdaptiveSub) : AdaptiveSub = {
+    sub with
+        Id = SubId.prefix prefix sub.Id
+  }
+
+/// <summary>
 /// An adaptive program: the complete description of an adaptive game.
 /// </summary>
 /// <remarks>
 /// <para>
 /// This is the adaptive counterpart of <see cref="T:Mibo.Elmish.Program`2"/>,
-/// with the message/command/subscription machinery removed. Changeable roots
-/// hold the state, derived projections compose it, and the runner forces the
-/// frame's projections at the end of every step. There is no <c>'Msg</c>, no
-/// <c>Cmd</c> and no <c>Sub</c> — handlers write roots directly and effects run
-/// directly.
+/// with the message/command machinery removed. Changeable roots hold the state,
+/// derived projections compose it, and the runner forces the frame's
+/// projections at the end of every step. There is no <c>'Msg</c> and no
+/// <c>Cmd</c> — handlers write roots directly. Deferred work and subscriptions
+/// have adaptive counterparts: systems post <c>unit -> unit</c> work through
+/// <see cref="P:Mibo.Adaptive.AdaptiveContext.Intents"/> — post (after this
+/// step's <c>Update</c>), postNextFrame (top of the next step), or
+/// postTask/postAsync (background work whose completion returns via post) —
+/// and external events arrive through
+/// <see cref="T:Mibo.Adaptive.AdaptiveSub"/> subscriptions whose callbacks
+/// post work.
 /// </para>
 /// <para>
-/// The <c>Init</c>/<c>Update</c>/<c>Observers</c> slots are the dependency
-/// graph (the simulation). The <c>Config</c>/<c>Renderers</c>/
-/// <c>ServiceRegistrations</c>/<c>AssetsBasePath</c> slots are host
-/// configuration (the presentation) consumed by the windowed hosts. The headless
-/// runner consumes only the simulation slots plus <c>FixedStep</c>.
+/// The two contexts are split by phase: <c>Init</c> and the subscription
+/// projection receive the queue-less
+/// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/> (roots and services
+/// only), while <c>Update</c> receives the full
+/// <see cref="T:Mibo.Adaptive.AdaptiveContext"/> with the intent queue — the
+/// force phase cannot enqueue by construction.
+/// </para>
+/// <para>
+/// The <c>Init</c>/<c>Update</c>/<c>Observers</c>/<c>Subscriptions</c> slots
+/// are the dependency graph (the simulation). The <c>Config</c>/
+/// <c>Renderers</c>/<c>ServiceRegistrations</c>/<c>AssetsBasePath</c> slots are
+/// host configuration (the presentation) consumed by the windowed hosts. The
+/// headless runner consumes only the simulation slots plus <c>FixedStep</c>.
 /// </para>
 /// </remarks>
 /// <example>
@@ -187,21 +408,35 @@ type AdaptiveFixedStepConfig = {
 type AdaptiveProgram<'Frame> = {
   /// <summary>
   /// Builds the graph (roots and projections) and registers handlers.
-  /// Returns the <see cref="T:Mibo.Adaptive.AdaptiveInit`1"/> — the frame
-  /// builder plus the disposables released when the runner is disposed or
-  /// restarted.
+  /// Receives the queue-less <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>:
+  /// graph building must not reach the intent queue. Returns the
+  /// <see cref="T:Mibo.Adaptive.AdaptiveInit`1"/> — the frame builder plus the
+  /// disposables released when the runner is disposed.
   /// </summary>
-  Init: AdaptiveContext -> AdaptiveInit<'Frame>
+  Init: AdaptiveFrameContext -> AdaptiveInit<'Frame>
 
   /// <summary>
   /// Optional per-frame phase. Runs after the time root is written and before
-  /// the frame is forced. Reads projections, writes roots. Under fixed-step it
-  /// runs once per fixed step.
+  /// the frame is forced. Reads projections, writes roots, posts intents
+  /// through the full <see cref="T:Mibo.Adaptive.AdaptiveContext"/>. Under
+  /// fixed-step it runs once per fixed step, each followed by the post drain.
   /// </summary>
   Update: AdaptiveContext -> GameTime -> unit
 
   /// <summary>Observer factories for receiving the forced frame each step.</summary>
   Observers: (unit -> IObserver<struct (GameContext * 'Frame * GameTime)>) list
+
+  /// <summary>
+  /// Optional subscription projection: an <c>amap</c> keyed by
+  /// <see cref="T:Mibo.Elmish.SubId"/> over
+  /// <see cref="T:Mibo.Adaptive.AdaptiveSub"/> specs, built from the
+  /// queue-less <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>. The runner
+  /// forces it once per step — incrementally, with no work when no dependency
+  /// moved — and diffs it by key against its attached table to start, keep,
+  /// and stop subscriptions. Wired via
+  /// <see cref="M:Mibo.Adaptive.AdaptiveProgram.withSubscriptions"/>.
+  /// </summary>
+  Subscriptions: (AdaptiveFrameContext -> amap<SubId, AdaptiveSub>) voption
 
   /// <summary>
   /// Configuration callbacks that transform the default
@@ -249,7 +484,7 @@ module AdaptiveProgram =
   /// the <c>OnError</c> and <c>OnCompleted</c> boilerplate.
   /// </summary>
   let inline observe
-    (onNext: struct (GameContext * 'Frame * GameTime) -> unit)
+    ([<InlineIfLambda>] onNext: struct (GameContext * 'Frame * GameTime) -> unit)
     : IObserver<struct (GameContext * 'Frame * GameTime)> =
     { new IObserver<struct (GameContext * 'Frame * GameTime)> with
         member _.OnNext value = onNext value
@@ -268,16 +503,17 @@ module AdaptiveProgram =
   /// update function is the per-frame imperative phase that reads projections
   /// and writes roots.
   /// </remarks>
-  /// <param name="init">Builds the graph and returns the <see cref="T:Mibo.Adaptive.AdaptiveInit`1"/>.</param>
-  /// <param name="update">Per-frame phase: reads projections, writes roots.</param>
-  let mkProgram
-    (init: AdaptiveContext -> AdaptiveInit<'Frame>)
-    (update: AdaptiveContext -> GameTime -> unit)
+  /// <param name="init">Builds the graph and returns the <see cref="T:Mibo.Adaptive.AdaptiveInit`1"/>. Receives the queue-less <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/> — no deferred work.</param>
+  /// <param name="update">Per-frame phase: reads projections, writes roots, posts intents. Receives the full <see cref="T:Mibo.Adaptive.AdaptiveContext"/>.</param>
+  let inline mkProgram
+    ([<InlineIfLambda>] init: AdaptiveFrameContext -> AdaptiveInit<'Frame>)
+    ([<InlineIfLambda>] update: AdaptiveContext -> GameTime -> unit)
     : AdaptiveProgram<'Frame> =
     {
       Init = init
       Update = update
       Observers = []
+      Subscriptions = ValueNone
       Config = []
       Renderers = []
       ServiceRegistrations = []
@@ -287,8 +523,8 @@ module AdaptiveProgram =
     }
 
   /// <summary>Sets the per-frame phase of the program.</summary>
-  let withUpdate
-    (update: AdaptiveContext -> GameTime -> unit)
+  let inline withUpdate
+    ([<InlineIfLambda>] update: AdaptiveContext -> GameTime -> unit)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
     { program with Update = update }
@@ -297,8 +533,9 @@ module AdaptiveProgram =
   /// Adds an observer factory to the program. Observers receive the forced
   /// frame each step, in registration order.
   /// </summary>
-  let withObserver
-    (factory: unit -> IObserver<struct (GameContext * 'Frame * GameTime)>)
+  let inline withObserver
+    ([<InlineIfLambda>] factory:
+      unit -> IObserver<struct (GameContext * 'Frame * GameTime)>)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
     {
@@ -307,12 +544,33 @@ module AdaptiveProgram =
     }
 
   /// <summary>
+  /// Sets the program's subscription projection. The runner forces the map
+  /// once per step (incremental — no work when no dependency moved), diffs it
+  /// by <see cref="T:Mibo.Elmish.SubId"/> against its attached table, and
+  /// starts new, keeps matching, and stops vanished subscriptions. The
+  /// projection receives the queue-less
+  /// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>. The adaptive
+  /// counterpart of <see cref="M:Mibo.Elmish.Program.withSubscription"/>.
+  /// </summary>
+  /// <param name="subscribe">Builds the subscription map from the context.</param>
+  /// <param name="program">The program to configure.</param>
+  let inline withSubscriptions
+    ([<InlineIfLambda>] subscribe:
+      AdaptiveFrameContext -> amap<SubId, AdaptiveSub>)
+    (program: AdaptiveProgram<'Frame>)
+    : AdaptiveProgram<'Frame> =
+    {
+      program with
+          Subscriptions = ValueSome subscribe
+    }
+
+  /// <summary>
   /// Configure game settings (resolution, title, framerate). The callback
   /// receives the current <see cref="T:Mibo.Elmish.GameConfig"/> and returns a
   /// modified copy.
   /// </summary>
-  let withConfig
-    (configure: GameConfig -> GameConfig)
+  let inline withConfig
+    ([<InlineIfLambda>] configure: GameConfig -> GameConfig)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
     {
@@ -324,8 +582,8 @@ module AdaptiveProgram =
   /// Adds a renderer factory to the program. Renderers are called each frame to
   /// draw the forced frame, in registration order.
   /// </summary>
-  let withRenderer
-    (factory: unit -> IRenderer<'Frame>)
+  let inline withRenderer
+    ([<InlineIfLambda>] factory: unit -> IRenderer<'Frame>)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
     {
@@ -338,8 +596,8 @@ module AdaptiveProgram =
   /// after core services (assets, input) are registered but before
   /// <c>Init</c>.
   /// </summary>
-  let withServiceRegistration
-    (register: GameContext -> unit)
+  let inline withServiceRegistration
+    ([<InlineIfLambda>] register: GameContext -> unit)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
     {
@@ -350,7 +608,7 @@ module AdaptiveProgram =
   /// <summary>
   /// Configures a base path for asset loading.
   /// </summary>
-  let withAssetsBasePath
+  let inline withAssetsBasePath
     (basePath: string)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
@@ -362,10 +620,10 @@ module AdaptiveProgram =
   /// <summary>
   /// Enables a framework-managed fixed timestep. When enabled, the runner
   /// converts the variable frame time into zero or more fixed-size steps per
-  /// <c>Step</c>, running <c>Update</c> once per step and forcing the frame
-  /// once at the end.
+  /// <c>Step</c>, running <c>Update</c> once per step (each followed by the
+  /// post drain) and forcing the frame once at the end.
   /// </summary>
-  let withFixedStep
+  let inline withFixedStep
     (cfg: AdaptiveFixedStepConfig)
     (program: AdaptiveProgram<'Frame>)
     : AdaptiveProgram<'Frame> =
@@ -389,7 +647,7 @@ module AdaptiveProgram =
   /// programs that read keyboard, mouse, touch, or gamepad input. Off by
   /// default — mirrors <see cref="M:Mibo.Elmish.Program.withInput"/>.
   /// </remarks>
-  let withInput(program: AdaptiveProgram<'Frame>) : AdaptiveProgram<'Frame> = {
-    program with
-        HasInput = true
-  }
+  let inline withInput
+    (program: AdaptiveProgram<'Frame>)
+    : AdaptiveProgram<'Frame> =
+    { program with HasInput = true }

--- a/src/Mibo.Core/AdaptiveProgram.fs
+++ b/src/Mibo.Core/AdaptiveProgram.fs
@@ -7,7 +7,7 @@ open Mibo.Elmish
 
 /// <summary>
 /// The intent queue of an adaptive program: the single place to post
-/// <c>unit -> unit</c> work during <c>Update</c>. Intents are thunks deferred
+/// <c>unit -> unit</c> work during <c>Update</c>. Intents are work items deferred
 /// to a moment the runtime owns, exposed as moment-named entry points:
 /// <see cref="M:Mibo.Adaptive.IntentQueue.post"/> (later in this step),
 /// <see cref="M:Mibo.Adaptive.IntentQueue.postNextFrame"/> (top of the next
@@ -17,16 +17,16 @@ open Mibo.Elmish
 /// — closures capture the handler, so no message type is needed.
 /// </summary>
 /// <remarks>
-/// Both lanes are MPSC: a
+/// Both lanes are multi-producer, single-consumer queues: a
 /// <see cref="T:System.Collections.Concurrent.ConcurrentQueue`1"/> for
-/// producers, drained wholesale by the single consumer (the runner) on the
-/// owner thread. The post drain runs until empty — thunks posted during the
-/// drain run in the same pass, in post order, mirroring MVU's
-/// <c>DispatchMode.Immediate</c> semantics; work-posting-work cycles are the
+/// producers, drained by the single consumer (the runner) on the
+/// owner thread. The post drain runs until empty — work posted during the
+/// drain runs in the same drain, in post order, mirroring MVU's
+/// <c>DispatchMode.Immediate</c> semantics; work that posts more work is the
 /// user's responsibility, exactly as message cycles are in MVU. The
 /// next-frame lane drains once per <c>Step</c> at the boundary, never per
 /// sub-step.
-/// Allocation: one queue node per posted thunk — acceptable on the cold
+/// Allocation: one queue node per posted work item — acceptable on the cold
 /// path, zero on steps with no posted work.
 /// </remarks>
 type IntentQueue() =
@@ -38,7 +38,7 @@ type IntentQueue() =
   /// after the next <c>Update</c> (after each sub-step's <c>Update</c> under
   /// fixed-step), in post order, drained until empty, before the frame is
   /// forced. Cross-system reactions, foreign-thread posts, and async
-  /// completions go here. Safe to call from any thread; the thunk itself must
+  /// completions go here. Safe to call from any thread; the work itself must
   /// only run owner-thread legal writes (plain <c>Set</c> calls). The
   /// adaptive counterpart of <c>Cmd.ofMsg</c>.
   /// </summary>
@@ -50,20 +50,22 @@ type IntentQueue() =
   /// <see cref="M:Mibo.Adaptive.AdaptiveHeadless`1.Step"/>: it runs on the
   /// owner thread at the frame boundary, after cross-thread posts are applied
   /// (<c>Posting.pump</c>) and before the time root is written. The adaptive
-  /// counterpart of <c>Cmd.deferNextFrame</c> — the lane exists for explicit
-  /// deferrals that must not react within the posting step. Safe to call
+  /// counterpart of <c>Cmd.deferNextFrame</c> — the lane exists for work that
+  /// must not run in the step that posted it. Safe to call
   /// from any thread.
   /// </summary>
   /// <param name="work">The work to run at the next step's boundary.</param>
   member _.postNextFrame(work: unit -> unit) = nextFrame.Enqueue work
 
   /// <summary>
-  /// Defers a background task to this queue: the starter runs on the owner
-  /// thread at the next post drain, <c>work</c> runs off the owner thread,
-  /// and the completion (<c>ofSuccess</c> or <c>ofError</c>) is posted to the
-  /// same lane and runs on the owner thread at a later post drain, where root
-  /// writes are legal. The runtime owns the crossing — the caller never
-  /// touches post/pump. The adaptive counterpart of <c>Cmd.ofTask</c>.
+  /// Defers a background task to this queue: the starter runs on the
+  /// owner thread at the next post drain and hands the work to the
+  /// thread pool — <c>work</c> (the task creation call) and the task itself
+  /// run off the owner thread — and the completion (<c>ofSuccess</c> or
+  /// <c>ofError</c>) is posted to the same lane and runs on the owner thread
+  /// at a later post drain, where root writes are legal. The runtime handles
+  /// the thread handoff for you — you never post or pump directly. The
+  /// adaptive counterpart of <c>Cmd.ofTask</c>.
   /// </summary>
   /// <param name="work">The background work to start; must not touch the graph.</param>
   /// <param name="ofSuccess">Receives the result on the owner thread at a later post drain.</param>
@@ -82,11 +84,13 @@ type IntentQueue() =
       |> Async.Start)
 
   /// <summary>
-  /// Defers an F# async workflow to this queue: the starter runs on the owner
-  /// thread at the next post drain, the workflow runs off the owner thread,
-  /// and the completion (<c>ofSuccess</c> or <c>ofError</c>) is posted to the
-  /// same lane and runs on the owner thread at a later post drain, where root
-  /// writes are legal. The adaptive counterpart of <c>Cmd.ofAsync</c>.
+  /// Defers an F# async workflow to this queue: the starter runs on the
+  /// owner thread at the next post drain and starts the workflow on the
+  /// thread pool — the workflow body runs off the owner thread — and the
+  /// completion (<c>ofSuccess</c> or <c>ofError</c>) is posted to the same
+  /// lane and runs on the owner thread at a later post drain, where root
+  /// writes are legal. The runtime handles the thread handoff for you — you
+  /// never post or pump directly. The adaptive counterpart of <c>Cmd.ofAsync</c>.
   /// </summary>
   /// <param name="work">The async workflow to start; must not touch the graph.</param>
   /// <param name="ofSuccess">Receives the result on the owner thread at a later post drain.</param>
@@ -105,9 +109,9 @@ type IntentQueue() =
       |> Async.Start)
 
   /// <summary>
-  /// Runs every pending posted thunk in post order on the calling (owner)
-  /// thread until the lane is empty: thunks posted during the drain (from
-  /// any thread) run in the same pass, in post order. No termination bound.
+  /// Runs every pending work item in post order on the calling (owner)
+  /// thread until the lane is empty: work posted during the drain (from
+  /// any thread) runs in the same drain, in post order. No termination bound.
   /// </summary>
   member internal _.Drain() =
     let mutable next = Unchecked.defaultof<unit -> unit>
@@ -117,8 +121,8 @@ type IntentQueue() =
 
   /// <summary>
   /// Runs the next-frame lane on the calling (owner) thread: everything queued
-  /// at the top of the step, in post order. Thunks posted during this drain
-  /// also run in the same pass (same semantics as the post drain).
+  /// at the top of the step, in post order. Work posted during this drain
+  /// also runs in the same drain (same semantics as the post drain).
   /// </summary>
   member internal _.DrainNextFrame() =
     let mutable next = Unchecked.defaultof<unit -> unit>
@@ -140,10 +144,9 @@ type IntentQueue() =
 /// and the registered services. The program reads these cells and derives
 /// its projections from them like any other root; only <c>ExitRequested</c>
 /// is written by the program. The context deliberately does NOT expose the
-/// intent queue — phase
-/// reachability by type: the frame builder and init/projection construction
-/// must not be able to defer work. The queue is reachable only from the
-/// <c>Update</c> phase, via <see cref="T:Mibo.Adaptive.AdaptiveContext"/>.
+/// intent queue: the frame builder and init/projection construction must not
+/// be able to defer work. Only the <c>Update</c> phase can reach the queue,
+/// via <see cref="T:Mibo.Adaptive.AdaptiveContext"/>.
 /// </remarks>
 type AdaptiveFrameContext
   internal (ctx: GameContext, time: cval<GameTime>, exitRequested: cval<bool>) =
@@ -172,7 +175,7 @@ type AdaptiveFrameContext
 /// The <c>Update</c>-phase context: everything on
 /// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/> plus the framework-owned
 /// intent queue, <see cref="P:Mibo.Adaptive.AdaptiveContext.Intents"/> —
-/// intents are thunks of <c>unit -> unit</c> work deferred to a
+/// intents are <c>unit -> unit</c> work items deferred to a
 /// framework-owned moment (after <c>Update</c>, at the top of the next step,
 /// or as background work whose completion returns via <c>post</c>).
 /// </summary>
@@ -181,7 +184,7 @@ type AdaptiveFrameContext
 /// reacts to what it read and defers work; the frame builder and projection
 /// construction see only
 /// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>, so the force phase
-/// cannot enqueue — correctness by construction, no runtime guards.
+/// cannot enqueue work — the design makes it impossible, no runtime checks.
 /// </remarks>
 type AdaptiveContext
   internal (frameCtx: AdaptiveFrameContext, intents: IntentQueue) =
@@ -338,7 +341,8 @@ type AdaptiveSub = {
   /// <c>post</c> argument is the same-step lane's entry point
   /// (<see cref="M:Mibo.Adaptive.IntentQueue.post"/>): event callbacks
   /// (possibly on foreign threads) may only enqueue work for the next post
-  /// drain — confinement is preserved by construction.
+  /// drain — a foreign-thread callback can never run game code directly, it
+  /// only schedules work for the owner thread.
   /// </summary>
   Attach: ((unit -> unit) -> unit) -> IDisposable
 }
@@ -380,8 +384,8 @@ module AdaptiveSub =
 /// projection receive the queue-less
 /// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/> (roots and services
 /// only), while <c>Update</c> receives the full
-/// <see cref="T:Mibo.Adaptive.AdaptiveContext"/> with the intent queue — the
-/// force phase cannot enqueue by construction.
+/// <see cref="T:Mibo.Adaptive.AdaptiveContext"/> with the intent queue — so
+/// the force phase cannot enqueue work.
 /// </para>
 /// <para>
 /// The <c>Init</c>/<c>Update</c>/<c>Observers</c>/<c>Subscriptions</c> slots

--- a/src/Mibo.Core/AdaptiveProgram.fs
+++ b/src/Mibo.Core/AdaptiveProgram.fs
@@ -17,20 +17,22 @@ open Mibo.Elmish
 /// — closures capture the handler, so no message type is needed.
 /// </summary>
 /// <remarks>
-/// Both lanes are multi-producer, single-consumer queues: a
+/// All three lanes are multi-producer, single-consumer queues: a
 /// <see cref="T:System.Collections.Concurrent.ConcurrentQueue`1"/> for
 /// producers, drained by the single consumer (the runner) on the
 /// owner thread. The post drain runs until empty — work posted during the
 /// drain runs in the same drain, in post order, mirroring MVU's
 /// <c>DispatchMode.Immediate</c> semantics; work that posts more work is the
 /// user's responsibility, exactly as message cycles are in MVU. The
-/// next-frame lane drains once per <c>Step</c> at the boundary, never per
-/// sub-step.
+/// pre-step lane holds subscription events and drains once per <c>Step</c>
+/// at the boundary, before <c>Update</c>; the next-frame lane also drains
+/// once per <c>Step</c> at the boundary, never per sub-step.
 /// Allocation: one queue node per posted work item — acceptable on the cold
 /// path, zero on steps with no posted work.
 /// </remarks>
 type IntentQueue() =
   let posted = ConcurrentQueue<unit -> unit>()
+  let preStep = ConcurrentQueue<unit -> unit>()
   let nextFrame = ConcurrentQueue<unit -> unit>()
 
   /// <summary>
@@ -44,6 +46,15 @@ type IntentQueue() =
   /// </summary>
   /// <param name="work">The work to run at the post drain.</param>
   member _.post(work: unit -> unit) = posted.Enqueue work
+
+  /// <summary>
+  /// Posts work for the pre-step drain: it runs on the owner thread at the
+  /// next step's boundary, after cross-thread posts are applied and before
+  /// <c>Update</c>. Used by the subscription machinery — subscription events
+  /// are handled before the step's <c>Update</c> reads state.
+  /// </summary>
+  /// <param name="work">The work to run at the next step's boundary.</param>
+  member internal _.postPreStep(work: unit -> unit) = preStep.Enqueue work
 
   /// <summary>
   /// Defers <c>work</c> to the top of the NEXT
@@ -130,11 +141,22 @@ type IntentQueue() =
     while nextFrame.TryDequeue(&next) do
       next()
 
+  /// <summary>
+  /// Runs the pre-step lane on the calling (owner) thread: subscription
+  /// events queued at the step boundary, in post order. Work posted during
+  /// this drain also runs in the same drain.
+  /// </summary>
+  member internal _.DrainPreStep() =
+    let mutable next = Unchecked.defaultof<unit -> unit>
+
+    while preStep.TryDequeue(&next) do
+      next()
+
 /// <summary>
 /// The graph-building context handed to an
 /// <see cref="T:Mibo.Adaptive.AdaptiveProgram`1"/> <c>Init</c> function and to
 /// the subscription projection
-/// (<see cref="M:Mibo.Adaptive.AdaptiveProgram.withSubscriptions"/>).
+/// (<see cref="M:Mibo.Adaptive.AdaptiveInit.withSubscriptions"/>).
 /// </summary>
 /// <remarks>
 /// The context exposes the framework-owned roots: the time cell, written by
@@ -221,6 +243,44 @@ type AdaptiveContext
   /// </summary>
   member _.Intents = intents
 
+/// <summary>
+/// A subscription spec: a stable identifier plus an attach function. The
+/// adaptive counterpart of <see cref="T:Mibo.Elmish.Sub`1"/>: the attach
+/// function receives the pre-step post function instead of
+/// <c>Dispatch&lt;'Msg&gt;</c>, so subscription events never run handlers
+/// directly — they post work, handled on the owner thread at the next step's
+/// boundary, before <c>Update</c>, in order.
+/// </summary>
+[<Struct>]
+type AdaptiveSub = {
+  /// <summary>Stable key the runtime uses to diff subscriptions across steps.</summary>
+  Id: SubId
+
+  /// <summary>
+  /// Attaches the subscription and returns a disposable that detaches it. The
+  /// <c>post</c> argument is the pre-step lane's entry point: event callbacks
+  /// (possibly on foreign threads) may only enqueue work, and the runner
+  /// handles it on the owner thread at the next step's boundary, before
+  /// <c>Update</c> — a foreign-thread callback can never run game code
+  /// directly.
+  /// </summary>
+  Attach: ((unit -> unit) -> unit) -> IDisposable
+}
+
+/// <summary>Functions for composing <see cref="T:Mibo.Adaptive.AdaptiveSub"/> values.</summary>
+module AdaptiveSub =
+
+  /// <summary>
+  /// Prefixes the subscription's <see cref="T:Mibo.Elmish.SubId"/> with a
+  /// namespace, for parent-child composition — the adaptive counterpart of
+  /// <c>Sub.map</c> without the message mapping. Delegates to
+  /// <see cref="M:Mibo.Elmish.SubId.prefix"/>.
+  /// </summary>
+  let inline prefix (prefix: string) (sub: AdaptiveSub) : AdaptiveSub = {
+    sub with
+        Id = SubId.prefix prefix sub.Id
+  }
+
 /// <summary>The result of building an adaptive program's graph.</summary>
 [<Struct>]
 type AdaptiveInit<'Frame> = {
@@ -231,30 +291,79 @@ type AdaptiveInit<'Frame> = {
   /// </summary>
   FrameBuilder: unit -> 'Frame
 
+  /// <summary>
+  /// The subscription projection, built in <c>Init</c> alongside the frame
+  /// builder — both capture the world from the same place. The runner calls
+  /// it once per step and compares the returned map against its attached
+  /// table to start, keep, and stop subscriptions. See
+  /// <see cref="M:Mibo.Adaptive.AdaptiveInit.withSubscriptions"/> for the
+  /// stable-map requirement.
+  /// </summary>
+  Subscriptions: AdaptiveFrameContext -> amap<SubId, AdaptiveSub>
+
   /// <summary>Disposables released when the runner is disposed.</summary>
   Disposables: IDisposable list
 }
 
 /// <summary>Helpers for building an <see cref="T:Mibo.Adaptive.AdaptiveInit`1"/>.</summary>
 /// <remarks>
-/// These keep the <c>Disposables</c> list hidden: <see cref="M:Mibo.Adaptive.AdaptiveInit.ofFrameBuilder"/>
-/// defaults it to empty, and <see cref="M:Mibo.Adaptive.AdaptiveInit.withDisposables"/> /
-/// <see cref="M:Mibo.Adaptive.AdaptiveInit.withDisposable"/> append to it. Callers never write
-/// <c>Disposables = []</c> by hand.
+/// These keep the <c>Disposables</c> list and the default subscription
+/// projection hidden: <see cref="M:Mibo.Adaptive.AdaptiveInit.ofFrameBuilder"/>
+/// defaults them (empty subscriptions, no disposables), and
+/// <see cref="M:Mibo.Adaptive.AdaptiveInit.withSubscriptions"/> /
+/// <see cref="M:Mibo.Adaptive.AdaptiveInit.withDisposables"/> /
+/// <see cref="M:Mibo.Adaptive.AdaptiveInit.withDisposable"/> replace or append
+/// to them. Callers never write <c>Disposables = []</c> by hand.
 /// </remarks>
 module AdaptiveInit =
 
   /// <summary>
-  /// Creates an init from a frame builder with no disposables.
+  /// Creates an init from a frame builder with no subscriptions and no
+  /// disposables.
   /// </summary>
   /// <param name="frameBuilder">Forces the frame's output projections and packs them into <c>'Frame</c>.</param>
   let inline ofFrameBuilder
     ([<InlineIfLambda>] frameBuilder: unit -> 'Frame)
     : AdaptiveInit<'Frame> =
+    // One shared empty map: a fresh AMap.empty per call would defeat the
+    // runner's version check and allocate every step.
+    let emptySubs: AdaptiveFrameContext -> amap<SubId, AdaptiveSub> =
+      let empty = AMap.empty
+      fun _ -> empty
+
     {
       FrameBuilder = frameBuilder
+      Subscriptions = emptySubs
       Disposables = []
     }
+
+  /// <summary>
+  /// Sets the subscription projection. The runner reads the map once per step
+  /// (skipping the read when nothing changed), compares it by
+  /// <see cref="T:Mibo.Elmish.SubId"/> against its attached table, and starts
+  /// new, keeps matching, and stops vanished subscriptions. The adaptive
+  /// counterpart of <see cref="M:Mibo.Elmish.Program.withSubscription"/>.
+  /// </summary>
+  /// <remarks>
+  /// The projection must return a stable map: build it once and return the
+  /// same instance. The runner checks the map's version every step and skips
+  /// the diff when nothing changed.
+  /// If you need subscriptions that change with game state, use
+  /// <c>AMap.custom</c> and describe the changes yourself — do not build a
+  /// fresh map from adaptive values (for example <c>AMap.ofAVal</c>) inside
+  /// the projection, that would create a new graph every step.
+  /// Subscription work feeds the step cycle: it runs at the next step's
+  /// boundary, before <c>Update</c>. Do not modify game state from it beyond
+  /// what the step cycle expects.
+  /// </remarks>
+  /// <param name="subscribe">Builds the subscription map from the context.</param>
+  /// <param name="init">The init to configure.</param>
+  let inline withSubscriptions
+    ([<InlineIfLambda>] subscribe:
+      AdaptiveFrameContext -> amap<SubId, AdaptiveSub>)
+    (init: AdaptiveInit<'Frame>)
+    : AdaptiveInit<'Frame> =
+    { init with Subscriptions = subscribe }
 
   /// <summary>
   /// Appends a list of disposables to the init. The disposables are released
@@ -324,44 +433,6 @@ type AdaptiveFixedStepConfig = {
 }
 
 /// <summary>
-/// A subscription spec: a stable identifier plus an attach function. The
-/// adaptive counterpart of <see cref="T:Mibo.Elmish.Sub`1"/>: the attach
-/// function receives the post function instead of
-/// <c>Dispatch&lt;'Msg&gt;</c>, so subscription events never run handlers
-/// directly — they post work, handled on the owner thread at the next post
-/// drain, in order.
-/// </summary>
-[<Struct>]
-type AdaptiveSub = {
-  /// <summary>Stable key the runtime uses to diff subscriptions across steps.</summary>
-  Id: SubId
-
-  /// <summary>
-  /// Attaches the subscription and returns a disposable that detaches it. The
-  /// <c>post</c> argument is the same-step lane's entry point
-  /// (<see cref="M:Mibo.Adaptive.IntentQueue.post"/>): event callbacks
-  /// (possibly on foreign threads) may only enqueue work for the next post
-  /// drain — a foreign-thread callback can never run game code directly, it
-  /// only schedules work for the owner thread.
-  /// </summary>
-  Attach: ((unit -> unit) -> unit) -> IDisposable
-}
-
-/// <summary>Functions for composing <see cref="T:Mibo.Adaptive.AdaptiveSub"/> values.</summary>
-module AdaptiveSub =
-
-  /// <summary>
-  /// Prefixes the subscription's <see cref="T:Mibo.Elmish.SubId"/> with a
-  /// namespace, for parent-child composition — the adaptive counterpart of
-  /// <c>Sub.map</c> without the message mapping. Delegates to
-  /// <see cref="M:Mibo.Elmish.SubId.prefix"/>.
-  /// </summary>
-  let inline prefix (prefix: string) (sub: AdaptiveSub) : AdaptiveSub = {
-    sub with
-        Id = SubId.prefix prefix sub.Id
-  }
-
-/// <summary>
 /// An adaptive program: the complete description of an adaptive game.
 /// </summary>
 /// <remarks>
@@ -380,15 +451,15 @@ module AdaptiveSub =
 /// post work.
 /// </para>
 /// <para>
-/// The two contexts are split by phase: <c>Init</c> and the subscription
-/// projection receive the queue-less
+/// The two contexts are split by phase: <c>Init</c> — and the subscription
+/// projection it returns — receive the queue-less
 /// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/> (roots and services
 /// only), while <c>Update</c> receives the full
 /// <see cref="T:Mibo.Adaptive.AdaptiveContext"/> with the intent queue — so
 /// the force phase cannot enqueue work.
 /// </para>
 /// <para>
-/// The <c>Init</c>/<c>Update</c>/<c>Observers</c>/<c>Subscriptions</c> slots
+/// The <c>Init</c>/<c>Update</c>/<c>Observers</c> slots
 /// are the dependency graph (the simulation). The <c>Config</c>/
 /// <c>Renderers</c>/<c>ServiceRegistrations</c>/<c>AssetsBasePath</c> slots are
 /// host configuration (the presentation) consumed by the windowed hosts. The
@@ -430,23 +501,6 @@ type AdaptiveProgram<'Frame> = {
   /// <summary>Observer factories for receiving the forced frame each step.</summary>
   Observers: (unit -> IObserver<struct (GameContext * 'Frame * GameTime)>) list
 
-  /// <summary>
-  /// Optional subscription projection: an <c>amap</c> keyed by
-  /// <see cref="T:Mibo.Elmish.SubId"/> over
-  /// <see cref="T:Mibo.Adaptive.AdaptiveSub"/> specs, built from the
-  /// queue-less <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>. The runner
-  /// forces it once per step — incrementally, with no work when no dependency
-  /// moved — and diffs it by key against its attached table to start, keep,
-  /// and stop subscriptions. Wired via
-  /// <see cref="M:Mibo.Adaptive.AdaptiveProgram.withSubscriptions"/>.
-  /// </summary>
-  Subscriptions: (AdaptiveFrameContext -> amap<SubId, AdaptiveSub>) voption
-
-  /// <summary>
-  /// Configuration callbacks that transform the default
-  /// <see cref="T:Mibo.Elmish.GameConfig"/>. Each callback receives the current
-  /// config and returns a modified copy. Applied in registration order.
-  /// </summary>
   Config: (GameConfig -> GameConfig) list
 
   /// <summary>
@@ -517,7 +571,6 @@ module AdaptiveProgram =
       Init = init
       Update = update
       Observers = []
-      Subscriptions = ValueNone
       Config = []
       Renderers = []
       ServiceRegistrations = []
@@ -545,27 +598,6 @@ module AdaptiveProgram =
     {
       program with
           Observers = factory :: program.Observers
-    }
-
-  /// <summary>
-  /// Sets the program's subscription projection. The runner forces the map
-  /// once per step (incremental — no work when no dependency moved), diffs it
-  /// by <see cref="T:Mibo.Elmish.SubId"/> against its attached table, and
-  /// starts new, keeps matching, and stops vanished subscriptions. The
-  /// projection receives the queue-less
-  /// <see cref="T:Mibo.Adaptive.AdaptiveFrameContext"/>. The adaptive
-  /// counterpart of <see cref="M:Mibo.Elmish.Program.withSubscription"/>.
-  /// </summary>
-  /// <param name="subscribe">Builds the subscription map from the context.</param>
-  /// <param name="program">The program to configure.</param>
-  let inline withSubscriptions
-    ([<InlineIfLambda>] subscribe:
-      AdaptiveFrameContext -> amap<SubId, AdaptiveSub>)
-    (program: AdaptiveProgram<'Frame>)
-    : AdaptiveProgram<'Frame> =
-    {
-      program with
-          Subscriptions = ValueSome subscribe
     }
 
   /// <summary>

--- a/src/Mibo.MonoGame/Adaptive.Runtime.fs
+++ b/src/Mibo.MonoGame/Adaptive.Runtime.fs
@@ -17,7 +17,7 @@ open Mibo.Elmish
 //
 // Work ordering each frame (matches MiboGame + AdaptiveHeadless.Step):
 //   Update: poll input → resize check → Step (posts → time root → Update →
-//           force frame) → consume restart request → exit check
+//           force frame) → exit check
 //   Draw:   iterate renderers in add-order (reversed, since the list is
 //           ::-prepended)
 //
@@ -26,7 +26,6 @@ open Mibo.Elmish
 //   - Input is opt-in: registered and polled only when the program opted in
 //     via AdaptiveProgram.withInput (mirrors MiboGame's HasInput gate).
 //   - The runner builds the graph lazily on the first Step.
-//   - Restart: the program may request a rebuild (fresh graph, fresh clock).
 //   - The runner owns the GameTime; the host reads runner.GameTime for draw.
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -162,11 +161,6 @@ type AdaptiveMonoGameGame<'Frame>(mgProgram: AdaptiveMonoGameProgram<'Frame>) as
       // The runner owns the clock: it builds the GameTime from the elapsed
       // delta and exposes runner.GameTime for the draw call.
       runner.Step(gameTime.ElapsedGameTime) |> ignore
-
-      // The program may have requested a rebuild (e.g. restart after game
-      // over): re-run Init — fresh graph, fresh clock, first frame forced.
-      if runner.RestartRequested then
-        runner.Restart()
 
       if runner.ShouldQuit then
         this.Exit()

--- a/src/Mibo.Raylib/Adaptive.Runtime.fs
+++ b/src/Mibo.Raylib/Adaptive.Runtime.fs
@@ -15,14 +15,13 @@ open Mibo.Elmish
 //
 // Work ordering each frame (matches RaylibGame + AdaptiveHeadless.Step):
 //   poll input → resize check → Step (posts → time root → Update → force frame)
-//                → consume restart request → draw renderers in add-order.
+//                → draw renderers in add-order.
 //
 // Intentional differences from RaylibGame (the adaptive contract):
 //   - No Program/Cmd/Sub machinery — the program is an AdaptiveProgram.
 //   - Input is opt-in: registered and polled only when the program opted in
 //     via AdaptiveProgram.withInput (mirrors RaylibGame's HasInput gate).
 //   - The runner builds the graph lazily on the first Step.
-//   - Restart: the program may request a rebuild (fresh graph, fresh clock).
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// <summary>
@@ -34,10 +33,10 @@ open Mibo.Elmish
 /// <remarks>
 /// Construct one with an <see cref="T:Mibo.Adaptive.AdaptiveProgram`1"/> and
 /// call <c>Run()</c>. Each frame: poll input, check for resize, <c>Step</c> the
-/// runner (which runs the program's Update phase and forces the frame), consume
-/// a restart request if the program wrote one, then draw the renderers with the
-/// forced frame. The frame's transient views are valid until the next
-/// <c>Step</c>, so the draw window is exactly the gap between them.
+/// runner (which runs the program's Update phase and forces the frame), then
+/// draw the renderers with the forced frame. The frame's transient views are
+/// valid until the next <c>Step</c>, so the draw window is exactly the gap
+/// between them.
 /// </remarks>
 type AdaptiveRaylibGame<'Frame>(program: AdaptiveProgram<'Frame>) =
 
@@ -112,11 +111,6 @@ type AdaptiveRaylibGame<'Frame>(program: AdaptiveProgram<'Frame>) =
         ctx.UpdateDimensions(Raylib.GetScreenWidth(), Raylib.GetScreenHeight())
 
       runner.Step(elapsed) |> ignore
-
-      // The program may have requested a rebuild (e.g. restart after game
-      // over): re-run Init — fresh graph, fresh clock, first frame forced.
-      if runner.RestartRequested then
-        runner.Restart()
 
       Raylib.BeginDrawing()
       Raylib.ClearBackground(Color.Black)


### PR DESCRIPTION
# Deferred work + subscriptions for adaptive programs

The adaptive integration (`AdaptiveProgram`/`AdaptiveHeadless`, experimental) had structure
(SPUF) but none of MVU's flexibility machinery. This PR adds the adaptive counterparts of
`Cmd` and `Sub` — without recreating the message loop. There is no `'Msg` and no dispatch:
closures over roots are the messages.

## One concept: deferred `unit -> unit` work

`AdaptiveContext.Intents` (an `IntentQueue`) is the single place to defer work, reachable
from `Update` only. The moment is chosen by name:

- **`post work`** — runs after this step's `Update`, drained until empty, in post order.
  Thunks posted during the drain run in the same pass — MVU's `DispatchMode.Immediate`
  semantics (the default in both MVU hosts), so reaction chains (`Killed → AwardScore →
  CheckWin`) settle before the frame is forced. The frame never renders a half-settled chain.
  The drain runs when no user enumeration is active and strictly sequentially, which is what
  makes cross-system chains that mutate collections (combat → dead → remove from cmap) safe.
- **`postNextFrame work`** — runs at the top of the next step. The `Cmd.deferNextFrame`
  counterpart.
- **`postTask` / `postAsync`** — background work. The runtime owns the thread crossing:
  the task starts with `Async.Start` (guaranteed to start), and the completion
  (`ofSuccess`/`ofError`) posts back into the same lane, landing on the owner thread at a
  later drain where root writes are legal. The user supplies pure halves and never holds a
  threading primitive — no callback executes on the pool thread, so there is no way to
  `Set` or `pump` from the wrong thread. No `obj` erasure: `'T` flows through typed closures.

`AdaptiveHeadless.Post` gives foreign code (tests, network callbacks, AI drivers) the same
entry point without holding the `Update` context — the `HeadlessRunner.Dispatch` counterpart.

Under fixed-step the drain runs after each sub-step's `Update`, so every sub-step reads
settled state; the next-frame lane drains once per `Step` at the boundary.

## Phase reachability by type (no runtime guards)

`AdaptiveProgram.Init` and the subscription projection receive the new **queue-less**
`AdaptiveFrameContext` (framework roots + `GameContext`); only `Update` receives the full
`AdaptiveContext` with `Intents`. The frame builder and projection construction cannot defer
work — by construction, not by DEBUG asserts, ThreadStatics, or checks in `Mibo.Adaptive`
(untouched; its laziness and write/mark paths are exactly as before).

## Subscriptions as a projection

`AdaptiveProgram.withSubscriptions` takes a keyed `amap<SubId, AdaptiveSub>` projection.
The runner reads it via `AMap.getValue` (incremental — no work when no dependency moved,
zero allocation on clean steps) and diffs by key against its attached table: new key →
attach, missing key → dispose, surviving key → keep (the key is the identity; never
re-attach on a fresh closure value). Attach functions receive the queue's `post` function,
so event callbacks from any thread only enqueue work for the drain — confinement is
preserved by construction. All subscriptions detach on `Dispose`.

## Removed: restart machinery

`RestartRequested` and `AdaptiveHeadless.Restart()` are gone, including the windowed hosts'
restart consumption. Users own start/stop through their own state machines; a fresh world
is dispose the runner and create a new one.

## Breaking changes (all under `[<Experimental>]`)

- `AdaptiveProgram.Init`: `AdaptiveContext` → `AdaptiveFrameContext`.
- `AdaptiveHeadless.RunAsync`: element type `struct (GameTime * 'Frame)` → `StepOutcome<'Frame>`.
- `RestartRequested` / `Restart()` removed.

## Verification

- `Mibo.Core.Tests`: 555 passed, 0 failed (Debug) — new coverage: same-step chains in post
  order, `postNextFrame` boundary timing, foreign-thread posts, `postTask`/`postAsync`
  completion and error re-entry, settle-write visibility in the same step's forced frame,
  cmap removal under a live projection, fixed-step per-sub-step drains, subscription
  lifecycle (attach/keep/detach, events post work, detach on dispose), consumer-thread
  root writes throwing (existing `ClaimOwner` DEBUG check).
- `Mibo.Raylib` and `Mibo.MonoGame` build clean; both windowed hosts consume `Step`
  unchanged (restart blocks removed).
- `dotnet fantomas` clean on all touched files.

## Not in this PR

- Defli sample migration (lives in Mibo.Samples) — follows once this lands.
- Docs (`adaptive.md`, `headless.md`, `services.md`) — follow-up PR once the API settles.
