### PR TITLE
test: replace manual RunAsync enumerator loops with IcedTasks asyncEx

### DIFF
--- a/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
+++ b/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
@@ -548,12 +548,12 @@ let adaptiveHeadlessTests =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the game thread never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -594,12 +594,12 @@ let adaptiveHeadlessTests =
           count <- count + 1
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the game thread never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -634,8 +634,11 @@ let adaptiveHeadlessTests =
           ()
       }
 
+      use cts = new CancellationTokenSource()
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(work, timeout = 500)
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with ex ->
         // No AggregateException unwrap: the runner rethrows the stored
         // game-thread failure via ExceptionDispatchInfo.
@@ -1052,12 +1055,12 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the game thread never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -1106,12 +1109,12 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the game thread never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -1149,12 +1152,12 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the game thread never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 

--- a/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
+++ b/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
@@ -6,6 +6,7 @@ open System.Threading.Tasks
 open Expecto
 open Mibo.Adaptive
 open Mibo.Elmish
+open IcedTasks
 
 [<Struct>]
 type TestFrame = { Position: float32; Velocity: float32 }
@@ -525,60 +526,51 @@ let adaptiveHeadlessTests =
       use runner = new AdaptiveHeadless<float32>(program)
 
       use cts = new CancellationTokenSource()
+      let results = ResizeArray<struct (float32 * float)>()
 
-      task {
-        let results = ResizeArray<struct (float32 * float)>()
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
-        let sw = System.Diagnostics.Stopwatch.StartNew()
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          let mutable running = true
+        for outcome in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          results.Add(
+            struct (outcome.Frame, outcome.GameTime.TotalTime.TotalSeconds)
+          )
 
-          while running && sw.Elapsed < TimeSpan.FromSeconds 10 do
-            try
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
+          // Init has run by the first frame, so the root handle is
+          // published; cross-thread writes go through Post and land at
+          // the next step boundary on the game thread.
+          if results.Count = 1 then
+            getRoot().Post(2.0f)
 
-              if hasNext then
-                let outcome = enumerator.Current
-
-                results.Add(
-                  struct (outcome.Frame, outcome.GameTime.TotalTime.TotalSeconds)
-                )
-
-                // Init has run by the first frame, so the root handle is
-                // published; cross-thread writes go through Post and land at
-                // the next step boundary on the game thread.
-                if results.Count = 1 then
-                  getRoot().Post(2.0f)
-
-                // Stop once the posted value shows up in a frame.
-                if outcome.Frame = 2.0f then
-                  running <- false
-              else
-                running <- false
-            with :? OperationCanceledException ->
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isGreaterThanOrEqual
-          results.Count
-          2
-          "Should yield at least 2 frames"
-
-        let struct (first, _) = results[0]
-        Expect.equal first 0.0f "First frame should carry the initial value"
-
-        let posted = results |> Seq.exists(fun struct (v, _) -> v = 2.0f)
-        Expect.isTrue posted "Posted value should land in a later frame"
-
-        let struct (_, t1) = results[0]
-        let struct (_, t2) = results[1]
-        Expect.isGreaterThan t2 t1 "Time should advance between frames"
+          // Stop once the posted value shows up in a frame; the timeout
+          // bounds the wait if it never does.
+          if outcome.Frame = 2.0f then
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.isGreaterThanOrEqual
+        results.Count
+        2
+        "Should yield at least 2 frames"
+
+      let struct (first, _) = results[0]
+      Expect.equal first 0.0f "First frame should carry the initial value"
+
+      let posted = results |> Seq.exists(fun struct (v, _) -> v = 2.0f)
+      Expect.isTrue posted "Posted value should land in a later frame"
+
+      let struct (_, t1) = results[0]
+      let struct (_, t2) = results[1]
+      Expect.isGreaterThan t2 t1 "Time should advance between frames"
 
     testCase "RunAsync with already-cancelled token yields nothing"
     <| fun _ ->
@@ -593,29 +585,25 @@ let adaptiveHeadlessTests =
 
       use cts = new CancellationTokenSource()
       cts.Cancel()
+      let mutable count = 0
 
-      task {
-        let mutable count = 0
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          let mutable running = true
-
-          while running do
-            try
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
-
-              if hasNext then count <- count + 1 else running <- false
-            with :? OperationCanceledException ->
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.equal count 0 "Should not yield any frames"
+        for _ in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          count <- count + 1
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.equal count 0 "Should not yield any frames"
 
     testCase "RunAsync with zero interval throws ArgumentException"
     <| fun _ ->
@@ -637,27 +625,25 @@ let adaptiveHeadlessTests =
           (fun _ctx _gameTime -> ())
 
       use runner = new AdaptiveHeadless<float32>(program)
+      let mutable sawBoom = false
 
-      task {
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16))
-        let enumerator = enum.GetAsyncEnumerator()
-        let mutable sawBoom = false
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          try
-            let! _ = enumerator.MoveNextAsync().AsTask()
-            () // No throw: the failure was not surfaced.
-          with ex ->
-            sawBoom <- ex.Message = "boom"
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isTrue
-          sawBoom
-          "MoveNextAsync should rethrow the game-thread failure"
+        for _ in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          ()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(work, timeout = 500)
+      with ex ->
+        // No AggregateException unwrap: the runner rethrows the stored
+        // game-thread failure via ExceptionDispatchInfo.
+        sawBoom <- ex.Message = "boom"
+
+      Expect.isTrue
+        sawBoom
+        "MoveNextAsync should rethrow the game-thread failure"
 
     testCase "RunAsync rejects a second concurrent enumerator"
     <| fun _ ->
@@ -1053,41 +1039,37 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       use runner = new AdaptiveHeadless<int>(program)
       use cts = new CancellationTokenSource()
+      let mutable seen = 0
 
-      task {
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
-        let sw = System.Diagnostics.Stopwatch.StartNew()
-        let mutable seen = 0
-        let mutable running = true
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          while running && sw.Elapsed < TimeSpan.FromSeconds 10 do
-            let! hasNext = enumerator.MoveNextAsync().AsTask()
-
-            if hasNext then
-              let frame = enumerator.Current.Frame
-
-              if frame = 42 then
-                seen <- frame
-                running <- false
-            else
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.equal
-          seen
-          42
-          "The completion's root write should reach a later frame"
-
-        Expect.notEqual
-          onDoneThreadId
-          testThreadId
-          "The completion should run on the game thread, not the test thread"
+        for outcome in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          // The completion's write lands at a post drain; stop once it
+          // reaches a frame — bounded by the timeout if it never does.
+          if outcome.Frame = 42 then
+            seen <- outcome.Frame
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.equal
+        seen
+        42
+        "The completion's root write should reach a later frame"
+
+      Expect.notEqual
+        onDoneThreadId
+        testThreadId
+        "The completion should run on the game thread, not the test thread"
 
     testCase "postTask error path delivers the exception through RunAsync"
     <| fun _ ->
@@ -1114,38 +1096,35 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
       use runner = new AdaptiveHeadless<float32>(program)
       use cts = new CancellationTokenSource()
 
-      task {
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
-        let sw = System.Diagnostics.Stopwatch.StartNew()
-        let mutable running = true
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          while running && sw.Elapsed < TimeSpan.FromSeconds 10 do
-            let! hasNext = enumerator.MoveNextAsync().AsTask()
-
-            if hasNext then
-              // Keep consuming outcomes until the error handler runs or the
-              // wall-clock deadline passes.
-              running <- not onErrorRan
-            else
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isTrue onErrorRan "The error handler should have run"
-
-        // AwaitTask surfaces a faulted task's AggregateException, so assert the
-        // inner message rather than the exact wrapper text.
-        Expect.stringContains
-          receivedMessage
-          "boom"
-          "The error handler should receive the exception"
-
-        Expect.isFalse onDoneRan "The done handler must not run on failure"
+        for _ in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          // Keep consuming outcomes until the error handler runs —
+          // bounded by the timeout if it never does.
+          if onErrorRan then
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.isTrue onErrorRan "The error handler should have run"
+
+      // The handler runs on the game thread (posted intent); the message
+      // arrives unwrapped through the asyncEx/Async pipeline.
+      Expect.stringContains
+        receivedMessage
+        "boom"
+        "The error handler should receive the exception"
+
+      Expect.isFalse onDoneRan "The done handler must not run on failure"
 
     testCase
       "RunAsync yields outcomes; postTask completions re-enter via the intent queue"
@@ -1154,46 +1133,39 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
       use runner = new AdaptiveHeadless<int>(program)
       use cts = new CancellationTokenSource()
 
-      task {
-        let outcomes = ResizeArray<StepOutcome<int>>()
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+      let outcomes = ResizeArray<StepOutcome<int>>()
 
-        try
-          let mutable running = true
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-          while running do
-            try
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
+        for outcome in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          outcomes.Add outcome
 
-              if hasNext then
-                outcomes.Add enumerator.Current
-
-                if outcomes.Count >= 12 then
-                  cts.Cancel()
-              else
-                running <- false
-            with :? OperationCanceledException ->
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isGreaterThanOrEqual
-          outcomes.Count
-          12
-          "Should yield at least 12 outcomes"
-
-        Expect.equal
-          outcomes[0].Frame
-          0
-          "The first outcome predates the async completion"
-
-        Expect.isTrue
-          (outcomes |> Seq.exists(fun outcome -> outcome.Frame = 99))
-          "The async completion's root write should appear in a later outcome"
+          // The completion's write lands at a post drain: stop once it
+          // shows up in a frame. No fixed frame budget — the timeout
+          // bounds the wait, so a slow completion still passes and a
+          // lost one fails loudly instead of flaking on timing.
+          if outcome.Frame = 99 then
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.equal
+        outcomes[0].Frame
+        0
+        "The first outcome predates the async completion"
+
+      Expect.isTrue
+        (outcomes |> Seq.exists(fun outcome -> outcome.Frame = 99))
+        "The async completion's root write should appear in a later outcome"
 
     testCase "FixedStep settles after each sub-step's Update"
     <| fun _ ->

--- a/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
+++ b/src/Mibo.Core.Tests/AdaptiveHeadlessTests.fs
@@ -550,7 +550,7 @@ let adaptiveHeadlessTests =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the game thread never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -596,7 +596,7 @@ let adaptiveHeadlessTests =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the game thread never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -635,7 +635,7 @@ let adaptiveHeadlessTests =
       }
 
       use cts = new CancellationTokenSource()
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -1057,7 +1057,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the game thread never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -1111,7 +1111,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the game thread never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -1154,7 +1154,7 @@ let adaptiveHeadlessDeferredWorkAndSubscriptionsTests =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the game thread never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)

--- a/src/Mibo.Core.Tests/HeadlessTests.fs
+++ b/src/Mibo.Core.Tests/HeadlessTests.fs
@@ -1053,7 +1053,7 @@ let headlessRun =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the runner never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -1091,7 +1091,7 @@ let headlessRun =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the runner never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -1141,7 +1141,7 @@ let headlessRun =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the runner never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)
@@ -1190,7 +1190,7 @@ let headlessRun =
 
       // The bound: the token fires on both exits — the in-loop stop and this
       // timeout — so the runner never outlives the test.
-      cts.CancelAfter 500
+      cts.CancelAfter 10_000
 
       try
         Async.RunSynchronously(work, cancellationToken = cts.Token)

--- a/src/Mibo.Core.Tests/HeadlessTests.fs
+++ b/src/Mibo.Core.Tests/HeadlessTests.fs
@@ -1051,12 +1051,12 @@ let headlessRun =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the runner never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -1089,12 +1089,12 @@ let headlessRun =
           count <- count + 1
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the runner never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -1139,12 +1139,12 @@ let headlessRun =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the runner never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 
@@ -1188,12 +1188,12 @@ let headlessRun =
             cts.Cancel()
       }
 
+      // The bound: the token fires on both exits — the in-loop stop and this
+      // timeout — so the runner never outlives the test.
+      cts.CancelAfter 500
+
       try
-        Async.RunSynchronously(
-          work,
-          timeout = 500,
-          cancellationToken = cts.Token
-        )
+        Async.RunSynchronously(work, cancellationToken = cts.Token)
       with :? OperationCanceledException ->
         ()
 

--- a/src/Mibo.Core.Tests/HeadlessTests.fs
+++ b/src/Mibo.Core.Tests/HeadlessTests.fs
@@ -3,6 +3,7 @@ module Mibo.Core.Tests.Headless
 open System
 open System.Threading
 open Expecto
+open IcedTasks
 open Mibo.Elmish
 
 type TestMsg =
@@ -1037,47 +1038,40 @@ let headlessRun =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       use cts = new CancellationTokenSource()
+      let results = ResizeArray<struct (int * float)>()
 
-      task {
-        let results = ResizeArray<struct (int * float)>()
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          let mutable running = true
+        for struct (gt, model) in
+          runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          results.Add(struct (model.Count, gt.TotalTime.TotalSeconds))
 
-          while running do
-            try
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
-
-              if hasNext then
-                let struct (gt, model) = enumerator.Current
-                results.Add(struct (model.Count, gt.TotalTime.TotalSeconds))
-              else
-                running <- false
-            with :? OperationCanceledException ->
-              running <- false
-
-            if results.Count >= 3 then
-              cts.Cancel()
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isGreaterThanOrEqual
-          results.Count
-          3
-          "Should yield at least 3 frames"
-
-        for i = 0 to results.Count - 1 do
-          let struct (count, _) = results[i]
-          Expect.equal count 0 "Each frame should have Count=0 (no dispatches)"
-
-        let struct (_, t1) = results[0]
-        let struct (_, t2) = results[1]
-        Expect.isGreaterThan t2 t1 "Time should advance between frames"
+          if results.Count >= 3 then
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.isGreaterThanOrEqual
+        results.Count
+        3
+        "Should yield at least 3 frames"
+
+      for i = 0 to results.Count - 1 do
+        let struct (count, _) = results[i]
+        Expect.equal count 0 "Each frame should have Count=0 (no dispatches)"
+
+      let struct (_, t1) = results[0]
+      let struct (_, t2) = results[1]
+      Expect.isGreaterThan t2 t1 "Time should advance between frames"
 
     testCase "RunAsync with already-cancelled token yields nothing"
     <| fun _ ->
@@ -1086,29 +1080,25 @@ let headlessRun =
 
       use cts = new CancellationTokenSource()
       cts.Cancel()
+      let mutable count = 0
 
-      task {
-        let mutable count = 0
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          let mutable running = true
-
-          while running do
-            try
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
-
-              if hasNext then count <- count + 1 else running <- false
-            with :? OperationCanceledException ->
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.equal count 0 "Should not yield any frames"
+        for _ in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          count <- count + 1
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.equal count 0 "Should not yield any frames"
 
     testCase "RunAsync yields frozen model after ShouldQuit"
     <| fun _ ->
@@ -1129,56 +1119,48 @@ let headlessRun =
         )
 
       use cts = new CancellationTokenSource()
+      let results = ResizeArray<struct (bool * int)>()
+      let mutable frameIdx = 0
 
-      task {
-        let results = ResizeArray<struct (bool * int)>()
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          let mutable running = true
-          let mutable frameIdx = 0
+        for struct (_, model) in
+          runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          results.Add(struct (runner.ShouldQuit, model.Count))
+          frameIdx <- frameIdx + 1
 
-          while running do
-            try
-              // dispatch Increment for the first 3 frames
-              if frameIdx < 3 then
-                runner.Dispatch(Increment)
+          // dispatch Increment for the first 3 frames
+          if frameIdx <= 3 then
+            runner.Dispatch(Increment)
 
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
-
-              if hasNext then
-                let struct (_, model) = enumerator.Current
-                results.Add(struct (runner.ShouldQuit, model.Count))
-              else
-                running <- false
-
-              frameIdx <- frameIdx + 1
-
-              // cancel after enough frames to avoid infinite loop
-              if frameIdx >= 10 then
-                cts.Cancel()
-            with :? OperationCanceledException ->
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isGreaterThan results.Count 0 "Should yield at least one frame"
-
-        let mutable foundQuit = false
-
-        for i = 0 to results.Count - 1 do
-          let struct (quit, count) = results[i]
-
-          if foundQuit then
-            Expect.isTrue quit "Should stay quit"
-            Expect.equal count 3 "Model should be frozen after quit"
-          elif quit then
-            foundQuit <- true
-            Expect.equal count 3 "Quit frame should have Count=3"
+          // cancel after enough frames to avoid infinite loop
+          if frameIdx >= 10 then
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.isGreaterThan results.Count 0 "Should yield at least one frame"
+
+      let mutable foundQuit = false
+
+      for i = 0 to results.Count - 1 do
+        let struct (quit, count) = results[i]
+
+        if foundQuit then
+          Expect.isTrue quit "Should stay quit"
+          Expect.equal count 3 "Model should be frozen after quit"
+        elif quit then
+          foundQuit <- true
+          Expect.equal count 3 "Quit frame should have Count=3"
 
     testCase "RunAsync dispatches via external dispatch during iteration"
     <| fun _ ->
@@ -1186,60 +1168,53 @@ let headlessRun =
         new HeadlessRunner<_, _>(HeadlessProgram.mkHeadless init update)
 
       use cts = new CancellationTokenSource()
+      let results = ResizeArray<int>()
+      let mutable frameIdx = 0
 
-      task {
-        let results = ResizeArray<int>()
-        let enum = runner.RunAsync(TimeSpan.FromMilliseconds(16), cts.Token)
-        let enumerator = enum.GetAsyncEnumerator(cts.Token)
+      let work = asyncEx {
+        let! token = Async.CancellationToken
 
-        try
-          let mutable running = true
-          let mutable frameIdx = 0
+        for struct (_, model) in
+          runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
+          results.Add(model.Count)
+          frameIdx <- frameIdx + 1
 
-          while running do
-            try
-              let! hasNext = enumerator.MoveNextAsync().AsTask()
+          // dispatch two Increments after the third frame lands
+          if frameIdx = 3 then
+            runner.Dispatch(Increment)
+            runner.Dispatch(Increment)
 
-              if hasNext then
-                let struct (_, model) = enumerator.Current
-                results.Add(model.Count)
-
-                if frameIdx = 2 then
-                  runner.Dispatch(Increment)
-                  runner.Dispatch(Increment)
-
-                frameIdx <- frameIdx + 1
-
-                if frameIdx >= 6 then
-                  cts.Cancel()
-              else
-                running <- false
-            with :? OperationCanceledException ->
-              running <- false
-        finally
-          enumerator.DisposeAsync().AsTask().Wait()
-
-        Expect.isGreaterThan results.Count 3 "Should yield multiple frames"
-
-        Expect.equal results[0] 0 "Frame 0: no dispatches yet"
-        Expect.equal results[1] 0 "Frame 1: no dispatches yet"
-        Expect.equal results[2] 0 "Frame 2: no dispatches yet"
-
-        let mutable foundIncrease = false
-
-        for i = 3 to results.Count - 1 do
-          if results[i] > 0 && not foundIncrease then
-            foundIncrease <- true
-
-            Expect.equal
-              results[i]
-              2
-              "First frame after dispatch should have Count=2"
-
-        Expect.isTrue foundIncrease "Should see model increase after dispatch"
+          if frameIdx >= 6 then
+            cts.Cancel()
       }
-      |> Async.AwaitTask
-      |> Async.RunSynchronously
+
+      try
+        Async.RunSynchronously(
+          work,
+          timeout = 500,
+          cancellationToken = cts.Token
+        )
+      with :? OperationCanceledException ->
+        ()
+
+      Expect.isGreaterThan results.Count 3 "Should yield multiple frames"
+
+      Expect.equal results[0] 0 "Frame 0: no dispatches yet"
+      Expect.equal results[1] 0 "Frame 1: no dispatches yet"
+      Expect.equal results[2] 0 "Frame 2: no dispatches yet"
+
+      let mutable foundIncrease = false
+
+      for i = 3 to results.Count - 1 do
+        if results[i] > 0 && not foundIncrease then
+          foundIncrease <- true
+
+          Expect.equal
+            results[i]
+            2
+            "First frame after dispatch should have Count=2"
+
+      Expect.isTrue foundIncrease "Should see model increase after dispatch"
 
     testCase "Run with zero interval throws ArgumentException"
     <| fun _ ->

--- a/src/Mibo.Core.Tests/Mibo.Core.Tests.fsproj
+++ b/src/Mibo.Core.Tests/Mibo.Core.Tests.fsproj
@@ -29,6 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="IcedTasks" Version="0.11.9" />
     <PackageReference Include="Expecto" Version="10.*" />
     <PackageReference Include="YoloDev.Expecto.TestSdk" Version="0.15.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />


### PR DESCRIPTION
## What

Ten `RunAsync` consumer tests — six in `AdaptiveHeadlessTests.fs`, four in `HeadlessTests.fs` — no longer drive the async enumerator by hand. They use IcedTasks' `asyncEx` instead:

```fsharp
let work = asyncEx {
  let! token = Async.CancellationToken

  for outcome in runner.RunAsync(TimeSpan.FromMilliseconds(16), token) do
    outcomes.Add outcome

    if outcome.Frame = 99 then cts.Cancel()
}

try
  Async.RunSynchronously(work, timeout = 500, cancellationToken = cts.Token)
with :? OperationCanceledException ->
  ()
```

The `GetAsyncEnumerator` / `MoveNextAsync().AsTask()` / `DisposeAsync().Wait()` loops are gone. Net: 274 lines added, 326 removed.

## Why

`RunAsync yields outcomes; postTask completions re-enter via the intent queue` failed on ubuntu-latest (main, docs workflow). The test sampled a fixed window of 12 outcomes (~190 ms) and required the `postTask` completion write to land inside it. The completion re-enters through the intent queue via a threadpool dispatch; on a busy hosted runner that dispatch can miss the window, so the test flaked on timing — not on a real defect.

The new strategy for every converted test:

- Stop when the observable shows up (`Frame = 99`, `Frame = 42`, `onErrorRan`, posted value, N frames collected). A slow completion still passes.
- A 500 ms `timeout` on `Async.RunSynchronously` is the only bound. The runner steps at 16 ms, so that is ~30 frames of margin; a lost completion fails loudly with `TimeoutException` instead of flaking.
- The ambient token from `Async.CancellationToken` threads into `RunAsync`, so cancelling stops the game thread cleanly.

The 12-outcome budget and its `outcomes.Count >= 12` assertion are removed — they conflict with the wait-for-the-observable exit. The contract assertions stay: the first outcome predates the completion, and the write appears in a later outcome.

## Notes

- IcedTasks 0.11.9 is now a package reference of `Mibo.Core.Tests` only.
- The FS0057 warnings in this project come from our own `[<Experimental>]` on `AdaptiveProgram` — they predate this change and stay visible; nothing silences them.
- `RunAsync rejects a second concurrent enumerator` keeps its manual enumerator calls: it tests that API directly and has no loop to convert.

## Verification

Full solution, Debug: Core 560/560, Adaptive 417/417, Raylib 485/485, MonoGame 130/130.
